### PR TITLE
feat: Add word archive feature for learned vocabulary

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		A1000010238D1234567890AB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000022238D1234567890AB /* SettingsView.swift */; };
 		A1000025238D1234567890AB /* TrashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000023238D1234567890AB /* TrashView.swift */; };
 		A1000026238D1234567890AB /* EditWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000024238D1234567890AB /* EditWordView.swift */; };
+		A1000075238D1234567890AB /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000074238D1234567890AB /* ArchiveView.swift */; };
 		A1000027238D1234567890AB /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000028238D1234567890AB /* AppConfig.swift */; };
 /* End PBXBuildFile section */
 
@@ -49,6 +50,7 @@
 		A1000022238D1234567890AB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		A1000023238D1234567890AB /* TrashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashView.swift; sourceTree = "<group>"; };
 		A1000024238D1234567890AB /* EditWordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditWordView.swift; sourceTree = "<group>"; };
+		A1000074238D1234567890AB /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		A1000028238D1234567890AB /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -126,6 +128,7 @@
 				A1000022238D1234567890AB /* SettingsView.swift */,
 				A1000023238D1234567890AB /* TrashView.swift */,
 				A1000024238D1234567890AB /* EditWordView.swift */,
+				A1000074238D1234567890AB /* ArchiveView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -233,6 +236,7 @@
 				A1000010238D1234567890AB /* SettingsView.swift in Sources */,
 				A1000025238D1234567890AB /* TrashView.swift in Sources */,
 				A1000026238D1234567890AB /* EditWordView.swift in Sources */,
