### PR TITLE
refactor: make WordDataManager ObservableObject for reactive UI updates

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
@@ -44,13 +44,22 @@ struct WordList: Codable {
     let words: [Word]
 }
 
-class WordDataManager {
+class WordDataManager: ObservableObject {
     static let shared = WordDataManager()
+
+    /// Active (non-deleted, non-archived) words. Updated automatically after every mutation.
+    @Published private(set) var words: [Word] = []
+    /// Words in the trash within the 10-day retention window.
+    @Published private(set) var trashedWords: [Word] = []
+    /// Archived words.
+    @Published private(set) var archivedWords: [Word] = []
 
     private let documentsFileName = "words.json"
     private let trashRetentionDays = 10
 
-    private init() {}
+    private init() {
+        refreshPublishedWords()
+    }
 
     private var documentsURL: URL? {
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?
@@ -135,21 +144,17 @@ class WordDataManager {
         }
     }
 
-    /// Saves all words (active + trashed) to Documents.
+    /// Adds a new word to storage.
+    func addWord(_ word: Word) {
+        var all = loadAllWords()
+        all.append(word)
+        saveAllWords(all)
+    }
+
+    /// Saves all words (active + trashed) to Documents and refreshes published properties.
     func saveAllWords(_ words: [Word]) {
-        guard let url = documentsURL else {
-            print("Could not get Documents URL")
-            return
-        }
-        do {
-            let wordList = WordList(words: words)
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(wordList)
-            try data.write(to: url)
-        } catch {
-            print("Error saving words: \(error)")
-        }
+        writeToDisk(words)
+        refreshPublishedWords()
     }
 
     /// Soft-deletes a word by setting deletedAt to now.
@@ -288,6 +293,38 @@ class WordDataManager {
     }
 
     // MARK: - Private Methods
+
+    /// Writes words to disk without triggering a published-property refresh.
+    /// Use this inside `refreshPublishedWords` to avoid re-entrancy.
+    private func writeToDisk(_ words: [Word]) {
+        guard let url = documentsURL else {
+            print("Could not get Documents URL")
+            return
+        }
+        do {
+            let wordList = WordList(words: words)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .prettyPrinted
+            let data = try encoder.encode(wordList)
+            try data.write(to: url)
+        } catch {
+            print("Error saving words: \(error)")
+        }
+    }
+
+    /// Reloads all words from disk, auto-purges expired trash, and updates published properties.
+    private func refreshPublishedWords() {
+        var all = loadAllWords()
+        let cutoff = Calendar.current.date(byAdding: .day, value: -trashRetentionDays, to: Date())!
+        let expired = all.filter { ($0.deletedAt ?? .distantFuture) < cutoff }
+        if !expired.isEmpty {
+            all.removeAll { ($0.deletedAt ?? .distantFuture) < cutoff }
+            writeToDisk(all)
+        }
+        words = all.filter { $0.deletedAt == nil && $0.archivedAt == nil }
+        trashedWords = all.filter { ($0.deletedAt ?? .distantFuture) >= cutoff && $0.deletedAt != nil }
+        archivedWords = all.filter { $0.archivedAt != nil && $0.deletedAt == nil }
+    }
 
     private func loadFromDocuments() -> [Word]? {
         guard let url = documentsURL else { return nil }

--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ArchiveView: View {
-    @State private var archivedWords: [Word] = []
+    @ObservedObject private var dataManager = WordDataManager.shared
 
     // MARK: Selection mode
     @State private var isSelecting = false
@@ -9,7 +9,7 @@ struct ArchiveView: View {
 
     var body: some View {
         Group {
-            if archivedWords.isEmpty {
+            if dataManager.archivedWords.isEmpty {
                 VStack(spacing: 16) {
                     Image(systemName: "archivebox")
                         .font(.system(size: 60))
@@ -25,7 +25,7 @@ struct ArchiveView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List {
-                    ForEach(archivedWords) { word in
+                    ForEach(dataManager.archivedWords) { word in
                         if isSelecting {
                             Button {
                                 toggleSelection(word.id)
@@ -43,7 +43,6 @@ struct ArchiveView: View {
                                 .swipeActions(edge: .leading) {
                                     Button {
                                         WordDataManager.shared.unarchive(wordId: word.id)
-                                        load()
                                     } label: {
                                         Label("元に戻す", systemImage: "arrow.uturn.backward")
                                     }
@@ -63,11 +62,11 @@ struct ArchiveView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if isSelecting {
-                    let allSelected = !archivedWords.isEmpty && archivedWords.allSatisfy { selectedIDs.contains($0.id) }
+                    let allSelected = !dataManager.archivedWords.isEmpty && dataManager.archivedWords.allSatisfy { selectedIDs.contains($0.id) }
                     Button(allSelected ? "すべて解除" : "すべて選択") {
-                        selectedIDs = allSelected ? [] : Set(archivedWords.map(\.id))
+                        selectedIDs = allSelected ? [] : Set(dataManager.archivedWords.map(\.id))
                     }
-                } else if !archivedWords.isEmpty {
+                } else if !dataManager.archivedWords.isEmpty {
                     Button("選択") { isSelecting = true }
                 }
             }
@@ -77,7 +76,6 @@ struct ArchiveView: View {
                 }
             }
         }
-        .onAppear { load() }
     }
 
     /// Renders a single word row with word text, phonetic, meaning, and archive date.
@@ -104,7 +102,6 @@ struct ArchiveView: View {
     private var archiveActionBar: some View {
         Button {
             WordDataManager.shared.unarchive(wordIds: Array(selectedIDs))
-            load()
             exitSelectionMode()
         } label: {
             Label("元に戻す", systemImage: "arrow.uturn.backward")
@@ -129,10 +126,6 @@ struct ArchiveView: View {
         selectedIDs = []
     }
 
-    /// Loads archived words from the data manager.
-    private func load() {
-        archivedWords = WordDataManager.shared.loadArchivedWords()
-    }
 }
 
 #Preview {

--- a/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct TrashView: View {
-    @State private var trashedWords: [Word] = []
+    @ObservedObject private var dataManager = WordDataManager.shared
     @State private var wordToDelete: Word? = nil
     @State private var showingDeleteConfirm = false
 
@@ -12,7 +12,7 @@ struct TrashView: View {
 
     var body: some View {
         Group {
-            if trashedWords.isEmpty {
+            if dataManager.trashedWords.isEmpty {
                 VStack(spacing: 16) {
                     Image(systemName: "trash")
                         .font(.system(size: 60))
@@ -28,7 +28,7 @@ struct TrashView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 List {
-                    ForEach(trashedWords) { word in
+                    ForEach(dataManager.trashedWords) { word in
                         if isSelecting {
                             Button {
                                 toggleSelection(word.id)
@@ -46,7 +46,6 @@ struct TrashView: View {
                                 .swipeActions(edge: .leading) {
                                     Button {
                                         WordDataManager.shared.restoreFromTrash(wordId: word.id)
-                                        loadTrash()
                                     } label: {
                                         Label("元に戻す", systemImage: "arrow.uturn.backward")
                                     }
@@ -74,11 +73,11 @@ struct TrashView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if isSelecting {
-                    let allSelected = !trashedWords.isEmpty && trashedWords.allSatisfy { selectedIDs.contains($0.id) }
+                    let allSelected = !dataManager.trashedWords.isEmpty && dataManager.trashedWords.allSatisfy { selectedIDs.contains($0.id) }
                     Button(allSelected ? "すべて解除" : "すべて選択") {
-                        selectedIDs = allSelected ? [] : Set(trashedWords.map(\.id))
+                        selectedIDs = allSelected ? [] : Set(dataManager.trashedWords.map(\.id))
                     }
-                } else if !trashedWords.isEmpty {
+                } else if !dataManager.trashedWords.isEmpty {
                     Button("選択") { isSelecting = true }
                 }
             }
@@ -88,9 +87,6 @@ struct TrashView: View {
                 }
             }
         }
-        .onAppear {
-            loadTrash()
-        }
         .confirmationDialog(
             "完全削除しますか？",
             isPresented: $showingDeleteConfirm,
@@ -99,7 +95,6 @@ struct TrashView: View {
             Button("完全削除", role: .destructive) {
                 if let word = wordToDelete {
                     WordDataManager.shared.permanentlyDelete(wordId: word.id)
-                    loadTrash()
                 }
             }
             Button("キャンセル", role: .cancel) {}
@@ -113,7 +108,6 @@ struct TrashView: View {
         ) {
             Button("完全削除", role: .destructive) {
                 WordDataManager.shared.permanentlyDelete(wordIds: Array(selectedIDs))
-                loadTrash()
                 exitSelectionMode()
             }
             Button("キャンセル", role: .cancel) {}
@@ -144,7 +138,6 @@ struct TrashView: View {
         HStack(spacing: 0) {
             Button {
                 WordDataManager.shared.restoreFromTrash(wordIds: Array(selectedIDs))
-                loadTrash()
                 exitSelectionMode()
             } label: {
                 Label("元に戻す", systemImage: "arrow.uturn.backward")
@@ -177,11 +170,6 @@ struct TrashView: View {
     private func exitSelectionMode() {
         isSelecting = false
         selectedIDs = []
-    }
-
-    /// Loads trashed words from the data manager.
-    private func loadTrash() {
-        trashedWords = WordDataManager.shared.loadTrashWords()
     }
 
     /// Returns a localized string describing how many days remain before permanent deletion.

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -25,7 +25,7 @@ enum WordSortOption: String, CaseIterable {
 // MARK: - WordListView
 
 struct WordListView: View {
-    @State private var words: [Word] = []
+    @ObservedObject private var dataManager = WordDataManager.shared
     @State private var searchText: String = ""
     @State private var wordToEdit: Word? = nil
     @State private var selectedLetter: Character? = nil
@@ -46,12 +46,12 @@ struct WordListView: View {
     }
 
     private var availableLetters: [Character] {
-        let letters = words.compactMap { $0.word.uppercased().first }
+        let letters = dataManager.words.compactMap { $0.word.uppercased().first }
         return Array(Set(letters)).sorted()
     }
 
     private var filteredWords: [Word] {
-        var result = words
+        var result = dataManager.words
 
         // Letter filter
         if let letter = selectedLetter {
@@ -110,13 +110,11 @@ struct WordListView: View {
                     .swipeActions(edge: .trailing) {
                         Button(role: .destructive) {
                             WordDataManager.shared.moveToTrash(wordId: word.id)
-                            words = WordDataManager.shared.loadWords()
                         } label: {
                             Label("ゴミ箱へ", systemImage: "trash")
                         }
                         Button {
                             WordDataManager.shared.archive(wordId: word.id)
-                            words = WordDataManager.shared.loadWords()
                         } label: {
                             Label("アーカイブ", systemImage: "archivebox")
                         }
@@ -178,19 +176,13 @@ struct WordListView: View {
         }
         .sheet(isPresented: $showingAddWordView) {
             AddWordView { newWord in
-                let all = WordDataManager.shared.loadAllWords() + [newWord]
-                WordDataManager.shared.saveAllWords(all)
-                words = WordDataManager.shared.loadWords()
+                WordDataManager.shared.addWord(newWord)
             }
         }
         .sheet(item: $wordToEdit) { word in
             EditWordView(word: word) { updatedWord in
                 WordDataManager.shared.updateWord(updatedWord)
-                words = WordDataManager.shared.loadWords()
             }
-        }
-        .onAppear {
-            words = WordDataManager.shared.loadWords()
         }
         .onChange(of: searchText) { _, _ in selectedIDs = [] }
         .onChange(of: selectedLetter) { _, _ in selectedIDs = [] }
@@ -201,7 +193,6 @@ struct WordListView: View {
         HStack(spacing: 0) {
             Button {
                 WordDataManager.shared.archive(wordIds: Array(selectedIDs))
-                words = WordDataManager.shared.loadWords()
                 exitSelectionMode()
             } label: {
                 Label("アーカイブ", systemImage: "archivebox")
@@ -214,7 +205,6 @@ struct WordListView: View {
 
             Button(role: .destructive) {
                 WordDataManager.shared.moveToTrash(wordIds: Array(selectedIDs))
-                words = WordDataManager.shared.loadWords()
                 exitSelectionMode()
             } label: {
                 Label("ゴミ箱へ", systemImage: "trash")


### PR DESCRIPTION
## Summary

- `WordDataManager` now conforms to `ObservableObject` with three `@Published` properties: `words`, `trashedWords`, `archivedWords`
- `saveAllWords()` is split into `private writeToDisk()` (disk write only) and a call to `private refreshPublishedWords()`, which recomputes all three arrays in a single disk read and handles trash auto-purge without re-entrancy risk
- `addWord(_:)` added so `WordListView` no longer reaches into `loadAllWords + saveAllWords` externally
- `WordListView`, `TrashView`, `ArchiveView` each adopt `@ObservedObject private var dataManager = WordDataManager.shared` and remove all manual reload calls

## Before / After

| | Before | After |
|---|---|---|
| `WordListView` | `words = WordDataManager.shared.loadWords()` called 7 times | Removed entirely |
| `TrashView` | `loadTrash()` called 4 times + defined as helper | Removed entirely |
| `ArchiveView` | `load()` called 3 times + defined as helper | Removed entirely |
| `.onAppear` reloads | 3 views × 1 each | None |

## Test plan

- [ ] App launches and word list displays correctly
- [ ] Add word → appears in list immediately without navigation
- [ ] Swipe to trash → word disappears from list, appears in Trash tab
- [ ] Swipe to archive → word disappears from list, appears in Archive tab
- [ ] Restore from trash → word reappears in main list
- [ ] Unarchive → word reappears in main list
- [ ] Permanently delete → word gone from all views
- [ ] Batch select + archive/trash/restore/delete → same reactive behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Restructured data management to ensure real-time synchronization of words across the main list, archive, and trash views.
  * Automatic UI updates now reflect changes immediately without manual refreshes.
  * Improved data persistence with automatic cleanup of expired trash items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->