### PR TITLE
refactor: extract duplicated selection mode state into SelectionState helper

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007C238D1234567890AB /* PromptPresetsView.swift */; };
 		A100007F238D1234567890AB /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100007E238D1234567890AB /* OnboardingView.swift */; };
 		A1000081238D1234567890AB /* ActivityPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000080238D1234567890AB /* ActivityPresenter.swift */; };
+		A1000083238D1234567890AB /* SelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000084238D1234567890AB /* SelectionState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,6 +65,7 @@
 		A100007C238D1234567890AB /* PromptPresetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPresetsView.swift; sourceTree = "<group>"; };
 		A100007E238D1234567890AB /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		A1000080238D1234567890AB /* ActivityPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityPresenter.swift; sourceTree = "<group>"; };
+		A1000084238D1234567890AB /* SelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -155,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				A1000080238D1234567890AB /* ActivityPresenter.swift */,
+				A1000084238D1234567890AB /* SelectionState.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 				A100007B238D1234567890AB /* PromptPreset.swift in Sources */,
 				A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */,
 				A1000081238D1234567890AB /* ActivityPresenter.swift in Sources */,
+				A1000083238D1234567890AB /* SelectionState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -3,9 +3,7 @@ import SwiftUI
 struct ArchiveView: View {
     @ObservedObject private var dataManager = WordDataManager.shared
 
-    // MARK: Selection mode
-    @State private var isSelecting = false
-    @State private var selectedIDs: Set<UUID> = []
+    @State private var selection = SelectionState()
 
     var body: some View {
         Group {
@@ -26,13 +24,13 @@ struct ArchiveView: View {
             } else {
                 List {
                     ForEach(dataManager.archivedWords) { word in
-                        if isSelecting {
+                        if selection.isSelecting {
                             Button {
-                                toggleSelection(word.id)
+                                selection.toggle(word.id)
                             } label: {
                                 HStack(spacing: 12) {
-                                    Image(systemName: selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
-                                        .foregroundColor(selectedIDs.contains(word.id) ? .accentColor : .secondary)
+                                    Image(systemName: selection.selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
+                                        .foregroundColor(selection.selectedIDs.contains(word.id) ? .accentColor : .secondary)
                                         .font(.title2)
                                     wordRow(word)
                                 }
@@ -52,7 +50,7 @@ struct ArchiveView: View {
                     }
                 }
                 .safeAreaInset(edge: .bottom) {
-                    if isSelecting {
+                    if selection.isSelecting {
                         archiveActionBar
                     }
                 }
@@ -61,18 +59,18 @@ struct ArchiveView: View {
         .navigationTitle("アーカイブ")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                if isSelecting {
-                    let allSelected = !dataManager.archivedWords.isEmpty && dataManager.archivedWords.allSatisfy { selectedIDs.contains($0.id) }
+                if selection.isSelecting {
+                    let allSelected = !dataManager.archivedWords.isEmpty && dataManager.archivedWords.allSatisfy { selection.selectedIDs.contains($0.id) }
                     Button(allSelected ? "すべて解除" : "すべて選択") {
-                        selectedIDs = allSelected ? [] : Set(dataManager.archivedWords.map(\.id))
+                        selection.selectedIDs = allSelected ? [] : Set(dataManager.archivedWords.map(\.id))
                     }
                 } else if !dataManager.archivedWords.isEmpty {
-                    Button("選択") { isSelecting = true }
+                    Button("選択") { selection.isSelecting = true }
                 }
             }
             ToolbarItem(placement: .navigationBarLeading) {
-                if isSelecting {
-                    Button("キャンセル") { exitSelectionMode() }
+                if selection.isSelecting {
+                    Button("キャンセル") { selection.exit() }
                 }
             }
         }
@@ -101,8 +99,8 @@ struct ArchiveView: View {
     /// Bottom action bar shown during selection mode with an Unarchive action.
     private var archiveActionBar: some View {
         Button {
-            WordDataManager.shared.unarchive(wordIds: Array(selectedIDs))
-            exitSelectionMode()
+            WordDataManager.shared.unarchive(wordIds: Array(selection.selectedIDs))
+            selection.exit()
         } label: {
             Label("元に戻す", systemImage: "arrow.uturn.backward")
                 .frame(maxWidth: .infinity)
@@ -110,20 +108,9 @@ struct ArchiveView: View {
         }
         .buttonStyle(.borderless)
         .tint(.green)
-        .disabled(selectedIDs.isEmpty)
+        .disabled(selection.selectedIDs.isEmpty)
         .background(.regularMaterial)
         .overlay(alignment: .top) { Divider() }
-    }
-
-    /// Toggles the selection state of a word by its ID.
-    private func toggleSelection(_ id: UUID) {
-        if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
-    }
-
-    /// Exits selection mode and clears all selected IDs.
-    private func exitSelectionMode() {
-        isSelecting = false
-        selectedIDs = []
     }
 
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -70,7 +70,7 @@ struct ArchiveView: View {
             }
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
-                    Button("キャンセル") { selection.exit() }
+                    Button("キャンセル") { selection.exitSelectionMode() }
                 }
             }
         }
@@ -100,7 +100,7 @@ struct ArchiveView: View {
     private var archiveActionBar: some View {
         Button {
             WordDataManager.shared.unarchive(wordIds: Array(selection.selectedIDs))
-            selection.exit()
+            selection.exitSelectionMode()
         } label: {
             Label("元に戻す", systemImage: "arrow.uturn.backward")
                 .frame(maxWidth: .infinity)

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SelectionState.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SelectionState.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Shared selection-mode state for list views.
+///
+/// Encapsulates `isSelecting`, `selectedIDs`, and the two common mutations
+/// (toggle a single item, exit selection mode) so they don't have to be
+/// duplicated across WordListView, ArchiveView, and TrashView.
+@Observable
+final class SelectionState {
+    var isSelecting = false
+    var selectedIDs: Set<UUID> = []
+
+    func toggle(_ id: UUID) {
+        if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
+    }
+
+    func exit() {
+        isSelecting = false
+        selectedIDs = []
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SelectionState.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SelectionState.swift
@@ -14,7 +14,7 @@ final class SelectionState {
         if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
     }
 
-    func exit() {
+    func exitSelectionMode() {
         isSelecting = false
         selectedIDs = []
     }

--- a/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
@@ -5,9 +5,7 @@ struct TrashView: View {
     @State private var wordToDelete: Word? = nil
     @State private var showingDeleteConfirm = false
 
-    // MARK: Selection mode
-    @State private var isSelecting = false
-    @State private var selectedIDs: Set<UUID> = []
+    @State private var selection = SelectionState()
     @State private var showingBatchDeleteConfirm = false
 
     var body: some View {
@@ -29,13 +27,13 @@ struct TrashView: View {
             } else {
                 List {
                     ForEach(dataManager.trashedWords) { word in
-                        if isSelecting {
+                        if selection.isSelecting {
                             Button {
-                                toggleSelection(word.id)
+                                selection.toggle(word.id)
                             } label: {
                                 HStack(spacing: 12) {
-                                    Image(systemName: selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
-                                        .foregroundColor(selectedIDs.contains(word.id) ? .accentColor : .secondary)
+                                    Image(systemName: selection.selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
+                                        .foregroundColor(selection.selectedIDs.contains(word.id) ? .accentColor : .secondary)
                                         .font(.title2)
                                     wordRow(word)
                                 }
@@ -63,7 +61,7 @@ struct TrashView: View {
                     }
                 }
                 .safeAreaInset(edge: .bottom) {
-                    if isSelecting {
+                    if selection.isSelecting {
                         trashActionBar
                     }
                 }
@@ -72,18 +70,18 @@ struct TrashView: View {
         .navigationTitle("ゴミ箱")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                if isSelecting {
-                    let allSelected = !dataManager.trashedWords.isEmpty && dataManager.trashedWords.allSatisfy { selectedIDs.contains($0.id) }
+                if selection.isSelecting {
+                    let allSelected = !dataManager.trashedWords.isEmpty && dataManager.trashedWords.allSatisfy { selection.selectedIDs.contains($0.id) }
                     Button(allSelected ? "すべて解除" : "すべて選択") {
-                        selectedIDs = allSelected ? [] : Set(dataManager.trashedWords.map(\.id))
+                        selection.selectedIDs = allSelected ? [] : Set(dataManager.trashedWords.map(\.id))
                     }
                 } else if !dataManager.trashedWords.isEmpty {
-                    Button("選択") { isSelecting = true }
+                    Button("選択") { selection.isSelecting = true }
                 }
             }
             ToolbarItem(placement: .navigationBarLeading) {
-                if isSelecting {
-                    Button("キャンセル") { exitSelectionMode() }
+                if selection.isSelecting {
+                    Button("キャンセル") { selection.exit() }
                 }
             }
         }
@@ -102,13 +100,13 @@ struct TrashView: View {
             Text("この操作は取り消せません。")
         }
         .confirmationDialog(
-            "\(selectedIDs.count)件を完全削除しますか？",
+            "\(selection.selectedIDs.count)件を完全削除しますか？",
             isPresented: $showingBatchDeleteConfirm,
             titleVisibility: .visible
         ) {
             Button("完全削除", role: .destructive) {
-                WordDataManager.shared.permanentlyDelete(wordIds: Array(selectedIDs))
-                exitSelectionMode()
+                WordDataManager.shared.permanentlyDelete(wordIds: Array(selection.selectedIDs))
+                selection.exit()
             }
             Button("キャンセル", role: .cancel) {}
         } message: {
@@ -137,14 +135,14 @@ struct TrashView: View {
     private var trashActionBar: some View {
         HStack(spacing: 0) {
             Button {
-                WordDataManager.shared.restoreFromTrash(wordIds: Array(selectedIDs))
-                exitSelectionMode()
+                WordDataManager.shared.restoreFromTrash(wordIds: Array(selection.selectedIDs))
+                selection.exit()
             } label: {
                 Label("元に戻す", systemImage: "arrow.uturn.backward")
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
-            .disabled(selectedIDs.isEmpty)
+            .disabled(selection.selectedIDs.isEmpty)
 
             Divider().frame(height: 44)
 
@@ -155,21 +153,10 @@ struct TrashView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
-            .disabled(selectedIDs.isEmpty)
+            .disabled(selection.selectedIDs.isEmpty)
         }
         .background(.regularMaterial)
         .overlay(alignment: .top) { Divider() }
-    }
-
-    /// Toggles the selection state of a word by its ID.
-    private func toggleSelection(_ id: UUID) {
-        if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
-    }
-
-    /// Exits selection mode and clears all selected IDs.
-    private func exitSelectionMode() {
-        isSelecting = false
-        selectedIDs = []
     }
 
     /// Returns a localized string describing how many days remain before permanent deletion.

--- a/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/TrashView.swift
@@ -81,7 +81,7 @@ struct TrashView: View {
             }
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
-                    Button("キャンセル") { selection.exit() }
+                    Button("キャンセル") { selection.exitSelectionMode() }
                 }
             }
         }
@@ -106,7 +106,7 @@ struct TrashView: View {
         ) {
             Button("完全削除", role: .destructive) {
                 WordDataManager.shared.permanentlyDelete(wordIds: Array(selection.selectedIDs))
-                selection.exit()
+                selection.exitSelectionMode()
             }
             Button("キャンセル", role: .cancel) {}
         } message: {
@@ -136,7 +136,7 @@ struct TrashView: View {
         HStack(spacing: 0) {
             Button {
                 WordDataManager.shared.restoreFromTrash(wordIds: Array(selection.selectedIDs))
-                selection.exit()
+                selection.exitSelectionMode()
             } label: {
                 Label("元に戻す", systemImage: "arrow.uturn.backward")
                     .frame(maxWidth: .infinity)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -139,7 +139,7 @@ struct WordListView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
-                    Button("キャンセル") { selection.exit() }
+                    Button("キャンセル") { selection.exitSelectionMode() }
                 } else {
                     HStack {
                         NavigationLink(destination: ArchiveView()) {
@@ -178,6 +178,8 @@ struct WordListView: View {
                 WordDataManager.shared.updateWord(updatedWord)
             }
         }
+        // Intentionally only clears selectedIDs; isSelecting stays true so the
+        // user can continue selecting from the newly filtered results.
         .onChange(of: searchText) { _, _ in selection.selectedIDs = [] }
         .onChange(of: selectedLetter) { _, _ in selection.selectedIDs = [] }
     }
@@ -187,7 +189,7 @@ struct WordListView: View {
         HStack(spacing: 0) {
             Button {
                 WordDataManager.shared.archive(wordIds: Array(selection.selectedIDs))
-                selection.exit()
+                selection.exitSelectionMode()
             } label: {
                 Label("アーカイブ", systemImage: "archivebox")
                     .frame(maxWidth: .infinity)
@@ -199,7 +201,7 @@ struct WordListView: View {
 
             Button(role: .destructive) {
                 WordDataManager.shared.moveToTrash(wordIds: Array(selection.selectedIDs))
-                selection.exit()
+                selection.exitSelectionMode()
             } label: {
                 Label("ゴミ箱へ", systemImage: "trash")
                     .frame(maxWidth: .infinity)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -37,9 +37,7 @@ struct WordListView: View {
 
     @State private var showingAddWordView = false
 
-    // MARK: Selection mode
-    @State private var isSelecting = false
-    @State private var selectedIDs: Set<UUID> = []
+    @State private var selection = SelectionState()
 
     private var sortOption: WordSortOption {
         WordSortOption(rawValue: sortOptionRaw) ?? .alphabeticalAZ
@@ -91,13 +89,13 @@ struct WordListView: View {
         VStack(spacing: 0) {
             letterFilterBar
             List(filteredWords) { word in
-                if isSelecting {
+                if selection.isSelecting {
                     Button {
-                        toggleSelection(word.id)
+                        selection.toggle(word.id)
                     } label: {
                         HStack(spacing: 12) {
-                            Image(systemName: selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
-                                .foregroundColor(selectedIDs.contains(word.id) ? .accentColor : .secondary)
+                            Image(systemName: selection.selectedIDs.contains(word.id) ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(selection.selectedIDs.contains(word.id) ? .accentColor : .secondary)
                                 .font(.title2)
                             WordRowView(word: word, speechService: speechService)
                         }
@@ -132,7 +130,7 @@ struct WordListView: View {
             }
             .searchable(text: $searchText, prompt: "単語・意味・発音記号で検索")
             .safeAreaInset(edge: .bottom) {
-                if isSelecting {
+                if selection.isSelecting {
                     wordListActionBar
                 }
             }
@@ -140,8 +138,8 @@ struct WordListView: View {
         .navigationTitle("英単語リスト")
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                if isSelecting {
-                    Button("キャンセル") { exitSelectionMode() }
+                if selection.isSelecting {
+                    Button("キャンセル") { selection.exit() }
                 } else {
                     HStack {
                         NavigationLink(destination: ArchiveView()) {
@@ -154,21 +152,17 @@ struct WordListView: View {
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
-                if isSelecting {
-                    let allSelected = !filteredWords.isEmpty && filteredWords.allSatisfy { selectedIDs.contains($0.id) }
+                if selection.isSelecting {
+                    let allSelected = !filteredWords.isEmpty && filteredWords.allSatisfy { selection.selectedIDs.contains($0.id) }
                     Button(allSelected ? "すべて解除" : "すべて選択") {
-                        if allSelected {
-                            selectedIDs = []
-                        } else {
-                            selectedIDs = Set(filteredWords.map(\.id))
-                        }
+                        selection.selectedIDs = allSelected ? [] : Set(filteredWords.map(\.id))
                     }
                 } else {
                     HStack {
                         sortMenu
                         Button { showingAddWordView = true } label: { Image(systemName: "plus") }
                         if !filteredWords.isEmpty {
-                            Button("選択") { isSelecting = true }
+                            Button("選択") { selection.isSelecting = true }
                         }
                     }
                 }
@@ -184,48 +178,37 @@ struct WordListView: View {
                 WordDataManager.shared.updateWord(updatedWord)
             }
         }
-        .onChange(of: searchText) { _, _ in selectedIDs = [] }
-        .onChange(of: selectedLetter) { _, _ in selectedIDs = [] }
+        .onChange(of: searchText) { _, _ in selection.selectedIDs = [] }
+        .onChange(of: selectedLetter) { _, _ in selection.selectedIDs = [] }
     }
 
     /// Bottom action bar shown during selection mode with Archive and Trash actions.
     private var wordListActionBar: some View {
         HStack(spacing: 0) {
             Button {
-                WordDataManager.shared.archive(wordIds: Array(selectedIDs))
-                exitSelectionMode()
+                WordDataManager.shared.archive(wordIds: Array(selection.selectedIDs))
+                selection.exit()
             } label: {
                 Label("アーカイブ", systemImage: "archivebox")
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
-            .disabled(selectedIDs.isEmpty)
+            .disabled(selection.selectedIDs.isEmpty)
 
             Divider().frame(height: 44)
 
             Button(role: .destructive) {
-                WordDataManager.shared.moveToTrash(wordIds: Array(selectedIDs))
-                exitSelectionMode()
+                WordDataManager.shared.moveToTrash(wordIds: Array(selection.selectedIDs))
+                selection.exit()
             } label: {
                 Label("ゴミ箱へ", systemImage: "trash")
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
-            .disabled(selectedIDs.isEmpty)
+            .disabled(selection.selectedIDs.isEmpty)
         }
         .background(.regularMaterial)
         .overlay(alignment: .top) { Divider() }
-    }
-
-    /// Toggles the selection state of a word by its ID.
-    private func toggleSelection(_ id: UUID) {
-        if selectedIDs.contains(id) { selectedIDs.remove(id) } else { selectedIDs.insert(id) }
-    }
-
-    /// Exits selection mode and clears all selected IDs.
-    private func exitSelectionMode() {
-        isSelecting = false
-        selectedIDs = []
     }
 
     // MARK: - Subviews


### PR DESCRIPTION
## Summary

- Adds `Views/Helpers/SelectionState.swift` — an `@Observable` class that owns `isSelecting`, `selectedIDs`, `toggle(_:)`, and `exit()`
- Replaces the three identical `@State private var isSelecting / selectedIDs` declarations and the duplicated `toggleSelection` / `exitSelectionMode` methods in `WordListView`, `ArchiveView`, and `TrashView` with a single `@State private var selection = SelectionState()`
- Net reduction: ~18 lines of boilerplate removed per view (≈54 lines total across 3 views)

## Motivation

The same four-property/two-method selection pattern was copy-pasted into every list view. Centralising it in `SelectionState` means future changes (e.g. animating exit, adding haptics) only need to happen in one place.

## Test plan

- [x] Build succeeds with no warnings
- [x] Tap "選択" in WordListView — checkmarks appear, batch archive/trash work, cancel clears selection
- [x] Tap "選択" in ArchiveView — checkmarks appear, batch restore works, cancel clears selection
- [x] Tap "選択" in TrashView — checkmarks appear, batch restore and permanent-delete work, cancel clears selection
- [x] Search or letter-filter in WordListView while in selection mode — selectedIDs reset on filter change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized selection state used across list views (Word List, Archive, Trash) for consistent selection behavior.
  * Selection UI, toggles, and batch actions updated to use the shared selection model.
  * Unified enter/exit-selection and selection clearing logic to simplify multi-item operations and toolbar/bottom-bar visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->