### PR TITLE
refactor: アーカイブとゴミ箱のアイコンをヘッダーからフッターに移動

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -223,13 +223,22 @@ struct WordListView: View {
         .overlay(alignment: .top) { Divider() }
     }
 
-    /// Bottom navigation bar with Archive and Settings links, shown when not in selection mode.
+    /// Bottom navigation bar with Archive, Trash, and Settings links, shown when not in selection mode.
     private var navigationFooterBar: some View {
         HStack(spacing: 0) {
             NavigationLink(destination: ArchiveView()) {
                 Image(systemName: "archivebox")
                     .badgeOverlay(dataManager.archivedWords.count,
                                   accessibilityLabel: "\(dataManager.archivedWords.count)件アーカイブ済み")
+                    .font(.title2)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+
+            Divider().frame(height: 44)
+
+            NavigationLink(destination: TrashView()) {
+                Image(systemName: "trash")
                     .font(.title2)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -223,21 +223,23 @@ struct WordListView: View {
         .overlay(alignment: .top) { Divider() }
     }
 
-    /// Bottom navigation bar with Archive and Trash links, shown when not in selection mode.
+    /// Bottom navigation bar with Archive and Settings links, shown when not in selection mode.
     private var navigationFooterBar: some View {
         HStack(spacing: 0) {
             NavigationLink(destination: ArchiveView()) {
-                Label("アーカイブ", systemImage: "archivebox")
+                Image(systemName: "archivebox")
                     .badgeOverlay(dataManager.archivedWords.count,
                                   accessibilityLabel: "\(dataManager.archivedWords.count)件アーカイブ済み")
+                    .font(.title2)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }
 
             Divider().frame(height: 44)
 
-            NavigationLink(destination: TrashView()) {
-                Label("ゴミ箱", systemImage: "trash")
+            NavigationLink(destination: SettingsView()) {
+                Image(systemName: "gearshape")
+                    .font(.title2)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
             }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -147,6 +147,8 @@ struct WordListView: View {
             .safeAreaInset(edge: .bottom) {
                 if selection.isSelecting {
                     wordListActionBar
+                } else {
+                    navigationFooterBar
                 }
             }
         }
@@ -156,17 +158,6 @@ struct WordListView: View {
             ToolbarItem(placement: .navigationBarLeading) {
                 if selection.isSelecting {
                     Button("キャンセル") { selection.exitSelectionMode() }
-                } else {
-                    HStack {
-                        NavigationLink(destination: ArchiveView()) {
-                            Image(systemName: "archivebox")
-                                .badgeOverlay(dataManager.archivedWords.count,
-                                              accessibilityLabel: "\(dataManager.archivedWords.count)件アーカイブ済み")
-                        }
-                        NavigationLink(destination: TrashView()) {
-                            Image(systemName: "trash")
-                        }
-                    }
                 }
             }
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -227,6 +218,29 @@ struct WordListView: View {
                     .padding(.vertical, 14)
             }
             .disabled(selection.selectedIDs.isEmpty)
+        }
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
+    }
+
+    /// Bottom navigation bar with Archive and Trash links, shown when not in selection mode.
+    private var navigationFooterBar: some View {
+        HStack(spacing: 0) {
+            NavigationLink(destination: ArchiveView()) {
+                Label("アーカイブ", systemImage: "archivebox")
+                    .badgeOverlay(dataManager.archivedWords.count,
+                                  accessibilityLabel: "\(dataManager.archivedWords.count)件アーカイブ済み")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+
+            Divider().frame(height: 44)
+
+            NavigationLink(destination: TrashView()) {
+                Label("ゴミ箱", systemImage: "trash")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
         }
         .background(.regularMaterial)
         .overlay(alignment: .top) { Divider() }


### PR DESCRIPTION
## Summary

ナビゲーションバーのヘッダー（toolbar leading）から、画面下部のフッターにアーカイブとゴミ箱のアイコンを移動。

**Before:**
- ツールバー leading にアーカイブ・ゴミ箱アイコン
- 選択モード時のみ下部にアクションバー

**After:**
- ツールバー leading は選択モード時の「キャンセル」のみ
- 通常時: 下部にナビゲーションフッターバー（アーカイブ・ゴミ箱）
- 選択時: 下部にアクションバー（アーカイブ・ゴミ箱へ）

Closes #51

## Changes

- `navigationFooterBar` を新規作成
  - `Label` + `NavigationLink` 形式でアーカイブとゴミ箱へのリンク
  - アーカイブカウントバッジも引き続き表示
  - `.regularMaterial` 背景 + 上部 Divider
- `.safeAreaInset(edge: .bottom)` に条件分岐追加
  - 選択モード時: `wordListActionBar`
  - 通常時: `navigationFooterBar`
- ToolbarItem leading から archive/trash アイコン削除

## Test plan

- [ ] 通常時に画面下部にアーカイブ・ゴミ箱のフッターバーが表示されること
- [ ] アーカイブのバッジカウントが表示されること
- [ ] フッターバーのアイコンをタップして各画面に遷移できること
- [ ] 選択モードに入るとフッターバーが非表示になり、アクションバーが表示されること
- [ ] 選択モードを解除するとフッターバーが再表示されること
- [ ] ツールバー leading には選択モード時のみ「キャンセル」ボタンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a bottom navigation bar providing quick access to Archive and Settings features with an archived items badge, replacing the previous toolbar navigation layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->