### PR TITLE
feat: add continuous playback of all sentences in SentenceListView

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+/// Reference-type flag that can be mutated synchronously from non-mutating
+/// struct methods, ensuring onChange guards see the update before any @State
+/// batching occurs.
+private final class CancelFlag {
+    var value = false
+}
+
 struct SentenceListView: View {
     let word: Word
     @StateObject private var speechService = SpeechService()
@@ -9,9 +16,13 @@ struct SentenceListView: View {
     @State private var isPlayingAll = false
     @State private var playingIndex: Int = 0  // flat index into allSentences
     @State private var playingStep: Int = 0   // 0=EN, 1=JA, 2=EN, 3=JA
-    // Non-@State flag: set synchronously before stop() so onChange guard sees it immediately,
-    // preventing a spurious advancePlayback() call during manual cancel.
-    private var isCanceling = false
+    // Reference-type flag: set synchronously before stop() so the onChange guard
+    // sees it immediately, preventing a spurious advancePlayback() on manual cancel.
+    private let isCanceling = CancelFlag()
+
+    init(word: Word) {
+        self.word = word
+    }
 
     var groupedSentences: [(String, [Sentence])] {
         let grouped = Dictionary(grouping: word.sentences) { $0.category }
@@ -114,9 +125,9 @@ struct SentenceListView: View {
         }
         .onChange(of: speechService.isSpeaking) { _, newValue in
             // Advance only when an utterance finishes naturally.
-            // isCanceling is set synchronously before stop() is called, so this
+            // isCanceling.value is set synchronously before stop() is called, so this
             // guard reliably prevents a spurious advancePlayback() on manual cancel.
-            guard !newValue, isPlayingAll, !isCanceling else { return }
+            guard !newValue, isPlayingAll, !isCanceling.value else { return }
             advancePlayback()
         }
         .onDisappear {
@@ -126,10 +137,12 @@ struct SentenceListView: View {
 
     // MARK: - Playback control
 
-    /// Start continuous playback. If `from` is given, begins at that sentence;
-    /// otherwise starts from the first sentence in the list.
+    /// Start continuous playback. Stops any ongoing playback first, then begins
+    /// at `from` if given, otherwise from the first sentence in the list.
     private func startPlayAll(from sentence: Sentence? = nil) {
         guard !allSentences.isEmpty else { return }
+        // Stop existing playback so isSpeaking/isPlayingAll are in a known state.
+        if isPlayingAll { stopPlayAll() }
         if let sentence,
            let idx = allSentences.firstIndex(where: { $0.id == sentence.id }) {
             playingIndex = idx
@@ -142,11 +155,11 @@ struct SentenceListView: View {
     }
 
     private func stopPlayAll() {
-        isCanceling = true        // set before stop() so onChange guard catches it
+        isCanceling.value = true   // set before stop() so onChange guard catches it
         isPlayingAll = false
         playingStep = 0
         speechService.stop()
-        isCanceling = false
+        isCanceling.value = false
     }
 
     /// Speak the text for the current (sentence, step) position.

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -9,6 +9,9 @@ struct SentenceListView: View {
     @State private var isPlayingAll = false
     @State private var playingIndex: Int = 0  // flat index into allSentences
     @State private var playingStep: Int = 0   // 0=EN, 1=JA, 2=EN, 3=JA
+    // Non-@State flag: set synchronously before stop() so onChange guard sees it immediately,
+    // preventing a spurious advancePlayback() call during manual cancel.
+    private var isCanceling = false
 
     var groupedSentences: [(String, [Sentence])] {
         let grouped = Dictionary(grouping: word.sentences) { $0.category }
@@ -65,24 +68,25 @@ struct SentenceListView: View {
                 Section(header: Text(category)) {
                     ForEach(sentences) { sentence in
                         let isPlaying = playingSentenceID == sentence.id
-                        NavigationLink(destination: SentencePracticeView(sentence: sentence, word: word)) {
-                            HStack {
+                        // NavigationLink and play button are siblings in HStack so the
+                        // button tap is not intercepted by the NavigationLink gesture.
+                        HStack {
+                            NavigationLink(destination: SentencePracticeView(sentence: sentence, word: word)) {
                                 SentenceRowView(sentence: sentence, speechService: speechService)
-                                Spacer()
-                                Button {
-                                    if isPlaying {
-                                        stopPlayAll()
-                                    } else {
-                                        startPlayAll(from: sentence)
-                                    }
-                                } label: {
-                                    Image(systemName: isPlaying ? "stop.fill" : "play.fill")
-                                        .font(.subheadline)
-                                        .foregroundColor(isPlaying ? .red : .secondary)
-                                        .frame(width: 32, height: 32)
-                                }
-                                .buttonStyle(.borderless)
                             }
+                            Button {
+                                if isPlaying {
+                                    stopPlayAll()
+                                } else {
+                                    startPlayAll(from: sentence)
+                                }
+                            } label: {
+                                Image(systemName: isPlaying ? "stop.fill" : "play.fill")
+                                    .font(.subheadline)
+                                    .foregroundColor(isPlaying ? .red : .secondary)
+                                    .frame(width: 32, height: 32)
+                            }
+                            .buttonStyle(.borderless)
                         }
                         .listRowBackground(
                             isPlaying ? Color.accentColor.opacity(0.12) : nil
@@ -109,9 +113,10 @@ struct SentenceListView: View {
             }
         }
         .onChange(of: speechService.isSpeaking) { _, newValue in
-            // Advance to next step only when an utterance naturally finishes.
-            // If isPlayingAll was set to false (e.g. user stopped), guard exits early.
-            guard !newValue, isPlayingAll else { return }
+            // Advance only when an utterance finishes naturally.
+            // isCanceling is set synchronously before stop() is called, so this
+            // guard reliably prevents a spurious advancePlayback() on manual cancel.
+            guard !newValue, isPlayingAll, !isCanceling else { return }
             advancePlayback()
         }
         .onDisappear {
@@ -137,9 +142,11 @@ struct SentenceListView: View {
     }
 
     private func stopPlayAll() {
+        isCanceling = true        // set before stop() so onChange guard catches it
         isPlayingAll = false
         playingStep = 0
         speechService.stop()
+        isCanceling = false
     }
 
     /// Speak the text for the current (sentence, step) position.

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -5,9 +5,24 @@ struct SentenceListView: View {
     @StateObject private var speechService = SpeechService()
     @EnvironmentObject private var settings: SettingsManager
 
+    // MARK: Continuous playback
+    @State private var isPlayingAll = false
+    @State private var playingIndex: Int = 0  // flat index into allSentences
+    @State private var playingStep: Int = 0   // 0=EN, 1=JA, 2=EN, 3=JA
+
     var groupedSentences: [(String, [Sentence])] {
         let grouped = Dictionary(grouping: word.sentences) { $0.category }
         return grouped.sorted { $0.key < $1.key }
+    }
+
+    /// Flattened sentence list in display order, used for continuous playback indexing.
+    private var allSentences: [Sentence] {
+        groupedSentences.flatMap { $0.1 }
+    }
+
+    private var playingSentenceID: UUID? {
+        guard isPlayingAll, playingIndex < allSentences.count else { return nil }
+        return allSentences[playingIndex].id
     }
 
     var body: some View {
@@ -52,12 +67,96 @@ struct SentenceListView: View {
                         NavigationLink(destination: SentencePracticeView(sentence: sentence, word: word)) {
                             SentenceRowView(sentence: sentence, speechService: speechService)
                         }
+                        .listRowBackground(
+                            playingSentenceID == sentence.id
+                                ? Color.accentColor.opacity(0.12)
+                                : nil
+                        )
                     }
                 }
             }
         }
         .navigationTitle("例文一覧")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if isPlayingAll {
+                    Button { stopPlayAll() } label: {
+                        Image(systemName: "stop.fill")
+                    }
+                    .tint(.red)
+                } else {
+                    Button { startPlayAll() } label: {
+                        Image(systemName: "play.fill")
+                    }
+                    .disabled(allSentences.isEmpty)
+                }
+            }
+        }
+        .onChange(of: speechService.isSpeaking) { _, newValue in
+            // Advance to next step only when a utterance naturally finishes.
+            // If isPlayingAll was set to false (e.g. user stopped), guard exits early.
+            guard !newValue, isPlayingAll else { return }
+            advancePlayback()
+        }
+        .onDisappear {
+            if isPlayingAll { stopPlayAll() }
+        }
+    }
+
+    // MARK: - Playback control
+
+    private func startPlayAll() {
+        guard !allSentences.isEmpty else { return }
+        isPlayingAll = true
+        playingIndex = 0
+        playingStep = 0
+        speakCurrentStep()
+    }
+
+    private func stopPlayAll() {
+        isPlayingAll = false
+        playingStep = 0
+        speechService.stop()
+    }
+
+    /// Speak the text for the current (sentence, step) position.
+    private func speakCurrentStep() {
+        guard playingIndex < allSentences.count else {
+            stopPlayAll()
+            return
+        }
+        let sentence = allSentences[playingIndex]
+        switch playingStep {
+        case 0, 2:
+            speechService.speak(sentence.english, voiceGender: settings.voiceGender)
+        case 1, 3:
+            speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender)
+        default:
+            break
+        }
+    }
+
+    /// Called when the current utterance finishes; moves to the next step or sentence.
+    private func advancePlayback() {
+        let nextStep = playingStep + 1
+        if nextStep < 4 {
+            // More steps remain within the current sentence (EN→JA→EN→JA)
+            playingStep = nextStep
+            speakCurrentStep()
+        } else {
+            // Move to the next sentence
+            let nextIdx = playingIndex + 1
+            if nextIdx < allSentences.count {
+                playingIndex = nextIdx
+                playingStep = 0
+                speakCurrentStep()
+            } else {
+                // All sentences done
+                isPlayingAll = false
+                playingStep = 0
+            }
+        }
     }
 }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -64,13 +64,28 @@ struct SentenceListView: View {
             ForEach(groupedSentences, id: \.0) { category, sentences in
                 Section(header: Text(category)) {
                     ForEach(sentences) { sentence in
+                        let isPlaying = playingSentenceID == sentence.id
                         NavigationLink(destination: SentencePracticeView(sentence: sentence, word: word)) {
-                            SentenceRowView(sentence: sentence, speechService: speechService)
+                            HStack {
+                                SentenceRowView(sentence: sentence, speechService: speechService)
+                                Spacer()
+                                Button {
+                                    if isPlaying {
+                                        stopPlayAll()
+                                    } else {
+                                        startPlayAll(from: sentence)
+                                    }
+                                } label: {
+                                    Image(systemName: isPlaying ? "stop.fill" : "play.fill")
+                                        .font(.subheadline)
+                                        .foregroundColor(isPlaying ? .red : .secondary)
+                                        .frame(width: 32, height: 32)
+                                }
+                                .buttonStyle(.borderless)
+                            }
                         }
                         .listRowBackground(
-                            playingSentenceID == sentence.id
-                                ? Color.accentColor.opacity(0.12)
-                                : nil
+                            isPlaying ? Color.accentColor.opacity(0.12) : nil
                         )
                     }
                 }
@@ -94,7 +109,7 @@ struct SentenceListView: View {
             }
         }
         .onChange(of: speechService.isSpeaking) { _, newValue in
-            // Advance to next step only when a utterance naturally finishes.
+            // Advance to next step only when an utterance naturally finishes.
             // If isPlayingAll was set to false (e.g. user stopped), guard exits early.
             guard !newValue, isPlayingAll else { return }
             advancePlayback()
@@ -106,10 +121,17 @@ struct SentenceListView: View {
 
     // MARK: - Playback control
 
-    private func startPlayAll() {
+    /// Start continuous playback. If `from` is given, begins at that sentence;
+    /// otherwise starts from the first sentence in the list.
+    private func startPlayAll(from sentence: Sentence? = nil) {
         guard !allSentences.isEmpty else { return }
+        if let sentence,
+           let idx = allSentences.firstIndex(where: { $0.id == sentence.id }) {
+            playingIndex = idx
+        } else {
+            playingIndex = 0
+        }
         isPlayingAll = true
-        playingIndex = 0
         playingStep = 0
         speakCurrentStep()
     }
@@ -184,7 +206,8 @@ struct SentenceRowView: View {
             meaning: "珍しさ・希少性",
             phonetic: "ˈrer.ə.t̬i",
             sentences: [
-                Sentence(english: "True friendship is a rarity.", japanese: "本当の友情は珍しい。", category: "一般的な使い方")
+                Sentence(english: "True friendship is a rarity.", japanese: "本当の友情は珍しい。", category: "一般的な使い方"),
+                Sentence(english: "Snow is a rarity in this region.", japanese: "この地域では雪は珍しい。", category: "一般的な使い方")
             ]
         ))
     }


### PR DESCRIPTION
## Summary

Adds a **Play All / Stop** toolbar button to `SentenceListView` that plays all example sentences for a word automatically, one after another, without requiring the user to tap each sentence individually.

## Playback behaviour

For each sentence, the order is:

```
English → Japanese → English → Japanese
```

Then playback advances to the next sentence automatically. After the last sentence finishes, playback stops.

## Implementation

- `isPlayingAll`, `playingIndex` (flat sentence index), and `playingStep` (0–3) drive a lightweight state machine
- `onChange(of: speechService.isSpeaking)` triggers `advancePlayback()` when each utterance naturally finishes
  - Guard (`isPlayingAll`) prevents spurious advancement when the user taps **Stop**
- The currently playing row is highlighted with a tinted `listRowBackground`
- `onDisappear` stops playback when the user navigates away
- Uses `SettingsManager.voiceGender` — same voice setting as single-sentence playback

## UI changes

| State | Toolbar button |
|---|---|
| Idle | `play.fill` (disabled if no sentences) |
| Playing | `stop.fill` (red tint) |

## Test plan

- [ ] Play All button appears in `SentenceListView` toolbar
- [ ] Tapping Play All starts playback from the first sentence
- [ ] Each sentence is spoken EN → JA → EN → JA before advancing
- [ ] The currently playing row is visually highlighted
- [ ] Playback advances automatically to the next sentence
- [ ] Tapping Stop cancels playback at any point
- [ ] Playback ends automatically after the last sentence
- [ ] Navigating away from the view stops playback
- [ ] Voice setting from SettingsManager is respected

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Continuous Playback**: New toolbar control allows sequential playback of all sentences in the list.
* **Individual Sentence Controls**: Each sentence now has dedicated play/stop buttons for granular control.
* **Playback Feedback**: Active sentence rows are visually highlighted during playback.
* **Flexible Resume**: Start playback from any sentence rather than always from the beginning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->