### PR TITLE
feat: add Japanese TTS button alongside English speech buttons

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -1,10 +1,11 @@
 import AVFoundation
 
 class SpeechService: NSObject, ObservableObject {
-    private let synthesizer = AVSpeechSynthesizer()
+    nonisolated(unsafe) private let synthesizer = AVSpeechSynthesizer()
     private var audioPlayer: AVAudioPlayer?
 
     @Published var isSpeaking = false
+    @Published var speakingLanguage: String? = nil
     @Published var voiceGender: SettingsManager.VoiceGender = .default_
 
     override init() {
@@ -33,6 +34,7 @@ class SpeechService: NSObject, ObservableObject {
 
     func speak(_ text: String, language: String = "en-US", voiceGender: SettingsManager.VoiceGender = .default_) {
         stop()
+        speakingLanguage = language
 
         if voiceGender == .zundamon {
             isSpeaking = true
@@ -124,6 +126,7 @@ class SpeechService: NSObject, ObservableObject {
         audioPlayer?.stop()
         audioPlayer = nil
         isSpeaking = false
+        speakingLanguage = nil
     }
 }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -27,19 +27,35 @@ struct SentenceListView: View {
                         .font(.title3)
                         .foregroundColor(.blue)
 
-                    Button(action: {
-                        speechService.speak(word.word, voiceGender: settings.voiceGender)
-                    }) {
-                        HStack {
-                            Image(systemName: "speaker.wave.2.fill")
-                            Text("発音を聞く")
+                    HStack(spacing: 12) {
+                        Button(action: {
+                            speechService.speak(word.word, voiceGender: settings.voiceGender)
+                        }) {
+                            HStack {
+                                Image(systemName: "speaker.wave.2.fill")
+                                Text("英語を聞く")
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.blue.opacity(0.1))
+                            .cornerRadius(8)
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Color.blue.opacity(0.1))
-                        .cornerRadius(8)
+                        .foregroundColor(.blue)
+
+                        Button(action: {
+                            speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
+                        }) {
+                            HStack {
+                                Image(systemName: "speaker.wave.2.fill")
+                                Text("日本語を聞く")
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(Color.orange.opacity(0.1))
+                            .cornerRadius(8)
+                        }
+                        .foregroundColor(.orange)
                     }
-                    .foregroundColor(.blue)
                     .padding(.top, 4)
                 }
                 .frame(maxWidth: .infinity)

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -32,7 +32,7 @@ struct SentenceListView: View {
                             speechService.speak(word.word, voiceGender: settings.voiceGender)
                         }) {
                             HStack {
-                                Image(systemName: "speaker.wave.2.fill")
+                                Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                                 Text("英語を聞く")
                             }
                             .padding(.horizontal, 16)
@@ -46,7 +46,7 @@ struct SentenceListView: View {
                             speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
                         }) {
                             HStack {
-                                Image(systemName: "speaker.wave.2.fill")
+                                Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                                 Text("日本語を聞く")
                             }
                             .padding(.horizontal, 16)

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -41,6 +41,7 @@ struct SentenceListView: View {
                             .cornerRadius(8)
                         }
                         .foregroundColor(.blue)
+                        .buttonStyle(.borderless)
 
                         Button(action: {
                             speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
@@ -55,6 +56,7 @@ struct SentenceListView: View {
                             .cornerRadius(8)
                         }
                         .foregroundColor(.orange)
+                        .buttonStyle(.borderless)
                     }
                     .padding(.top, 4)
                 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
@@ -43,20 +43,38 @@ struct SentencePracticeView: View {
 
                 // 操作ボタン
                 VStack(spacing: 16) {
-                    // 音声読み上げボタン
+                    // 英語読み上げボタン
                     Button(action: {
                         speechService.speak(sentence.english, voiceGender: settings.voiceGender)
                     }) {
                         HStack {
-                            Image(systemName: speechService.isSpeaking ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                                 .font(.title2)
-                            Text("お手本を聞く")
+                            Text("英語を聞く")
                                 .font(.headline)
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 56)
                         .background(Color.blue.opacity(0.1))
                         .foregroundColor(.blue)
+                        .cornerRadius(12)
+                    }
+                    .padding(.horizontal)
+
+                    // 日本語訳読み上げボタン
+                    Button(action: {
+                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender)
+                    }) {
+                        HStack {
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                                .font(.title2)
+                            Text("日本語訳を聞く")
+                                .font(.headline)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                        .background(Color.orange.opacity(0.1))
+                        .foregroundColor(.orange)
                         .cornerRadius(12)
                     }
                     .padding(.horizontal)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -121,14 +121,25 @@ struct WordRowView: View {
 
             Spacer()
 
-            Button(action: {
-                speechService.speak(word.word, voiceGender: speechService.voiceGender)
-            }) {
-                Image(systemName: speechService.isSpeaking ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
-                    .font(.title2)
-                    .foregroundColor(.blue)
+            HStack(spacing: 12) {
+                Button(action: {
+                    speechService.speak(word.word, voiceGender: speechService.voiceGender)
+                }) {
+                    Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                        .font(.title2)
+                        .foregroundColor(.blue)
+                }
+                .buttonStyle(.borderless)
+
+                Button(action: {
+                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: speechService.voiceGender)
+                }) {
+                    Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                        .font(.title2)
+                        .foregroundColor(.orange)
+                }
+                .buttonStyle(.borderless)
             }
-            .buttonStyle(.borderless)
         }
         .padding(.vertical, 4)
     }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
@@ -30,20 +30,37 @@ struct WordPracticeView: View {
             Spacer()
 
             // 音声読み上げボタン
-            Button(action: {
-                speechService.speak(word.word, voiceGender: settings.voiceGender)
-            }) {
-                VStack {
-                    Image(systemName: speechService.isSpeaking ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
-                        .font(.system(size: 40))
-                    Text("お手本を聞く")
-                        .font(.subheadline)
+            HStack(spacing: 16) {
+                Button(action: {
+                    speechService.speak(word.word, voiceGender: settings.voiceGender)
+                }) {
+                    VStack {
+                        Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                            .font(.system(size: 40))
+                        Text("英語を聞く")
+                            .font(.subheadline)
+                    }
+                    .frame(width: 120, height: 80)
+                    .background(Color.blue.opacity(0.1))
+                    .cornerRadius(16)
                 }
-                .frame(width: 120, height: 80)
-                .background(Color.blue.opacity(0.1))
-                .cornerRadius(16)
+                .foregroundColor(.blue)
+
+                Button(action: {
+                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
+                }) {
+                    VStack {
+                        Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                            .font(.system(size: 40))
+                        Text("日本語を聞く")
+                            .font(.subheadline)
+                    }
+                    .frame(width: 120, height: 80)
+                    .background(Color.orange.opacity(0.1))
+                    .cornerRadius(16)
+                }
+                .foregroundColor(.orange)
             }
-            .foregroundColor(.blue)
 
             // 発音チェックボタン
             Button(action: {


### PR DESCRIPTION
- Add speakingLanguage tracking to SpeechService to distinguish which language is currently playing
- Add nonisolated(unsafe) to AVSpeechSynthesizer property to suppress Sendable warning
- Add independent Japanese (ja-JP) speech buttons (orange) to WordListView, WordPracticeView, SentenceListView, and SentencePracticeView
- Each button reflects its own active state independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced single pronunciation controls with dedicated English and Japanese listen buttons across views, labeled "英語を聞く" and "日本語を聞く".
  * Distinct blue (English) and orange (Japanese) styling for clarity.
  * Speaking indicator now highlights which language is playing.

* **Bug Fixes**
  * Speaking indicator resets when playback stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->