### PR TITLE
feat: show word count in title and archive badge

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ArchiveView.swift
@@ -48,7 +48,7 @@ struct ArchiveView: View {
                 }
             }
         }
-        .navigationTitle("アーカイブ")
+        .navigationTitle("アーカイブ (\(dataManager.archivedWords.count))")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if selection.isSelecting {

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -135,7 +135,7 @@ struct WordListView: View {
                 }
             }
         }
-        .navigationTitle("英単語リスト")
+        .navigationTitle("英単語リスト (\(dataManager.words.count))")
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
@@ -144,6 +144,18 @@ struct WordListView: View {
                     HStack {
                         NavigationLink(destination: ArchiveView()) {
                             Image(systemName: "archivebox")
+                                .overlay(alignment: .topTrailing) {
+                                    if dataManager.archivedWords.count > 0 {
+                                        Text("\(dataManager.archivedWords.count)")
+                                            .font(.system(size: 10, weight: .bold))
+                                            .foregroundColor(.white)
+                                            .padding(.horizontal, 4)
+                                            .padding(.vertical, 2)
+                                            .background(Color.accentColor)
+                                            .clipShape(Capsule())
+                                            .offset(x: 8, y: -6)
+                                    }
+                                }
                         }
                         NavigationLink(destination: TrashView()) {
                             Image(systemName: "trash")

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -85,6 +85,14 @@ struct WordListView: View {
         return result
     }
 
+    /// Shows total count when no filter is active; filtered count otherwise,
+    /// preventing a mismatch between the title number and the visible rows.
+    private var titleWordCount: Int {
+        selectedLetter == nil && searchText.isEmpty
+            ? dataManager.words.count
+            : filteredWords.count
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             letterFilterBar
@@ -135,7 +143,7 @@ struct WordListView: View {
                 }
             }
         }
-        .navigationTitle("英単語リスト (\(dataManager.words.count))")
+        .navigationTitle("英単語リスト (\(titleWordCount))")
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
@@ -144,18 +152,8 @@ struct WordListView: View {
                     HStack {
                         NavigationLink(destination: ArchiveView()) {
                             Image(systemName: "archivebox")
-                                .overlay(alignment: .topTrailing) {
-                                    if dataManager.archivedWords.count > 0 {
-                                        Text("\(dataManager.archivedWords.count)")
-                                            .font(.system(size: 10, weight: .bold))
-                                            .foregroundColor(.white)
-                                            .padding(.horizontal, 4)
-                                            .padding(.vertical, 2)
-                                            .background(Color.accentColor)
-                                            .clipShape(Capsule())
-                                            .offset(x: 8, y: -6)
-                                    }
-                                }
+                                .badgeOverlay(dataManager.archivedWords.count,
+                                              accessibilityLabel: "\(dataManager.archivedWords.count)件アーカイブ済み")
                         }
                         NavigationLink(destination: TrashView()) {
                             Image(systemName: "trash")
@@ -345,5 +343,28 @@ struct WordRowView: View {
 #Preview {
     NavigationStack {
         WordListView()
+    }
+}
+
+// MARK: - Badge Overlay
+
+extension View {
+    /// Overlays a numeric badge at the top-trailing corner of any view.
+    /// Caps at "99+" to prevent the badge from overflowing narrow icons.
+    func badgeOverlay(_ count: Int, accessibilityLabel: String = "") -> some View {
+        overlay(alignment: .topTrailing) {
+            if count > 0 {
+                let label = count < 100 ? "\(count)" : "99+"
+                Text(label)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(Color.accentColor)
+                    .clipShape(Capsule())
+                    .offset(x: 8, y: -6)
+                    .accessibilityLabel(accessibilityLabel.isEmpty ? label : accessibilityLabel)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `WordListView` navigation title now shows the total active word count e.g. **英単語リスト (42)**
- The `archivebox` toolbar icon shows a capsule badge with the archived word count when > 0
- `ArchiveView` navigation title shows the archived word count e.g. **アーカイブ (12)**

All counts come from `@Published` `WordDataManager` properties and update automatically on any mutation.

## Test plan

- [ ] Word list title shows correct count; count decreases when a word is archived or trashed
- [ ] Archivebox badge appears when archived words > 0, disappears when all restored
- [ ] Badge number matches the count shown inside ArchiveView
- [ ] ArchiveView title shows correct count; updates when words are restored

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)