### PR TITLE
feat: support multi-environment CDK deploy with VoicevoxStack-{env} naming

### DIFF
--- a/aws/bin/app.ts
+++ b/aws/bin/app.ts
@@ -4,10 +4,16 @@ import { VoicevoxStack } from '../lib/voicevox-stack';
 
 const app = new cdk.App();
 
-new VoicevoxStack(app, 'VoicevoxStack', {
+const env = app.node.tryGetContext('env') ?? 'poc';
+const validEnvs = ['poc', 'dev', 'pro'];
+if (!validEnvs.includes(env)) {
+  throw new Error(`Invalid env: "${env}". Must be one of: ${validEnvs.join(' | ')}`);
+}
+
+new VoicevoxStack(app, `VoicevoxStack-${env}`, {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION ?? 'ap-northeast-1',
   },
-  description: 'VOICEVOX TTS Lambda stack for Zundamon voice (PoC)',
+  stackEnv: env,
 });

--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -9,15 +9,29 @@ import * as ecrDeploy from 'cdk-ecr-deployment';
 import { Construct } from 'constructs';
 import * as path from 'path';
 
+export interface VoicevoxStackProps extends cdk.StackProps {
+  /** Deployment environment: 'poc' | 'dev' | 'pro' */
+  stackEnv: string;
+}
+
+const envConfig: Record<string, { memorySize: number; throttleRateLimit: number; throttleBurstLimit: number }> = {
+  poc: { memorySize: 2048, throttleRateLimit: 5,   throttleBurstLimit: 10  },
+  dev: { memorySize: 2048, throttleRateLimit: 10,  throttleBurstLimit: 20  },
+  pro: { memorySize: 3008, throttleRateLimit: 50,  throttleBurstLimit: 100 },
+};
+
 export class VoicevoxStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props: VoicevoxStackProps) {
     super(scope, id, props);
+
+    const { stackEnv } = props;
+    const cfg = envConfig[stackEnv];
 
     // ----------------------------------------------------------------
     // ECR: dedicated repository with human-readable name
     // ----------------------------------------------------------------
     const repository = new ecr.Repository(this, 'VoicevoxRepository', {
-      repositoryName: 'voicevox-engine',
+      repositoryName: `voicevox-engine-${stackEnv}`,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       // Allow `cdk destroy` to succeed even when the repository contains images
       emptyOnDelete: true,
@@ -37,7 +51,7 @@ export class VoicevoxStack extends cdk.Stack {
       platform: ecr_assets.Platform.LINUX_AMD64,
     });
 
-    // Copy to voicevox-engine:<hash> so CloudFormation detects image changes automatically
+    // Copy to voicevox-engine-{env}:<hash> so CloudFormation detects image changes automatically
     const deployHashTag = new ecrDeploy.ECRDeployment(this, 'DeployVoicevoxImageHash', {
       src: new ecrDeploy.DockerImageName(imageAsset.imageUri),
       dest: new ecrDeploy.DockerImageName(`${repository.repositoryUri}:${imageAsset.imageTag}`),
@@ -53,7 +67,7 @@ export class VoicevoxStack extends cdk.Stack {
     // Lambda: VOICEVOX engine (Container Image + Lambda Web Adapter)
     // ----------------------------------------------------------------
     const executionRole = new iam.Role(this, 'VoicevoxFunctionRole', {
-      roleName: 'voicevox-engine-role',
+      roleName: `voicevox-engine-role-${stackEnv}`,
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       managedPolicies: [
         iam.ManagedPolicy.fromAwsManagedPolicyName(
@@ -63,16 +77,15 @@ export class VoicevoxStack extends cdk.Stack {
     });
 
     const voicevoxFn = new lambda.DockerImageFunction(this, 'VoicevoxFunction', {
-      functionName: 'voicevox-engine',
+      functionName: `voicevox-engine-${stackEnv}`,
       role: executionRole,
-      // Reference voicevox-engine repo with content-hash tag.
+      // Reference voicevox-engine-{env} repo with content-hash tag.
       // The hash changes when the Dockerfile changes, so CloudFormation
       // automatically re-deploys Lambda on every image update.
       code: lambda.DockerImageCode.fromEcr(repository, {
         tagOrDigest: imageAsset.imageTag,
       }),
-      // CPU inference only. 2GB to give VOICEVOX enough headroom
-      memorySize: 2048,
+      memorySize: cfg.memorySize,
       // Allow time for cold start (VOICEVOX model loading ~30s) + TTS generation
       timeout: cdk.Duration.seconds(120),
       architecture: lambda.Architecture.X86_64,
@@ -84,18 +97,18 @@ export class VoicevoxStack extends cdk.Stack {
         // Path used by Lambda Web Adapter to confirm the app is ready
         READINESS_CHECK_PATH: '/version',
       },
-      description: 'VOICEVOX TTS engine (Zundamon) - PoC',
+      description: `VOICEVOX TTS engine (Zundamon) - ${stackEnv}`,
       // NOTE: reservedConcurrentExecutions is intentionally omitted.
       // New AWS accounts have a default Lambda concurrency limit of 10.
       // Reserving any units would drop unreserved concurrency below the
       // required minimum of 10, causing a deployment error.
-      // Cost is capped instead by API Gateway throttling (5 RPS / burst 10).
+      // Cost is capped instead by API Gateway throttling.
     });
 
     // Allow Lambda to pull the container image from the dedicated ECR repository
     repository.grantPull(executionRole);
 
-    // Ensure Lambda is updated only after the image is copied to voicevox-engine:<hash>.
+    // Ensure Lambda is updated only after the image is copied to voicevox-engine-{env}:<hash>.
     // Without this, CloudFormation may update Lambda before ECRDeployment completes,
     // causing "Source image does not exist" errors.
     voicevoxFn.node.addDependency(deployHashTag);
@@ -104,8 +117,8 @@ export class VoicevoxStack extends cdk.Stack {
     // API Gateway: HTTP API
     // ----------------------------------------------------------------
     const httpApi = new apigatewayv2.HttpApi(this, 'VoicevoxHttpApi', {
-      apiName: 'voicevox-api',
-      description: 'VOICEVOX TTS API (PoC)',
+      apiName: `voicevox-api-${stackEnv}`,
+      description: `VOICEVOX TTS API (${stackEnv})`,
       corsPreflight: {
         allowOrigins: ['*'],
         allowMethods: [
@@ -117,13 +130,12 @@ export class VoicevoxStack extends cdk.Stack {
       },
     });
 
-    // Apply throttling to the $default stage to limit request rate
-    // and reduce cost exposure while CORS is fully open (PoC)
+    // Apply per-environment throttling to the $default stage
     const defaultStage = httpApi.defaultStage?.node.defaultChild as apigatewayv2.CfnStage;
     if (defaultStage) {
       defaultStage.defaultRouteSettings = {
-        throttlingBurstLimit: 10,  // max concurrent requests
-        throttlingRateLimit: 5,    // requests per second
+        throttlingBurstLimit: cfg.throttleBurstLimit,
+        throttlingRateLimit: cfg.throttleRateLimit,
       };
     }
 
@@ -174,7 +186,7 @@ export class VoicevoxStack extends cdk.Stack {
     new cdk.CfnOutput(this, 'VoicevoxApiEndpoint', {
       value: httpApi.apiEndpoint,
       description: 'VOICEVOX API Gateway endpoint URL',
-      exportName: 'VoicevoxApiEndpoint',
+      exportName: `VoicevoxApiEndpoint-${stackEnv}`,
     });
 
     new cdk.CfnOutput(this, 'VoicevoxFunctionArn', {

--- a/aws/package.json
+++ b/aws/package.json
@@ -6,10 +6,18 @@
     "build": "tsc",
     "watch": "tsc -w",
     "cdk": "cdk",
-    "synth": "cdk synth",
-    "diff": "cdk diff",
-    "deploy": "cdk deploy",
-    "destroy": "cdk destroy"
+    "deploy:poc": "cdk deploy -c env=poc",
+    "deploy:dev": "cdk deploy -c env=dev",
+    "deploy:pro": "cdk deploy -c env=pro",
+    "diff:poc": "cdk diff -c env=poc",
+    "diff:dev": "cdk diff -c env=dev",
+    "diff:pro": "cdk diff -c env=pro",
+    "synth:poc": "cdk synth -c env=poc",
+    "synth:dev": "cdk synth -c env=dev",
+    "synth:pro": "cdk synth -c env=pro",
+    "destroy:poc": "cdk destroy -c env=poc",
+    "destroy:dev": "cdk destroy -c env=dev",
+    "destroy:pro": "cdk destroy -c env=pro"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.120.0",


### PR DESCRIPTION
## Summary

- Parameterize CDK stack name and all resource names with `{env}` suffix (`poc` / `dev` / `pro`)
- Read environment from CDK context (`-c env=poc`); default is `poc`
- Add per-environment configuration (memorySize, throttle limits)
- Add `deploy/diff/synth/destroy` npm scripts per environment

## Changes

- `aws/bin/app.ts` – read `env` from CDK context, validate, instantiate `VoicevoxStack-{env}`
- `aws/lib/voicevox-stack.ts` – add `VoicevoxStackProps.stackEnv`, suffix all resource names, apply env-specific config table
- `aws/package.json` – replace generic scripts with per-environment variants

## Environment Config

| env | memorySize | rateLimit | burstLimit |
|-----|-----------|-----------|------------|
| poc | 2048 MB   | 5 RPS     | 10         |
| dev | 2048 MB   | 10 RPS    | 20         |
| pro | 3008 MB   | 50 RPS    | 100        |

## Usage

```bash
npm run deploy:poc   # deploys VoicevoxStack-poc
npm run deploy:dev   # deploys VoicevoxStack-dev
npm run deploy:pro   # deploys VoicevoxStack-pro
```

## Test Plan

- [x] `npm run build` passes with no TypeScript errors
- [x] Manually verified deploy to `poc` environment

## Related

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-environment deployment support with separate configurations for Proof of Concept, Development, and Production environments.
  * Stack identities and resources now dynamically reflect the target environment.
  * Added environment validation to prevent invalid deployment configurations.

* **Chores**
  * Replaced generic deployment scripts with environment-specific variants (deploy:poc, deploy:dev, deploy:pro, etc.).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->