### PR TITLE
feat: add multiple switchable prompt presets (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,10 @@ Two files must be created locally before building the iOS app:
 6. **Commit** — commit with a clear message referencing the Issue number.
 7. **Push and open a PR** — push the branch and create a pull request targeting `develop`.
 
+### Important Notes
+
+- **DEVELOPMENT_TEAM** does not commit to Debug or Release
+
 ## Current Security Posture
 
 The VOICEVOX API Gateway has **no authentication** (PoC state): CORS is `allowOrigins: ['*']`, no API keys, throttling is the only guard. Issues #11 (access control) and #12 (multi-env deploy) track the planned hardening for release.

--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		A1000075238D1234567890AB /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000074238D1234567890AB /* ArchiveView.swift */; };
 		A1000077238D1234567890AB /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000076238D1234567890AB /* PrivacyPolicyView.swift */; };
 		A1000079238D1234567890AB /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000078238D1234567890AB /* TermsOfServiceView.swift */; };
+		A100007B238D1234567890AB /* PromptPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007A238D1234567890AB /* PromptPreset.swift */; };
+		A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007C238D1234567890AB /* PromptPresetsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -56,6 +58,8 @@
 		A1000074238D1234567890AB /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		A1000076238D1234567890AB /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		A1000078238D1234567890AB /* TermsOfServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceView.swift; sourceTree = "<group>"; };
+		A100007A238D1234567890AB /* PromptPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPreset.swift; sourceTree = "<group>"; };
+		A100007C238D1234567890AB /* PromptPresetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPresetsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +109,7 @@
 			isa = PBXGroup;
 			children = (
 				A1000013238D1234567890AB /* Word.swift */,
+				A100007A238D1234567890AB /* PromptPreset.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -135,6 +140,7 @@
 				A1000074238D1234567890AB /* ArchiveView.swift */,
 				A1000076238D1234567890AB /* PrivacyPolicyView.swift */,
 				A1000078238D1234567890AB /* TermsOfServiceView.swift */,
+				A100007C238D1234567890AB /* PromptPresetsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -246,6 +252,8 @@
 				A1000077238D1234567890AB /* PrivacyPolicyView.swift in Sources */,
 				A1000079238D1234567890AB /* TermsOfServiceView.swift in Sources */,
 				A1000027238D1234567890AB /* AppConfig.swift in Sources */,
+				A100007B238D1234567890AB /* PromptPreset.swift in Sources */,
+				A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -384,6 +392,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EnglishLearnApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 92Z8G96R6X;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EnglishLearnApp/Info.plist;
@@ -417,6 +426,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EnglishLearnApp/Preview Content\"";
+				DEVELOPMENT_TEAM = 92Z8G96R6X;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EnglishLearnApp/Info.plist;

--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -392,7 +392,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EnglishLearnApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 92Z8G96R6X;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EnglishLearnApp/Info.plist;
@@ -426,7 +425,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EnglishLearnApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 92Z8G96R6X;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EnglishLearnApp/Info.plist;

