### PR TITLE
feat: set app display name to ボカブラ

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Info.plist
+++ b/EnglishLearnApp/EnglishLearnApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>ボカブラ</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>発音を認識するために音声認識を使用します</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/EnglishLearnApp/EnglishLearnApp/Views/PrivacyPolicyView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/PrivacyPolicyView.swift
@@ -34,7 +34,7 @@ struct PrivacyPolicyView: View {
 
             section("1. 概要") {
                 policyText(
-                    "EnglishLearnApp（以下「本アプリ」）は個人向けの英語学習アプリです。" +
+                    "ボカブラ（vocabulary 以下「本アプリ」）は個人向けの英語学習アプリです。" +
                     "開発者は外部サーバーで個人データを収集・送信・保存しません。" +
                     "すべてのデータはお客様のデバイス上にのみ保存されます。"
                 )
@@ -84,7 +84,7 @@ struct PrivacyPolicyView: View {
 
             section("1. Overview") {
                 policyText(
-                    "EnglishLearnApp (\"the App\") is a personal vocabulary learning application. " +
+                    "ボカブラ (a play on \"vocabulary\", hereinafter \"the App\") is a personal vocabulary learning application. " +
                     "The developer does not collect, transmit, or store any personal data on external servers. " +
                     "All data remains on your device unless you explicitly share it."
                 )

--- a/EnglishLearnApp/EnglishLearnApp/Views/TermsOfServiceView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/TermsOfServiceView.swift
@@ -33,11 +33,11 @@ struct TermsOfServiceView: View {
             policyText("最終更新日：2026年2月")
 
             section("1. 同意") {
-                policyText("EnglishLearnApp（以下「本アプリ」）をダウンロードまたは使用することにより、本利用規約に同意したものとみなします。同意しない場合は本アプリをご使用にならないでください。")
+                policyText("ボカブラ（vocabulary 以下「本アプリ」）をダウンロードまたは使用することにより、本利用規約に同意したものとみなします。同意しない場合は本アプリをご使用にならないでください。")
             }
 
             section("2. サービスの説明") {
-                policyText("本アプリは英単語の登録・発音練習・AI例文生成を行う個人向け語学学習ツールです。AI機能はお客様自身のAPI認証情報を使用するサードパーティサービスを介して提供されます。")
+                policyText("本アプリ（ボカブラ）は英単語の登録・発音練習・AI例文生成を行う個人向け語学学習ツールです。AI機能はお客様自身のAPI認証情報を使用するサードパーティサービスを介して提供されます。")
             }
 
             section("3. ユーザーの責任") {
@@ -79,11 +79,11 @@ struct TermsOfServiceView: View {
             policyText("Last updated: February 2026")
 
             section("1. Acceptance of Terms") {
-                policyText("By downloading or using EnglishLearnApp (\"the App\"), you agree to be bound by these Terms of Service. If you do not agree, please do not use the App.")
+                policyText("By downloading or using ボカブラ (a play on \"vocabulary\", hereinafter \"the App\"), you agree to be bound by these Terms of Service. If you do not agree, please do not use the App.")
             }
 
             section("2. Description of Service") {
-                policyText("The App is a personal vocabulary learning tool that allows you to register English words, practice pronunciation, and generate example sentences using third-party AI services via your own API credentials.")
+                policyText("ボカブラ is a personal vocabulary learning tool that allows you to register English words, practice pronunciation, and generate example sentences using third-party AI services via your own API credentials.")
             }
 
             section("3. User Responsibilities") {


### PR DESCRIPTION
## Summary
- `Info.plist` に `CFBundleDisplayName = ボカブラ` を追加し、アイコン下の表示名を設定
- `PrivacyPolicyView` / `TermsOfServiceView` のアプリ名を `EnglishLearnApp` から `ボカブラ`（vocabulary の語呂合わせ）に更新

## Related Issue
N/A

## Type of Change
- [x] Enhancement (既存機能の改善)

## Changes
- `Info.plist`: `CFBundleDisplayName = ボカブラ` 追加
- `PrivacyPolicyView.swift`: 日英両方のアプリ名を更新
- `TermsOfServiceView.swift`: 日英両方のアプリ名を更新

## Testing
- [x] シミュレータ or 実機でホーム画面アイコン下に「ボカブラ」と表示されることを確認
- [x] 設定 → プライバシーポリシー / 利用規約 を開き、アプリ名表記を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Branding Update**
  * App renamed to ボカブラ (a play on "vocabulary")
  * Updated app display name across all platforms

* **Documentation**
  * Updated privacy policy with new app name
  * Updated terms of service with new app name

<!-- end of auto-generated comment: release notes by coderabbit.ai -->