### PR TITLE
feat: add onboarding flow with OpenAI API key setup

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A1000075238D1234567890AB /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000074238D1234567890AB /* ArchiveView.swift */; };
 		A1000077238D1234567890AB /* PrivacyPolicyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000076238D1234567890AB /* PrivacyPolicyView.swift */; };
 		A1000079238D1234567890AB /* TermsOfServiceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000078238D1234567890AB /* TermsOfServiceView.swift */; };
+		A100007F238D1234567890AB /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007E238D1234567890AB /* OnboardingView.swift */; };
 		A100007B238D1234567890AB /* PromptPreset.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007A238D1234567890AB /* PromptPreset.swift */; };
 		A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007C238D1234567890AB /* PromptPresetsView.swift */; };
 /* End PBXBuildFile section */
@@ -58,6 +59,7 @@
 		A1000074238D1234567890AB /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		A1000076238D1234567890AB /* PrivacyPolicyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyPolicyView.swift; sourceTree = "<group>"; };
 		A1000078238D1234567890AB /* TermsOfServiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceView.swift; sourceTree = "<group>"; };
+		A100007E238D1234567890AB /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		A100007A238D1234567890AB /* PromptPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPreset.swift; sourceTree = "<group>"; };
 		A100007C238D1234567890AB /* PromptPresetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPresetsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -140,6 +142,7 @@
 				A1000074238D1234567890AB /* ArchiveView.swift */,
 				A1000076238D1234567890AB /* PrivacyPolicyView.swift */,
 				A1000078238D1234567890AB /* TermsOfServiceView.swift */,
+				A100007E238D1234567890AB /* OnboardingView.swift */,
 				A100007C238D1234567890AB /* PromptPresetsView.swift */,
 			);
 			path = Views;
@@ -251,6 +254,7 @@
 				A1000075238D1234567890AB /* ArchiveView.swift in Sources */,
 				A1000077238D1234567890AB /* PrivacyPolicyView.swift in Sources */,
 				A1000079238D1234567890AB /* TermsOfServiceView.swift in Sources */,
+				A100007F238D1234567890AB /* OnboardingView.swift in Sources */,
 				A1000027238D1234567890AB /* AppConfig.swift in Sources */,
 				A100007B238D1234567890AB /* PromptPreset.swift in Sources */,
 				A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */,

--- a/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
+++ b/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
@@ -3,11 +3,17 @@ import SwiftUI
 @main
 struct EnglishLearnAppApp: App {
     @StateObject private var settingsManager = SettingsManager.shared
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(settingsManager)
+            if hasCompletedOnboarding {
+                ContentView()
+                    .environmentObject(settingsManager)
+            } else {
+                OnboardingView(hasCompletedOnboarding: $hasCompletedOnboarding)
+                    .environmentObject(settingsManager)
+            }
         }
     }
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/OnboardingView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/OnboardingView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+enum OnboardingStep {
+    case welcome
+    case apiKey
+}
+
+struct OnboardingView: View {
+    @Binding var hasCompletedOnboarding: Bool
+    @EnvironmentObject private var settings: SettingsManager
+
+    @State private var step: OnboardingStep = .welcome
+    @State private var apiKeyInput: String = ""
+
+    var body: some View {
+        NavigationStack {
+            switch step {
+            case .welcome:
+                WelcomeStepView(onAgree: { step = .apiKey })
+            case .apiKey:
+                APIKeyStepView(
+                    apiKeyInput: $apiKeyInput,
+                    onRegister: {
+                        settings.openAIAPIKey = apiKeyInput.isEmpty ? nil : apiKeyInput
+                        hasCompletedOnboarding = true
+                    },
+                    onSkip: {
+                        hasCompletedOnboarding = true
+                    }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Step 1: Welcome
+
+private struct WelcomeStepView: View {
+    let onAgree: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                Image(systemName: "text.book.closed.fill")
+                    .font(.system(size: 72))
+                    .foregroundColor(.blue)
+
+                VStack(spacing: 8) {
+                    Text("WordCraft へようこそ")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    Text("AIを活用した英語学習アプリです。\n単語を登録すると例文を自動生成し、\n発音練習もサポートします。")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer()
+
+            VStack(spacing: 16) {
+                VStack(spacing: 4) {
+                    Text("続行することで以下に同意したものとみなします")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 4) {
+                        NavigationLink(destination: PrivacyPolicyView()) {
+                            Text("プライバシーポリシー")
+                                .font(.footnote)
+                                .underline()
+                        }
+                        Text("と")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        NavigationLink(destination: TermsOfServiceView()) {
+                            Text("利用規約")
+                                .font(.footnote)
+                                .underline()
+                        }
+                    }
+                }
+
+                Button(action: onAgree) {
+                    Text("同意して次へ")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+// MARK: - Step 2: API Key
+
+private struct APIKeyStepView: View {
+    @Binding var apiKeyInput: String
+    let onRegister: () -> Void
+    let onSkip: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+
+            VStack(spacing: 24) {
+                Image(systemName: "key.fill")
+                    .font(.system(size: 72))
+                    .foregroundColor(.orange)
+
+                VStack(spacing: 8) {
+                    Text("OpenAI API キーの設定")
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+
+                    Text("APIキーを登録すると、単語追加時に\n例文を自動生成できます。\n後から設定画面でも変更できます。")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer()
+
+            VStack(spacing: 16) {
+                SecureField("sk-...", text: $apiKeyInput)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(10)
+
+                Button(action: onRegister) {
+                    Text("登録して始める")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .background(apiKeyInput.isEmpty ? Color.gray.opacity(0.3) : Color.blue)
+                        .foregroundColor(apiKeyInput.isEmpty ? Color.secondary : .white)
+                        .cornerRadius(12)
+                }
+                .disabled(apiKeyInput.isEmpty)
+
+                Button(action: onSkip) {
+                    Text("スキップ")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
+        }
+        .navigationBarHidden(true)
+    }
+}
+
+#Preview {
+    OnboardingView(hasCompletedOnboarding: .constant(false))
+        .environmentObject(SettingsManager.shared)
+}


### PR DESCRIPTION
## Summary

- `OnboardingView.swift` を新規作成し、2ステップのオンボーディングフローを実装
  - Step 1 (Welcome): アプリ説明 + プライバシーポリシー / 利用規約へのリンク + 「同意して次へ」ボタン
  - Step 2 (API Key): OpenAI API キーの任意入力 (SecureField) + 「登録して始める」/ 「スキップ」ボタン
- `EnglishLearnAppApp.swift` に `@AppStorage("hasCompletedOnboarding")` を追加し、初回起動時のみ `OnboardingView` を表示
- `project.pbxproj` に `OnboardingView.swift` を登録（PBXBuildFile / PBXFileReference / PBXGroup / PBXSourcesBuildPhase）

## Test plan

- [x] シミュレータで「App Data をクリア」後に起動 → Step 1 (Welcome) が表示されること
- [x] 「同意して次へ」→ Step 2 (API キー) が表示されること
- [x] API キーを入力して「登録して始める」→ ContentView に遷移し、Settings に API キーが反映されていること
- [x] 「スキップ」→ ContentView に遷移し API キーが空のこと
- [x] 2回目以降の起動では OnboardingView が表示されないこと

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-step onboarding flow with welcome introduction and API key configuration
  * Added persistent onboarding state to prevent repeated setup after initial completion
  * Integrated links to privacy policy and terms of service within onboarding
  * Enabled option to skip API key registration during initial setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->