--- a/EnglishLearnApp/EnglishLearnApp/Models/PromptPreset.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/PromptPreset.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// A named set of conditions appended to the sentence-generation prompt.
+struct PromptPreset: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var conditions: String
+    let isBuiltIn: Bool
+
+    init(id: UUID = UUID(), name: String, conditions: String, isBuiltIn: Bool = false) {
+        self.id = id
+        self.name = name
+        self.conditions = conditions
+        self.isBuiltIn = isBuiltIn
+    }
+}
+
+extension PromptPreset {
+    /// The five built-in presets shipped with the app.
+    /// UUIDs are hardcoded and must never change after shipping.
+    static let builtIns: [PromptPreset] = [
+        PromptPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            name: "一般",
+            conditions: """
+            条件：
+            - 日常会話、ビジネス、学習など多様なシーンの例文を含めてください
+            - カテゴリは「日常会話」「ビジネス」「学習・教育」「趣味・娯楽」「旅行」などから適切なものを選んでください
+            - 自然で実用的な例文にしてください
+            - 日本語訳は自然な日本語にしてください
+            """,
+            isBuiltIn: true
+        ),
+        PromptPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            name: "ビジネス",
+            conditions: """
+            条件：
+            - ビジネスシーンで使える例文を生成してください
+            - カテゴリは「会議」「メール」「プレゼン」「交渉」「報告」などから適切なものを選んでください
+            - フォーマルで丁寧な表現を使ってください
+            - 日本語訳は自然なビジネス日本語にしてください
+            """,
+            isBuiltIn: true
+        ),
+        PromptPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+            name: "旅行",
+            conditions: """
+            条件：
+            - 旅行シーンで使える例文を生成してください
+            - カテゴリは「空港」「ホテル」「レストラン」「観光」「交通」などから適切なものを選んでください
+            - 実際に旅行先で使える実用的な表現を使ってください
+            - 日本語訳は自然な日本語にしてください
+            """,
+            isBuiltIn: true
+        ),
+        PromptPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000004")!,
+            name: "学術",
+            conditions: """
+            条件：
+            - 学術・教育シーンで使える例文を生成してください
+            - カテゴリは「論文」「講義」「研究」「議論」「発表」などから適切なものを選んでください
+            - アカデミックな文体で書いてください
+            - 日本語訳は自然な学術日本語にしてください
+            """,
+            isBuiltIn: true
+        ),
+        PromptPreset(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000005")!,
+            name: "カジュアル",
+            conditions: """
+            条件：
+            - 友人や家族との日常会話で使える例文を生成してください
+            - カテゴリは「友人との会話」「SNS」「趣味」「娯楽」「食事」などから適切なものを選んでください
+            - くだけた自然な表現を使ってください
+            - 日本語訳は自然な口語日本語にしてください
+            """,
+            isBuiltIn: true
+        )
+    ]
+
+    /// Convenience accessor for the default (general) preset.
+    static var general: PromptPreset { builtIns[0] }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
@@ -77,9 +77,10 @@ class OpenAIService: ObservableObject {
     ///   - word: The English word to include in the example sentences.
     ///   - meaning: The Japanese meaning of the word (used as context for the prompt).
     ///   - count: The number of sentences to generate (default: 20).
+    ///   - conditions: The prompt conditions to use. If nil, uses the active preset's conditions.
     /// - Returns: An array of generated `Sentence` objects.
     /// - Throws: `OpenAIError` for missing API key, network errors, or parsing failures.
-    func generateSentences(for word: String, meaning: String, count: Int = 20) async throws -> [Sentence] {
+    func generateSentences(for word: String, meaning: String, count: Int = 20, conditions: String? = nil) async throws -> [Sentence] {
         guard let apiKey = SettingsManager.shared.openAIAPIKey, !apiKey.isEmpty else {
             throw OpenAIError.missingAPIKey
         }
@@ -88,6 +89,8 @@ class OpenAIService: ObservableObject {
             isLoading = true
             errorMessage = nil
         }
+
+        let resolvedConditions = conditions ?? SettingsManager.shared.activeConditions
 
         let systemPrompt = """
         あなたは英語学習アプリ用の例文を生成するアシスタントです。
@@ -107,7 +110,7 @@ class OpenAIService: ObservableObject {
         let userPrompt = """
         「\(word)」（\(meaning)）を使った例文を\(count)個生成してください。
 
-        \(SettingsManager.shared.promptConditions)
+        \(resolvedConditions)
         """
 
         let request = OpenAIRequest(

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -230,13 +230,7 @@ class SettingsManager: ObservableObject {
         let legacyKey = "promptConditions"
         if UserDefaults.standard.object(forKey: "promptPresets") == nil,
            let legacyConditions = UserDefaults.standard.string(forKey: legacyKey) {
-            let defaultConditions = """
-            条件：
-            - 日常会話、ビジネス、学習など多様なシーンの例文を含めてください
-            - カテゴリは「日常会話」「ビジネス」「学習・教育」「趣味・娯楽」「旅行」などから適切なものを選んでください
-            - 自然で実用的な例文にしてください
-            - 日本語訳は自然な日本語にしてください
-            """
+            let defaultConditions = PromptPreset.general.conditions
             if legacyConditions.trimmingCharacters(in: .whitespacesAndNewlines) !=
                defaultConditions.trimmingCharacters(in: .whitespacesAndNewlines) {
                 // User had a custom prompt — migrate it as a new custom preset

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -45,12 +45,25 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    /// The conditions appended to the user prompt for sentence generation.
-    ///
-    /// Changes are automatically persisted to UserDefaults.
-    @Published var promptConditions: String {
+    /// Custom (non-built-in) presets stored in UserDefaults.
+    @Published var customPresets: [PromptPreset] {
         didSet {
-            UserDefaults.standard.set(promptConditions, forKey: "promptConditions")
+            saveCustomPresets(customPresets)
+        }
+    }
+
+    /// The ID of the currently active preset.
+    @Published var activePresetID: UUID {
+        didSet {
+            UserDefaults.standard.set(activePresetID.uuidString, forKey: "activePresetID")
+        }
+    }
+
+    /// User edits to built-in preset conditions, keyed by UUID string.
+    /// Only the overridden text is stored; the name stays fixed.
+    @Published var builtInOverrides: [String: String] {
+        didSet {
+            saveBuiltInOverrides()
         }
     }
 
@@ -60,6 +73,35 @@ class SettingsManager: ObservableObject {
             UserDefaults.standard.set(voicevoxStyle.rawValue, forKey: "voicevoxStyle")
         }
     }
+
+    // MARK: - Computed Properties
+
+    /// All presets: built-ins (with any user edits applied) first, then custom.
+    var allPresets: [PromptPreset] {
+        let overriddenBuiltIns = PromptPreset.builtIns.map { preset -> PromptPreset in
+            if let overriddenConditions = builtInOverrides[preset.id.uuidString] {
+                return PromptPreset(id: preset.id, name: preset.name,
+                                   conditions: overriddenConditions, isBuiltIn: true)
+            }
+            return preset
+        }
+        return overriddenBuiltIns + customPresets
+    }
+
+    /// The currently active preset, falling back to the general preset.
+    var activePreset: PromptPreset {
+        allPresets.first { $0.id == activePresetID } ?? PromptPreset.general
+    }
+
+    /// The conditions string of the active preset.
+    var activeConditions: String {
+        activePreset.conditions
+    }
+
+    /// Maximum total number of presets (built-in + custom).
+    static let maxPresets = 10
+
+    // MARK: - Nested Types
 
     /// Voice gender options for text-to-speech.
     enum VoiceGender: String, CaseIterable {
@@ -130,17 +172,10 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    /// The default conditions for the user prompt in sentence generation.
-    static let defaultPromptConditions = """
-    条件：
-    - 日常会話、ビジネス、学習など多様なシーンの例文を含めてください
-    - カテゴリは「日常会話」「ビジネス」「学習・教育」「趣味・娯楽」「旅行」などから適切なものを選んでください
-    - 自然で実用的な例文にしてください
-    - 日本語訳は自然な日本語にしてください
-    """
-
     /// The UserDefaults key for the OpenAI API key.
     private let openAIAPIKeyKey = "openAIAPIKey"
+
+    // MARK: - Initializer
 
     /// Initializes the settings manager and loads saved preferences.
     init() {
@@ -160,17 +195,110 @@ class SettingsManager: ObservableObject {
             self.openAIModel = .gpt4oMini
         }
 
-        if let saved = UserDefaults.standard.string(forKey: "promptConditions") {
-            self.promptConditions = saved
-        } else {
-            self.promptConditions = SettingsManager.defaultPromptConditions
-        }
-
         if let savedStyle = UserDefaults.standard.object(forKey: "voicevoxStyle") as? Int,
            let style = VoicevoxStyle(rawValue: savedStyle) {
             self.voicevoxStyle = style
         } else {
             self.voicevoxStyle = .normal
+        }
+
+        // Load custom presets
+        if let data = UserDefaults.standard.data(forKey: "promptPresets"),
+           let decoded = try? JSONDecoder().decode([PromptPreset].self, from: data) {
+            self.customPresets = decoded
+        } else {
+            self.customPresets = []
+        }
+
+        // Load active preset ID
+        if let idString = UserDefaults.standard.string(forKey: "activePresetID"),
+           let uuid = UUID(uuidString: idString) {
+            self.activePresetID = uuid
+        } else {
+            self.activePresetID = PromptPreset.general.id
+        }
+
+        // Load built-in overrides
+        if let data = UserDefaults.standard.data(forKey: "builtInOverrides"),
+           let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
+            self.builtInOverrides = decoded
+        } else {
+            self.builtInOverrides = [:]
+        }
+
+        // Migration: convert legacy promptConditions to a custom preset if needed
+        let legacyKey = "promptConditions"
+        if UserDefaults.standard.object(forKey: "promptPresets") == nil,
+           let legacyConditions = UserDefaults.standard.string(forKey: legacyKey) {
+            let defaultConditions = """
+            条件：
+            - 日常会話、ビジネス、学習など多様なシーンの例文を含めてください
+            - カテゴリは「日常会話」「ビジネス」「学習・教育」「趣味・娯楽」「旅行」などから適切なものを選んでください
+            - 自然で実用的な例文にしてください
+            - 日本語訳は自然な日本語にしてください
+            """
+            if legacyConditions.trimmingCharacters(in: .whitespacesAndNewlines) !=
+               defaultConditions.trimmingCharacters(in: .whitespacesAndNewlines) {
+                // User had a custom prompt — migrate it as a new custom preset
+                let migrated = PromptPreset(name: "マイプリセット", conditions: legacyConditions)
+                self.customPresets = [migrated]
+                self.activePresetID = migrated.id
+                saveCustomPresets([migrated])
+                UserDefaults.standard.set(migrated.id.uuidString, forKey: "activePresetID")
+            }
+            UserDefaults.standard.removeObject(forKey: legacyKey)
+        }
+    }
+
+    // MARK: - Preset Management
+
+    /// Adds a new custom preset if the total count is below the maximum.
+    func addPreset(_ preset: PromptPreset) {
+        guard allPresets.count < SettingsManager.maxPresets else { return }
+        customPresets.append(preset)
+    }
+
+    /// Updates a preset by ID.
+    /// For built-ins, stores the edited conditions in `builtInOverrides` (or clears the
+    /// override when the conditions are restored to the original).
+    /// For custom presets, updates the entry in `customPresets`.
+    func updatePreset(_ preset: PromptPreset) {
+        if preset.isBuiltIn {
+            let original = PromptPreset.builtIns.first { $0.id == preset.id }?.conditions ?? ""
+            if preset.conditions == original {
+                builtInOverrides.removeValue(forKey: preset.id.uuidString)
+            } else {
+                builtInOverrides[preset.id.uuidString] = preset.conditions
+            }
+        } else {
+            guard let idx = customPresets.firstIndex(where: { $0.id == preset.id }) else { return }
+            customPresets[idx] = preset
+        }
+    }
+
+    /// Restores a built-in preset's conditions to the hardcoded original.
+    func resetPreset(id: UUID) {
+        builtInOverrides.removeValue(forKey: id.uuidString)
+    }
+
+    /// Returns true if a built-in preset has been edited by the user.
+    func isPresetModified(id: UUID) -> Bool {
+        builtInOverrides[id.uuidString] != nil
+    }
+
+    /// Deletes a custom preset by ID. Built-in presets cannot be deleted.
+    func deletePreset(id: UUID) {
+        customPresets.removeAll { $0.id == id }
+        // If the deleted preset was active, fall back to general
+        if activePresetID == id {
+            activePresetID = PromptPreset.general.id
+        }
+    }
+
+    /// Persists custom presets to UserDefaults.
+    func saveCustomPresets(_ presets: [PromptPreset]) {
+        if let data = try? JSONEncoder().encode(presets) {
+            UserDefaults.standard.set(data, forKey: "promptPresets")
         }
     }
 
@@ -179,6 +307,13 @@ class SettingsManager: ObservableObject {
     /// Persists the voice gender setting to UserDefaults.
     private func saveVoiceGender() {
         UserDefaults.standard.set(voiceGender.rawValue, forKey: "voiceGender")
+    }
+
+    /// Persists built-in overrides to UserDefaults.
+    private func saveBuiltInOverrides() {
+        if let data = try? JSONEncoder().encode(builtInOverrides) {
+            UserDefaults.standard.set(data, forKey: "builtInOverrides")
+        }
     }
 
     /// Persists the OpenAI API key to UserDefaults.

--- a/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
@@ -7,11 +7,13 @@ import SwiftUI
 ///
 /// ## Features
 /// - Input fields for word, meaning, and phonetic transcription
+/// - Prompt preset picker (local selection, defaults to global active preset)
 /// - Auto-generation of example sentences via OpenAI
 /// - Preview of generated sentences with categories
 /// - Save functionality to persist the word
 struct AddWordView: View {
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var settings: SettingsManager
     @StateObject private var openAIService = OpenAIService()
 
     /// The English word to add.
@@ -32,6 +34,12 @@ struct AddWordView: View {
     /// The error message to display in the alert.
     @State private var alertMessage = ""
 
+    /// The locally selected preset ID (not bound back to global settings).
+    @State private var selectedPresetID: UUID = PromptPreset.general.id
+
+    /// Whether the preset disclosure group is expanded.
+    @State private var isPresetSectionExpanded: Bool = false
+
     /// Callback invoked when a word is successfully saved.
     var onSave: ((Word) -> Void)?
 
@@ -48,6 +56,38 @@ struct AddWordView: View {
                     TextField("発音記号", text: $phonetic)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
+                }
+
+                Section {
+                    DisclosureGroup(isExpanded: $isPresetSectionExpanded) {
+                        Picker("プリセット", selection: $selectedPresetID) {
+                            ForEach(settings.allPresets) { preset in
+                                Text(preset.name).tag(preset.id)
+                            }
+                        }
+                        .pickerStyle(.menu)
+
+                        let selectedPreset = settings.allPresets.first { $0.id == selectedPresetID }
+                        if let conditions = selectedPreset?.conditions {
+                            Text(conditions)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } label: {
+                        HStack {
+                            Image(systemName: "text.alignleft")
+                                .foregroundColor(.accentColor)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("例文生成の条件")
+                                    .font(.body)
+                                let activeName = settings.allPresets.first { $0.id == selectedPresetID }?.name
+                                    ?? settings.activePreset.name
+                                Text(activeName)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
                 }
 
                 Section {
@@ -120,6 +160,9 @@ struct AddWordView: View {
                     }
                 }
             }
+            .onAppear {
+                selectedPresetID = settings.activePresetID
+            }
             .alert("エラー", isPresented: $showingAlert) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -132,11 +175,13 @@ struct AddWordView: View {
 
     /// Generates example sentences using the OpenAI service.
     ///
-    /// Calls the OpenAI API asynchronously to generate sentences for the current word.
+    /// Uses the locally selected preset's conditions for generation.
     /// Updates `generatedSentences` on success or shows an alert on failure.
     private func generateSentences() async {
+        let conditions = settings.allPresets.first { $0.id == selectedPresetID }?.conditions
+            ?? settings.activeConditions
         do {
-            let sentences = try await openAIService.generateSentences(for: word, meaning: meaning)
+            let sentences = try await openAIService.generateSentences(for: word, meaning: meaning, conditions: conditions)
             await MainActor.run {
                 generatedSentences = sentences
             }
@@ -167,4 +212,5 @@ struct AddWordView: View {
 
 #Preview {
     AddWordView()
+        .environmentObject(SettingsManager.shared)
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/PromptPresetsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/PromptPresetsView.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+
+/// A dedicated screen for managing prompt presets.
+///
+/// Shows all presets (built-in + custom) in a list.
+/// - Tap a row to set it as the active preset.
+/// - Swipe trailing "編集" to edit; "削除" to delete (custom only).
+/// - "+" toolbar button adds a new custom preset.
+struct PromptPresetsView: View {
+    @EnvironmentObject private var settings: SettingsManager
+
+    @State private var navigationTarget: PresetEditTarget? = nil
+    @State private var deletingPresetID: UUID? = nil
+    @State private var showDeleteAlert = false
+
+    var body: some View {
+        List {
+            ForEach(settings.allPresets) { preset in
+                presetRow(preset)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        if !preset.isBuiltIn {
+                            Button(role: .destructive) {
+                                deletingPresetID = preset.id
+                                showDeleteAlert = true
+                            } label: {
+                                Label("削除", systemImage: "trash")
+                            }
+                        }
+                        Button {
+                            navigationTarget = .edit(preset)
+                        } label: {
+                            Label("編集", systemImage: "pencil")
+                        }
+                        .tint(.orange)
+                    }
+            }
+        }
+        .navigationTitle("例文生成の条件")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if settings.allPresets.count < SettingsManager.maxPresets {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        navigationTarget = .new()
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+        }
+        .navigationDestination(item: $navigationTarget) { target in
+            PresetEditView(target: target)
+        }
+        .alert("プリセットを削除", isPresented: $showDeleteAlert) {
+            Button("削除", role: .destructive) {
+                if let id = deletingPresetID {
+                    settings.deletePreset(id: id)
+                }
+                deletingPresetID = nil
+            }
+            Button("キャンセル", role: .cancel) {
+                deletingPresetID = nil
+            }
+        } message: {
+            Text("このプリセットを削除しますか？この操作は元に戻せません。")
+        }
+    }
+
+    @ViewBuilder
+    private func presetRow(_ preset: PromptPreset) -> some View {
+        Button {
+            settings.activePresetID = preset.id
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(preset.name)
+                            .font(.body)
+                            .foregroundColor(.primary)
+                        if preset.isBuiltIn {
+                            Text("組み込み")
+                                .font(.caption2)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Color.secondary.opacity(0.15))
+                                .foregroundColor(.secondary)
+                                .cornerRadius(4)
+                        }
+                        if preset.isBuiltIn && settings.isPresetModified(id: preset.id) {
+                            Text("変更済み")
+                                .font(.caption2)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(Color.orange.opacity(0.15))
+                                .foregroundColor(.orange)
+                                .cornerRadius(4)
+                        }
+                    }
+                    Text(preset.conditions)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer()
+                if settings.activePresetID == preset.id {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.accentColor)
+                        .font(.body.weight(.semibold))
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Navigation target wrapper
+
+/// Wraps the preset being navigated to, distinguishing new-add from edit.
+private struct PresetEditTarget: Identifiable, Hashable {
+    let id: UUID
+    let preset: PromptPreset?
+
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: PresetEditTarget, rhs: PresetEditTarget) -> Bool { lhs.id == rhs.id }
+
+    static func new() -> PresetEditTarget {
+        PresetEditTarget(id: UUID(), preset: nil)
+    }
+
+    static func edit(_ preset: PromptPreset) -> PresetEditTarget {
+        PresetEditTarget(id: preset.id, preset: preset)
+    }
+}
+
+// MARK: - Preset Edit View
+
+private struct PresetEditView: View {
+    @EnvironmentObject private var settings: SettingsManager
+    @Environment(\.dismiss) private var dismiss
+
+    let target: PresetEditTarget
+
+    @State private var name: String
+    @State private var conditions: String
+    @State private var showResetAlert = false
+
+    private var isBuiltIn: Bool { target.preset?.isBuiltIn == true }
+
+    /// Whether conditions have drifted from the hardcoded original.
+    private var isAtDefault: Bool {
+        guard let preset = target.preset, preset.isBuiltIn else { return false }
+        let original = PromptPreset.builtIns.first { $0.id == preset.id }?.conditions ?? ""
+        return conditions == original
+    }
+
+    init(target: PresetEditTarget) {
+        self.target = target
+        _name = State(initialValue: target.preset?.name ?? "")
+        _conditions = State(initialValue: target.preset?.conditions ?? "")
+    }
+
+    var body: some View {
+        Form {
+            Section(header: Text("プリセット名")) {
+                if isBuiltIn {
+                    // Built-in names are fixed; show as read-only label
+                    LabeledContent("名前", value: name)
+                } else {
+                    TextField("名前", text: $name)
+                }
+            }
+
+            Section(header: Text("条件")) {
+                TextEditor(text: $conditions)
+                    .frame(minHeight: 200)
+                    .font(.caption)
+            }
+
+            if isBuiltIn {
+                Section {
+                    Button(role: .destructive) {
+                        showResetAlert = true
+                    } label: {
+                        HStack {
+                            Image(systemName: "arrow.counterclockwise")
+                            Text("デフォルトに戻す")
+                        }
+                    }
+                    .disabled(isAtDefault)
+                }
+            }
+        }
+        .navigationTitle(target.preset == nil ? "新しいプリセット" : "プリセットを編集")
+        .navigationBarTitleDisplayMode(.inline)
+        .scrollDismissesKeyboard(.interactively)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("保存") {
+                    save()
+                    dismiss()
+                }
+                .disabled(isSaveDisabled)
+            }
+        }
+        .alert("デフォルトに戻す", isPresented: $showResetAlert) {
+            Button("リセット", role: .destructive) {
+                if let preset = target.preset {
+                    settings.resetPreset(id: preset.id)
+                    if let original = PromptPreset.builtIns.first(where: { $0.id == preset.id }) {
+                        conditions = original.conditions
+                    }
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            Text("このプリセットの条件をデフォルトの内容に戻します。よろしいですか？")
+        }
+    }
+
+    private var isSaveDisabled: Bool {
+        conditions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+        (!isBuiltIn && name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private func save() {
+        if let existingPreset = target.preset {
+            let updated = PromptPreset(
+                id: existingPreset.id,
+                name: existingPreset.name,
+                conditions: conditions,
+                isBuiltIn: existingPreset.isBuiltIn
+            )
+            settings.updatePreset(updated)
+        } else {
+            let newPreset = PromptPreset(name: name, conditions: conditions, isBuiltIn: false)
+            settings.addPreset(newPreset)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        PromptPresetsView()
+            .environmentObject(SettingsManager.shared)
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/PromptPresetsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/PromptPresetsView.swift
@@ -225,9 +225,10 @@ private struct PresetEditView: View {
 
     private func save() {
         if let existingPreset = target.preset {
+            let updatedName = isBuiltIn ? existingPreset.name : name
             let updated = PromptPreset(
                 id: existingPreset.id,
-                name: existingPreset.name,
+                name: updatedName,
                 conditions: conditions,
                 isBuiltIn: existingPreset.isBuiltIn
             )

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -7,7 +7,7 @@ import UniformTypeIdentifiers
 /// - Voice gender selection for text-to-speech
 /// - OpenAI API key configuration for sentence generation
 /// - OpenAI model selection
-/// - System prompt customization
+/// - Prompt preset management
 ///
 /// Settings are automatically persisted via `SettingsManager`.
 struct SettingsView: View {
@@ -19,12 +19,6 @@ struct SettingsView: View {
 
     /// Local state for the API key input field.
     @State private var apiKeyInput: String = ""
-
-    /// Controls visibility of the reset confirmation alert.
-    @State private var showResetPromptAlert = false
-
-    /// Tracks whether the prompt TextEditor is focused.
-    @FocusState private var isPromptFocused: Bool
 
     // MARK: - Export / Import state
     @State private var exportURL: URL? = nil
@@ -120,38 +114,13 @@ struct SettingsView: View {
                 }
 
                 Section(header: Text("例文生成の条件")) {
-                    TextEditor(text: $settings.promptConditions)
-                        .frame(minHeight: 160)
-                        .font(.caption)
-                        .focused($isPromptFocused)
-                        .toolbar {
-                            ToolbarItemGroup(placement: .keyboard) {
-                                Spacer()
-                                Button("完了") {
-                                    isPromptFocused = false
-                                    UIApplication.shared.sendAction(
-                                        #selector(UIResponder.resignFirstResponder),
-                                        to: nil, from: nil, for: nil
-                                    )
-                                }
-                            }
-                        }
-
-                    Button(role: .destructive) {
-                        showResetPromptAlert = true
-                    } label: {
+                    NavigationLink(destination: PromptPresetsView()) {
                         HStack {
-                            Image(systemName: "arrow.counterclockwise")
-                            Text("デフォルトに戻す")
+                            Text("プリセット管理")
+                            Spacer()
+                            Text(settings.activePreset.name)
+                                .foregroundColor(.secondary)
                         }
-                    }
-                    .alert("条件をリセット", isPresented: $showResetPromptAlert) {
-                        Button("リセット", role: .destructive) {
-                            settings.promptConditions = SettingsManager.defaultPromptConditions
-                        }
-                        Button("キャンセル", role: .cancel) {}
-                    } message: {
-                        Text("例文生成の条件をデフォルトの内容に戻します。よろしいですか？")
                     }
                 }
 
@@ -224,7 +193,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("AIモデルは精度やコストに応じて選択できます。GPT-4o miniは高速で低コスト、GPT-4oは高性能です。")
                             .font(.body)
-                        Text("例文生成の条件を編集することで、生成される例文のシーンやカテゴリをカスタマイズできます。")
+                        Text("例文生成の条件は「プリセット管理」から選択・編集できます。組み込みプリセットはデフォルトに戻すことができます。")
                             .font(.body)
                             .foregroundColor(.secondary)
                     }
@@ -294,6 +263,7 @@ struct SettingsView: View {
             Text(exportErrorMessage ?? "不明なエラーが発生しました")
         }
     }
+
 }
 
 // MARK: - UIKit Share Sheet bridge


### PR DESCRIPTION
## Summary

- `PromptPreset` モデルを新規追加（組み込み5種 + カスタム最大5種）
- `SettingsManager` に preset 管理ロジックを追加（旧 `promptConditions` から自動マイグレーション）
- `SettingsView` → `PromptPresetsView`（別画面）で一覧・編集・追加・削除を管理
- 組み込みプリセットも条件テキストを編集可能、「デフォルトに戻す」で復元
- `AddWordView` にローカルなプリセット選択セクション（グローバル設定を変更しない）
- `OpenAIService.generateSentences()` に `conditions` 引数を追加（nil 時は activeConditions にフォールバック）

## Changes

| File | Change |
|---|---|
| `Models/PromptPreset.swift` | 新規：モデル定義・5つの組み込みプリセット |
| `Services/SettingsManager.swift` | preset 管理プロパティ・メソッド追加、旧データのマイグレーション |
| `Services/OpenAIService.swift` | `conditions` オプション引数追加 |
| `Views/PromptPresetsView.swift` | 新規：プリセット一覧・編集画面 |
| `Views/SettingsView.swift` | プリセットセクションを NavigationLink 1行に置き換え |
| `Views/AddWordView.swift` | ローカルプリセット選択 UI 追加 |

## Test plan

- [x] 新規インストール：「一般」プリセットがアクティブ、組み込み5件が設定画面に表示される
- [x] 組み込みプリセットの条件テキストを編集 → 保存 → 「変更済み」バッジが表示される
- [x] 「デフォルトに戻す」でテキストが元に戻る
- [x] カスタムプリセットを追加・編集・削除できる
- [ ] 10件上限で「+」ボタンが非表示になる
- [ ] `AddWordView` のプリセット選択はグローバル設定を変更しない
- [ ] 例文生成が選択プリセットの条件を使う

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt preset system: create, edit, delete, and choose multiple custom presets.
  * Five built-in presets provided; built-ins can be reset to defaults and show when modified.
  * Dedicated presets management screen with add/edit flows and active-preset selection.
  * Select a specific preset when adding words to control sentence generation.

* **Chores**
  * Migrates legacy single-prompt setting into the new presets system and persists presets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->