+				A1000075238D1234567890AB /* ArchiveView.swift in Sources */,
 				A1000027238D1234567890AB /* AppConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
@@ -24,9 +24,11 @@ struct Word: Codable, Identifiable {
     var sentences: [Sentence]
     var deletedAt: Date?
     var createdAt: Date?
+    var archivedAt: Date?
 
     init(id: UUID = UUID(), word: String, meaning: String, phonetic: String,
-         sentences: [Sentence] = [], deletedAt: Date? = nil, createdAt: Date? = Date()) {
+         sentences: [Sentence] = [], deletedAt: Date? = nil, createdAt: Date? = Date(),
+         archivedAt: Date? = nil) {
         self.id = id
         self.word = word
         self.meaning = meaning
@@ -34,6 +36,7 @@ struct Word: Codable, Identifiable {
         self.sentences = sentences
         self.deletedAt = deletedAt
         self.createdAt = createdAt
+        self.archivedAt = archivedAt
     }
 }
 
@@ -71,7 +74,7 @@ class WordDataManager {
             }
             saveAllWords(all)
         }
-        return all.filter { $0.deletedAt == nil }
+        return all.filter { $0.deletedAt == nil && $0.archivedAt == nil }
     }
 
     /// Loads all words including trashed ones.
@@ -98,6 +101,29 @@ class WordDataManager {
         }
         saveAllWords(migrated)
         return migrated
+    }
+
+    /// Loads all archived words.
+    func loadArchivedWords() -> [Word] {
+        return loadAllWords().filter { $0.archivedAt != nil && $0.deletedAt == nil }
+    }
+
+    /// Archives a word by setting archivedAt to now.
+    func archive(wordId: UUID) {
+        var all = loadAllWords()
+        if let idx = all.firstIndex(where: { $0.id == wordId }) {
+            all[idx].archivedAt = Date()
+            saveAllWords(all)
+        }
+    }
+
+    /// Restores an archived word by clearing archivedAt.
+    func unarchive(wordId: UUID) {
+        var all = loadAllWords()
+        if let idx = all.firstIndex(where: { $0.id == wordId }) {
+            all[idx].archivedAt = nil
+            saveAllWords(all)
+        }
     }
 
     /// Loads only trashed words within the 10-day retention window.

--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ArchiveView: View {
+    @State private var archivedWords: [Word] = []
+
+    var body: some View {
+        Group {
+            if archivedWords.isEmpty {
+                VStack(spacing: 16) {
+                    Image(systemName: "archivebox")
+                        .font(.system(size: 60))
+                        .foregroundColor(.secondary)
+                    Text("アーカイブは空です")
+                        .font(.title2)
+                        .foregroundColor(.secondary)
+                    Text("習得済みの単語をアーカイブに移動できます")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List {
+                    ForEach(archivedWords) { word in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(word.word)
+                                .font(.headline)
+                            Text(word.phonetic)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text(word.meaning)
+                                .font(.subheadline)
+                                .foregroundColor(.blue)
+                            if let archivedAt = word.archivedAt {
+                                Text("Archived \(archivedAt.formatted(date: .abbreviated, time: .omitted))")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                WordDataManager.shared.unarchive(wordId: word.id)
+                                load()
+                            } label: {
+                                Label("元に戻す", systemImage: "arrow.uturn.backward")
+                            }
+                            .tint(.green)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("アーカイブ")
+        .onAppear { load() }
+    }
+
+    private func load() {
+        archivedWords = WordDataManager.shared.loadArchivedWords()
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ArchiveView()
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -32,7 +32,7 @@ struct ArchiveView: View {
                                 .font(.subheadline)
                                 .foregroundColor(.blue)
                             if let archivedAt = word.archivedAt {
-                                Text("Archived \(archivedAt.formatted(date: .abbreviated, time: .omitted))")
+                                Text("アーカイブ日: \(archivedAt.formatted(date: .abbreviated, time: .omitted))")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -97,6 +97,13 @@ struct WordListView: View {
                     } label: {
                         Label("ゴミ箱へ", systemImage: "trash")
                     }
+                    Button {
+                        WordDataManager.shared.archive(wordId: word.id)
+                        words = WordDataManager.shared.loadWords()
+                    } label: {
+                        Label("アーカイブ", systemImage: "archivebox")
+                    }
+                    .tint(.teal)
                 }
                 .swipeActions(edge: .leading) {
                     Button {
@@ -119,6 +126,11 @@ struct WordListView: View {
                     showingAddWordView = true
                 }) {
                     Image(systemName: "plus")
+                }
+            }
+            ToolbarItem(placement: .navigationBarLeading) {
+                NavigationLink(destination: ArchiveView()) {
+                    Image(systemName: "archivebox")
                 }
             }
             ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## Summary

Add an archive feature that lets users move mastered words out of the active study list, keeping it focused without losing learned vocabulary.

## Changes

- `Models/Word.swift` – add `archivedAt: Date?` field; update `loadWords()` to exclude archived words; add `archive()`, `unarchive()`, `loadArchivedWords()` to `WordDataManager`
- `Views/ArchiveView.swift` – new dedicated screen (empty state + list with unarchive swipe)
- `Views/WordListView.swift` – trailing swipe adds Archive (teal) alongside Trash; archive icon added to leading toolbar

## Features

### Archive from word list
- Swipe left → **Archive** (teal) | **Trash** (red)
- Archived word immediately disappears from the active list

### Archive view (`archivebox` toolbar icon)
- Lists all archived words with word, phonetic, meaning, and archive date
- Swipe right → **Restore** (green) to move back to the active list
- Empty state shown when no archived words exist

### Persistence
- `archivedAt: Date?` stored in JSON via `WordDataManager`
- Existing words decode with `archivedAt = nil` — no migration needed

## Test Plan

- [x] Swipe left on a word → Archive (teal) and Trash (red) appear
- [x] Tapping Archive removes the word from the main list immediately
- [x] Archived word appears in ArchiveView with correct archive date
- [x] Swipe right in ArchiveView → word returns to the main list
- [x] Archive state persists after app restart
- [x] Empty state is shown when no words are archived
- [x] Trash action still works independently of Archive

## Related

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added archive functionality to organize and separate words from your active learning set
  * New dedicated archive view to display and manage archived words
  * Swipe-to-archive action on word lists for quick organization
  * One-tap unarchive capability to restore archived words to your active set

<!-- end of auto-generated comment: release notes by coderabbit.ai -->