### PR TITLE
feat: auto-fill meaning and phonetic from AI; require only English word

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
@@ -8,7 +8,7 @@ import Foundation
 /// ## Usage
 /// ```swift
 /// let service = OpenAIService()
-/// let sentences = try await service.generateSentences(for: "rarity", meaning: "珍しさ")
+/// let content = try await service.generateContent(for: "rarity")
 /// ```
 ///
 /// - Note: You must set `SettingsManager.shared.openAIAPIKey` before using this service.
@@ -55,8 +55,10 @@ class OpenAIService: ObservableObject {
         }
     }
 
-    /// The JSON structure of generated sentences returned by the API.
-    struct GeneratedSentences: Codable {
+    /// The JSON structure returned by the API, including meaning, phonetic, and sentences.
+    struct GeneratedContent: Codable {
+        let meaning: String
+        let phonetic: String
         let sentences: [GeneratedSentence]
 
         struct GeneratedSentence: Codable {
@@ -68,19 +70,18 @@ class OpenAIService: ObservableObject {
 
     // MARK: - Public Methods
 
-    /// Generates example sentences for the specified word.
+    /// Generates meaning, phonetic transcription, and example sentences for the specified word.
     ///
-    /// Calls the OpenAI API to generate example sentences using the specified English word.
-    /// Each generated sentence includes an English sentence, Japanese translation, and category.
+    /// Calls the OpenAI API with a single request that returns the Japanese meaning,
+    /// IPA phonetic notation, and example sentences for the given English word.
     ///
     /// - Parameters:
-    ///   - word: The English word to include in the example sentences.
-    ///   - meaning: The Japanese meaning of the word (used as context for the prompt).
+    ///   - word: The English word to look up and generate sentences for.
     ///   - count: The number of sentences to generate (default: 20).
     ///   - conditions: The prompt conditions to use. If nil, uses the active preset's conditions.
-    /// - Returns: An array of generated `Sentence` objects.
+    /// - Returns: A `GeneratedContent` containing meaning, phonetic, and sentences.
     /// - Throws: `OpenAIError` for missing API key, network errors, or parsing failures.
-    func generateSentences(for word: String, meaning: String, count: Int = 20, conditions: String? = nil) async throws -> [Sentence] {
+    func generateContent(for word: String, count: Int = 20, conditions: String? = nil) async throws -> GeneratedContent {
         guard let apiKey = SettingsManager.shared.openAIAPIKey, !apiKey.isEmpty else {
             throw OpenAIError.missingAPIKey
         }
@@ -93,10 +94,12 @@ class OpenAIService: ObservableObject {
         let resolvedConditions = conditions ?? SettingsManager.shared.activeConditions
 
         let systemPrompt = """
-        あなたは英語学習アプリ用の例文を生成するアシスタントです。
-        与えられた英単語を使った自然な例文を生成してください。
+        あなたは英語学習アプリ用のアシスタントです。
+        与えられた英単語について、日本語の意味・IPA発音記号・自然な例文を生成してください。
         以下の形式のJSON形式で返答してください：
         {
+          "meaning": "日本語の意味（簡潔に）",
+          "phonetic": "/IPA発音記号/",
           "sentences": [
             {
               "english": "英文",
@@ -108,7 +111,7 @@ class OpenAIService: ObservableObject {
         """
 
         let userPrompt = """
-        「\(word)」（\(meaning)）を使った例文を\(count)個生成してください。
+        「\(word)」の意味・発音記号・例文を\(count)個生成してください。
 
         \(resolvedConditions)
         """
@@ -156,17 +159,11 @@ class OpenAIService: ObservableObject {
                 throw OpenAIError.invalidJSON
             }
 
-            let generatedSentences = try JSONDecoder().decode(GeneratedSentences.self, from: contentData)
+            let generatedContent = try JSONDecoder().decode(GeneratedContent.self, from: contentData)
 
             await MainActor.run { isLoading = false }
 
-            return generatedSentences.sentences.map { generated in
-                Sentence(
-                    english: generated.english,
-                    japanese: generated.japanese,
-                    category: generated.category
-                )
-            }
+            return generatedContent
         } catch {
             await MainActor.run { isLoading = false }
             throw error

--- a/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/OpenAIService.swift
@@ -61,6 +61,13 @@ class OpenAIService: ObservableObject {
         let phonetic: String
         let sentences: [GeneratedSentence]
 
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.sentences = try container.decode([GeneratedSentence].self, forKey: .sentences)
+            self.meaning = (try? container.decode(String.self, forKey: .meaning)) ?? ""
+            self.phonetic = (try? container.decode(String.self, forKey: .phonetic)) ?? ""
+        }
+
         struct GeneratedSentence: Codable {
             let english: String
             let japanese: String
@@ -93,6 +100,9 @@ class OpenAIService: ObservableObject {
 
         let resolvedConditions = conditions ?? SettingsManager.shared.activeConditions
 
+        // Sanitize word: strip newlines and limit length to prevent prompt injection.
+        let sanitizedWord = String(word.replacingOccurrences(of: "\n", with: " ").prefix(100))
+
         let systemPrompt = """
         あなたは英語学習アプリ用のアシスタントです。
         与えられた英単語について、日本語の意味・IPA発音記号・自然な例文を生成してください。
@@ -111,7 +121,7 @@ class OpenAIService: ObservableObject {
         """
 
         let userPrompt = """
-        「\(word)」の意味・発音記号・例文を\(count)個生成してください。
+        「\(sanitizedWord)」の意味・発音記号・例文を\(count)個生成してください。
 
         \(resolvedConditions)
         """
@@ -127,6 +137,7 @@ class OpenAIService: ObservableObject {
 
         var urlRequest = URLRequest(url: URL(string: endpoint)!)
         urlRequest.httpMethod = "POST"
+        urlRequest.timeoutInterval = 120
         urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = try JSONEncoder().encode(request)

--- a/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
@@ -109,7 +109,7 @@ struct AddWordView: View {
                         .frame(maxWidth: .infinity)
                         .frame(height: 44)
                     }
-                    .disabled(word.isEmpty || meaning.isEmpty || openAIService.isLoading)
+                    .disabled(word.isEmpty || openAIService.isLoading)
                 }
 
                 if !generatedSentences.isEmpty {
@@ -181,9 +181,13 @@ struct AddWordView: View {
         let conditions = settings.allPresets.first { $0.id == selectedPresetID }?.conditions
             ?? settings.activeConditions
         do {
-            let sentences = try await openAIService.generateSentences(for: word, meaning: meaning, conditions: conditions)
+            let content = try await openAIService.generateContent(for: word, conditions: conditions)
             await MainActor.run {
-                generatedSentences = sentences
+                if !content.meaning.isEmpty { meaning = content.meaning }
+                if !content.phonetic.isEmpty { phonetic = content.phonetic }
+                generatedSentences = content.sentences.map {
+                    Sentence(english: $0.english, japanese: $0.japanese, category: $0.category)
+                }
             }
         } catch {
             await MainActor.run {

--- a/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/AddWordView.swift
@@ -51,9 +51,9 @@ struct AddWordView: View {
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
 
-                    TextField("意味", text: $meaning)
+                    TextField("意味（未入力なら自動生成）", text: $meaning)
 
-                    TextField("発音記号", text: $phonetic)
+                    TextField("発音記号（未入力なら自動生成）", text: $phonetic)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                 }
@@ -183,8 +183,10 @@ struct AddWordView: View {
         do {
             let content = try await openAIService.generateContent(for: word, conditions: conditions)
             await MainActor.run {
-                if !content.meaning.isEmpty { meaning = content.meaning }
-                if !content.phonetic.isEmpty { phonetic = content.phonetic }
+                if meaning.isEmpty && !content.meaning.isEmpty { meaning = content.meaning }
+                if phonetic.isEmpty && !content.phonetic.isEmpty {
+                    phonetic = content.phonetic.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                }
                 generatedSentences = content.sentences.map {
                     Sentence(english: $0.english, japanese: $0.japanese, category: $0.category)
                 }


### PR DESCRIPTION
## Summary

- `OpenAIService` に `GeneratedContent` struct（`meaning` / `phonetic` / `sentences`）を追加
- `generateSentences(for:meaning:)` → `generateContent(for:)` に変更し、1回の API コールで意味・発音記号・例文をまとめて取得
- `AddWordView` のボタン有効条件を `word.isEmpty` のみに緩和（意味・発音記号は不要に）
- 生成後、AI が返した値が空でなければ意味・発音記号フィールドを自動補完
- フィールドは引き続き編集可能（保存前に上書き可）

## Test plan

- [ ] 英単語のみ入力した状態で「例文を自動生成」ボタンが有効になること
- [ ] 生成後、意味・発音記号フィールドが AI の返答で自動補完されること
- [ ] 生成後、意味・発音記号を手動で書き換えてから保存できること
- [ ] AI が空文字を返した場合はフィールドが空のまま（プレースホルダーで埋めない）こと
- [ ] 既存の単語データ（手動入力済み）は影響を受けないこと

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Word content generation now returns meaning and phonetic pronunciation alongside example sentences.
  * Updated word addition interface to display and utilize the new meaning and phonetic data.

* **Improvements**
  * Refined button availability logic in the word addition workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->