### PR TITLE
feat: add 100-word dataset with 20 example sentences each (#34)

### DIFF
--- a/EnglishLearnApp/data/word_set.json
+++ b/EnglishLearnApp/data/word_set.json
@@ -1,0 +1,12904 @@
+{
+  "words": [
+    {
+      "id": "10000001-0001-0001-0001-000000000001",
+      "word": "important",
+      "meaning": "重要な",
+      "phonetic": "ɪmˈpɔːr.tənt",
+      "sentences": [
+        {
+          "id": "10000001-0001-0001-0001-000000000101",
+          "english": "This is an important decision.",
+          "japanese": "これは重要な決断だ。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000102",
+          "english": "Education is important for everyone.",
+          "japanese": "教育は誰にとっても重要だ。",
+          "category": "教育"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000103",
+          "english": "It's important to be on time.",
+          "japanese": "時間を守ることは重要だ。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000104",
+          "english": "Family is the most important thing to me.",
+          "japanese": "家族が私にとって最も重要なものだ。",
+          "category": "家族"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000105",
+          "english": "This document contains important information.",
+          "japanese": "この文書には重要な情報が含まれている。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000106",
+          "english": "Health is more important than wealth.",
+          "japanese": "健康は富より重要だ。",
+          "category": "健康"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000107",
+          "english": "I have something important to tell you.",
+          "japanese": "あなたに伝えたい重要なことがある。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000108",
+          "english": "Customer satisfaction is important to our company.",
+          "japanese": "顧客満足は当社にとって重要だ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000109",
+          "english": "It's important to listen carefully.",
+          "japanese": "注意深く聞くことが重要だ。",
+          "category": "コミュニケーション"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000110",
+          "english": "This is an important step in the process.",
+          "japanese": "これはプロセスにおける重要なステップだ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000111",
+          "english": "Safety is our most important priority.",
+          "japanese": "安全が私たちの最も重要な優先事項だ。",
+          "category": "安全"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000112",
+          "english": "What's important is that we tried our best.",
+          "japanese": "重要なのは最善を尽くしたことだ。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000113",
+          "english": "It's important to stay hydrated in summer.",
+          "japanese": "夏は水分補給が重要だ。",
+          "category": "健康"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000114",
+          "english": "Your opinion is important to us.",
+          "japanese": "あなたの意見は私たちにとって重要だ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000115",
+          "english": "This meeting is very important.",
+          "japanese": "この会議は非常に重要だ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000116",
+          "english": "It's important to save money for the future.",
+          "japanese": "将来のためにお金を貯めることが重要だ。",
+          "category": "金融"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000117",
+          "english": "Environmental protection is important for future generations.",
+          "japanese": "環境保護は将来の世代にとって重要だ。",
+          "category": "環境"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000118",
+          "english": "Communication skills are important in any job.",
+          "japanese": "どんな仕事でもコミュニケーション能力は重要だ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000119",
+          "english": "It's important to learn from your mistakes.",
+          "japanese": "失敗から学ぶことが重要だ。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000001-0001-0001-0001-000000000120",
+          "english": "Timing is important in business.",
+          "japanese": "ビジネスではタイミングが重要だ。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793022394.889790
+    },
+    {
+      "id": "10000002-0002-0002-0002-000000000002",
+      "word": "different",
+      "meaning": "異なる、違う",
+      "phonetic": "ˈdɪf.ər.ənt",
+      "sentences": [
+        {
+          "id": "10000002-0002-0002-0002-000000000201",
+          "english": "This is different from what I expected.",
+          "japanese": "これは私が期待していたものとは違う。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000202",
+          "english": "Everyone has different opinions.",
+          "japanese": "誰もが異なる意見を持っている。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000203",
+          "english": "Let's try a different approach.",
+          "japanese": "別のアプローチを試してみよう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000204",
+          "english": "This year is different from last year.",
+          "japanese": "今年は去年とは違う。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000205",
+          "english": "We come from different backgrounds.",
+          "japanese": "私たちは異なる背景を持っている。",
+          "category": "文化"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000206",
+          "english": "That's a completely different story.",
+          "japanese": "それは全く別の話だ。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000207",
+          "english": "I want to try something different today.",
+          "japanese": "今日は何か違うことをやってみたい。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000208",
+          "english": "Each person has different needs.",
+          "japanese": "人それぞれ異なるニーズがある。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000209",
+          "english": "The two products are very different in quality.",
+          "japanese": "この2つの製品は品質が大きく異なる。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000210",
+          "english": "Things look different from this angle.",
+          "japanese": "この角度から見ると物事が違って見える。",
+          "category": "視点"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000211",
+          "english": "We need a different solution to this problem.",
+          "japanese": "この問題には別の解決策が必要だ。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000212",
+          "english": "Tokyo and Osaka are quite different cities.",
+          "japanese": "東京と大阪はかなり異なる都市だ。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000213",
+          "english": "I feel different after the workout.",
+          "japanese": "運動後は気分が違う。",
+          "category": "健康"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000214",
+          "english": "Her new hairstyle makes her look different.",
+          "japanese": "新しい髪型で彼女は違って見える。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000215",
+          "english": "Different cultures have different customs.",
+          "japanese": "文化が違えば習慣も違う。",
+          "category": "文化"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000216",
+          "english": "The new manager has a different management style.",
+          "japanese": "新しいマネージャーは異なる管理スタイルを持っている。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000217",
+          "english": "Let me show you a different way to do it.",
+          "japanese": "別のやり方を見せましょう。",
+          "category": "教育"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000218",
+          "english": "This tastes different from the original recipe.",
+          "japanese": "これは元のレシピとは味が違う。",
+          "category": "料理"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000219",
+          "english": "We have different priorities right now.",
+          "japanese": "今は優先順位が違う。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000002-0002-0002-0002-000000000220",
+          "english": "It's good to see things from a different perspective.",
+          "japanese": "物事を別の視点から見るのは良いことだ。",
+          "category": "視点"
+        }
+      ],
+      "createdAt": 793026000.000000
+    },
+    {
+      "id": "10000003-0003-0003-0003-000000000003",
+      "word": "available",
+      "meaning": "利用できる、入手可能な",
+      "phonetic": "əˈveɪ.lə.bəl",
+      "sentences": [
+        {
+          "id": "10000003-0003-0003-0003-000000000301",
+          "english": "Is this product available online?",
+          "japanese": "この商品はオンラインで購入できますか？",
+          "category": "買い物"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000302",
+          "english": "I'm available tomorrow afternoon.",
+          "japanese": "明日の午後なら時間があります。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000303",
+          "english": "Are there any seats available?",
+          "japanese": "空席はありますか？",
+          "category": "旅行"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000304",
+          "english": "This service is available 24/7.",
+          "japanese": "このサービスは24時間年中無休で利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000305",
+          "english": "The manager is not available at the moment.",
+          "japanese": "マネージャーは今不在です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000306",
+          "english": "Limited quantities are available.",
+          "japanese": "数量限定で入手できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000307",
+          "english": "When will you be available for a meeting?",
+          "japanese": "いつミーティングに参加できますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000308",
+          "english": "This information is publicly available.",
+          "japanese": "この情報は一般に公開されています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000309",
+          "english": "Free Wi-Fi is available in the lobby.",
+          "japanese": "ロビーで無料Wi-Fiが利用できます。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000310",
+          "english": "The product will be available next month.",
+          "japanese": "その製品は来月発売されます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000311",
+          "english": "Are you available to help me?",
+          "japanese": "手伝ってもらえますか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000312",
+          "english": "The hotel has rooms available for tonight.",
+          "japanese": "ホテルには今夜の空室があります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000313",
+          "english": "All resources are available to team members.",
+          "japanese": "すべてのリソースがチームメンバーに利用可能です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000314",
+          "english": "This feature is only available to premium users.",
+          "japanese": "この機能はプレミアムユーザーのみ利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000315",
+          "english": "The doctor is available on weekdays.",
+          "japanese": "その医師は平日に診察しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000316",
+          "english": "Parking is available on a first-come basis.",
+          "japanese": "駐車場は先着順で利用できます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000317",
+          "english": "Technical support is available via email.",
+          "japanese": "技術サポートはメールで利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000318",
+          "english": "The app is available for both iOS and Android.",
+          "japanese": "このアプリはiOSとAndroidの両方で利用できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000319",
+          "english": "I'm sorry, that size is not available.",
+          "japanese": "申し訳ありませんが、そのサイズは在庫がありません。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000003-0003-0003-0003-000000000320",
+          "english": "The service will be available starting next week.",
+          "japanese": "そのサービスは来週から利用可能になります。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793029600.000000
+    },
+    {
+      "id": "10000004-0004-0004-0004-000000000004",
+      "word": "consider",
+      "meaning": "考慮する、検討する",
+      "phonetic": "kənˈsɪd.ər",
+      "sentences": [
+        {
+          "id": "10000004-0004-0004-0004-000000000401",
+          "english": "Please consider my proposal.",
+          "japanese": "私の提案を検討してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000402",
+          "english": "We need to consider all options.",
+          "japanese": "すべての選択肢を考慮する必要があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000403",
+          "english": "I'm considering changing jobs.",
+          "japanese": "転職を考えています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000404",
+          "english": "Have you considered the consequences?",
+          "japanese": "結果について考えましたか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000405",
+          "english": "She is considered an expert in this field.",
+          "japanese": "彼女はこの分野の専門家と見なされています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000406",
+          "english": "We should consider the budget carefully.",
+          "japanese": "予算を慎重に検討すべきです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000407",
+          "english": "I'll consider your offer and get back to you.",
+          "japanese": "あなたの申し出を検討して、後で返事します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000408",
+          "english": "Consider the environmental impact before buying.",
+          "japanese": "購入前に環境への影響を考慮してください。",
+          "category": "環境"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000409",
+          "english": "They are considering expanding to Asia.",
+          "japanese": "彼らはアジアへの拡大を検討しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000410",
+          "english": "I consider him a close friend.",
+          "japanese": "私は彼を親しい友人だと思っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000411",
+          "english": "Please consider joining our team.",
+          "japanese": "私たちのチームへの参加を検討してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000412",
+          "english": "We must consider the safety of our employees.",
+          "japanese": "従業員の安全を考慮しなければなりません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000413",
+          "english": "Have you considered studying abroad?",
+          "japanese": "留学を考えたことがありますか？",
+          "category": "教育"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000414",
+          "english": "This is considered the best restaurant in town.",
+          "japanese": "これは町で最高のレストランと見なされています。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000415",
+          "english": "Let's consider both the pros and cons.",
+          "japanese": "メリットとデメリットの両方を考えましょう。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000416",
+          "english": "I'm considering taking a vacation next month.",
+          "japanese": "来月休暇を取ることを考えています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000417",
+          "english": "The company is considering new marketing strategies.",
+          "japanese": "会社は新しいマーケティング戦略を検討しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000418",
+          "english": "You should consider getting health insurance.",
+          "japanese": "健康保険に加入することを検討すべきです。",
+          "category": "健康"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000419",
+          "english": "They considered the meeting a success.",
+          "japanese": "彼らは会議を成功と見なしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000004-0004-0004-0004-000000000420",
+          "english": "Consider this a warning.",
+          "japanese": "これを警告と受け取ってください。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793033200.000000
+    },
+    {
+      "id": "10000005-0005-0005-0005-000000000005",
+      "word": "necessary",
+      "meaning": "必要な",
+      "phonetic": "ˈnes.ə.ser.i",
+      "sentences": [
+        {
+          "id": "10000005-0005-0005-0005-000000000501",
+          "english": "Is it necessary to bring a passport?",
+          "japanese": "パスポートを持参する必要がありますか？",
+          "category": "旅行"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000502",
+          "english": "We'll take all necessary measures.",
+          "japanese": "必要なすべての措置を講じます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000503",
+          "english": "Sleep is necessary for good health.",
+          "japanese": "睡眠は健康に必要です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000504",
+          "english": "It's not necessary to apologize.",
+          "japanese": "謝罪する必要はありません。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000505",
+          "english": "We have all the necessary equipment.",
+          "japanese": "必要な設備はすべて揃っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000506",
+          "english": "Practice is necessary to improve your skills.",
+          "japanese": "スキルを向上させるには練習が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000507",
+          "english": "A visa is necessary for some countries.",
+          "japanese": "一部の国ではビザが必要です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000508",
+          "english": "Is it really necessary to attend the meeting?",
+          "japanese": "本当に会議に出席する必要がありますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000509",
+          "english": "I'll do whatever is necessary to succeed.",
+          "japanese": "成功するために必要なことは何でもします。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000510",
+          "english": "Water is necessary for all living things.",
+          "japanese": "水はすべての生物に必要です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000511",
+          "english": "The necessary documents are on your desk.",
+          "japanese": "必要な書類はあなたの机の上にあります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000512",
+          "english": "Training is necessary for new employees.",
+          "japanese": "新入社員には研修が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000513",
+          "english": "It's necessary to book in advance.",
+          "japanese": "事前予約が必要です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000514",
+          "english": "Sometimes change is necessary for growth.",
+          "japanese": "成長のためには変化が必要な時もあります。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000515",
+          "english": "We'll make the necessary arrangements.",
+          "japanese": "必要な手配をします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000516",
+          "english": "Exercise is necessary for maintaining health.",
+          "japanese": "運動は健康維持に必要です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000517",
+          "english": "It's necessary to update the software regularly.",
+          "japanese": "ソフトウェアを定期的に更新する必要があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000518",
+          "english": "Is a reservation necessary for dinner?",
+          "japanese": "夕食の予約は必要ですか？",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000519",
+          "english": "Teamwork is necessary for this project.",
+          "japanese": "このプロジェクトにはチームワークが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000005-0005-0005-0005-000000000520",
+          "english": "All necessary precautions have been taken.",
+          "japanese": "必要な予防措置はすべて講じられています。",
+          "category": "安全"
+        }
+      ],
+      "createdAt": 793036800.000000
+    },
+    {
+      "id": "10000006-0006-0006-0006-000000000006",
+      "word": "develop",
+      "meaning": "発展させる、開発する",
+      "phonetic": "dɪˈvel.əp",
+      "sentences": [
+        {
+          "id": "10000006-0006-0006-0006-000000000601",
+          "english": "We need to develop a new strategy.",
+          "japanese": "新しい戦略を開発する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000602",
+          "english": "Children develop at different rates.",
+          "japanese": "子供は異なる速度で成長します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000603",
+          "english": "The company is developing new software.",
+          "japanese": "会社は新しいソフトウェアを開発しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000604",
+          "english": "He developed a passion for music.",
+          "japanese": "彼は音楽への情熱を育みました。",
+          "category": "趣味"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000605",
+          "english": "We must develop our skills continuously.",
+          "japanese": "私たちは継続的にスキルを伸ばさなければなりません。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000606",
+          "english": "The city is rapidly developing.",
+          "japanese": "その都市は急速に発展しています。",
+          "category": "都市開発"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000607",
+          "english": "She developed a new teaching method.",
+          "japanese": "彼女は新しい教育方法を開発しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000608",
+          "english": "This situation could develop into a problem.",
+          "japanese": "この状況は問題に発展する可能性があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000609",
+          "english": "The team is developing a marketing plan.",
+          "japanese": "チームはマーケティング計画を策定しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000610",
+          "english": "Reading helps develop imagination.",
+          "japanese": "読書は想像力を発達させます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000611",
+          "english": "They developed a close friendship.",
+          "japanese": "彼らは親密な友情を育みました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000612",
+          "english": "Scientists are developing a new vaccine.",
+          "japanese": "科学者たちは新しいワクチンを開発しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000613",
+          "english": "You need to develop your own style.",
+          "japanese": "自分自身のスタイルを開発する必要があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000614",
+          "english": "The project is still developing.",
+          "japanese": "プロジェクトはまだ進行中です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000615",
+          "english": "He developed an interest in photography.",
+          "japanese": "彼は写真への関心を育てました。",
+          "category": "趣味"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000616",
+          "english": "The company wants to develop overseas markets.",
+          "japanese": "会社は海外市場を開拓したいと考えています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000617",
+          "english": "We're developing a new product line.",
+          "japanese": "私たちは新しい製品ラインを開発しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000618",
+          "english": "She developed her language skills abroad.",
+          "japanese": "彼女は海外で語学力を伸ばしました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000619",
+          "english": "The storm is developing quickly.",
+          "japanese": "嵐が急速に発達しています。",
+          "category": "天気"
+        },
+        {
+          "id": "10000006-0006-0006-0006-000000000620",
+          "english": "This area will be developed into a park.",
+          "japanese": "このエリアは公園に開発される予定です。",
+          "category": "都市開発"
+        }
+      ],
+      "createdAt": 793040400.000000
+    },
+    {
+      "id": "10000007-0007-0007-0007-000000000007",
+      "word": "provide",
+      "meaning": "提供する",
+      "phonetic": "prəˈvaɪd",
+      "sentences": [
+        {
+          "id": "10000007-0007-0007-0007-000000000701",
+          "english": "We provide excellent customer service.",
+          "japanese": "私たちは優れた顧客サービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000702",
+          "english": "The hotel provides free breakfast.",
+          "japanese": "ホテルは無料の朝食を提供しています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000703",
+          "english": "Can you provide more information?",
+          "japanese": "もっと情報を提供していただけますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000704",
+          "english": "This app provides many useful features.",
+          "japanese": "このアプリは多くの便利な機能を提供します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000705",
+          "english": "Schools should provide a safe environment.",
+          "japanese": "学校は安全な環境を提供すべきです。",
+          "category": "教育"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000706",
+          "english": "We'll provide all the necessary materials.",
+          "japanese": "必要な資料はすべて提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000707",
+          "english": "The company provides health insurance.",
+          "japanese": "会社は健康保険を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000708",
+          "english": "Please provide your email address.",
+          "japanese": "メールアドレスを提供してください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000709",
+          "english": "The library provides free internet access.",
+          "japanese": "図書館は無料のインターネットアクセスを提供しています。",
+          "category": "公共サービス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000710",
+          "english": "They provide support in multiple languages.",
+          "japanese": "彼らは複数の言語でサポートを提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000711",
+          "english": "The restaurant provides delivery service.",
+          "japanese": "そのレストランは配達サービスを提供しています。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000712",
+          "english": "Our service provides 24-hour support.",
+          "japanese": "当社のサービスは24時間サポートを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000713",
+          "english": "The program provides job training.",
+          "japanese": "そのプログラムは職業訓練を提供します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000714",
+          "english": "We provide solutions for your needs.",
+          "japanese": "お客様のニーズに合わせたソリューションを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000715",
+          "english": "The museum provides audio guides.",
+          "japanese": "博物館は音声ガイドを提供しています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000716",
+          "english": "Please provide proof of payment.",
+          "japanese": "支払いの証明を提供してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000717",
+          "english": "The course provides valuable skills.",
+          "japanese": "そのコースは貴重なスキルを提供します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000718",
+          "english": "They provide childcare services.",
+          "japanese": "彼らは保育サービスを提供しています。",
+          "category": "育児"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000719",
+          "english": "The website provides detailed instructions.",
+          "japanese": "そのウェブサイトは詳細な説明を提供しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000007-0007-0007-0007-000000000720",
+          "english": "We provide customized solutions.",
+          "japanese": "私たちはカスタマイズされたソリューションを提供します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793044000.000000
+    },
+    {
+      "id": "10000008-0008-0008-0008-000000000008",
+      "word": "achieve",
+      "meaning": "達成する、成し遂げる",
+      "phonetic": "əˈtʃiːv",
+      "sentences": [
+        {
+          "id": "10000008-0008-0008-0008-000000000801",
+          "english": "She achieved her goal of running a marathon.",
+          "japanese": "彼女はマラソン完走の目標を達成しました。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000802",
+          "english": "We can achieve great things together.",
+          "japanese": "私たちは一緒に素晴らしいことを成し遂げられます。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000803",
+          "english": "Hard work helped him achieve success.",
+          "japanese": "努力が彼の成功達成を助けました。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000804",
+          "english": "The company achieved record sales this year.",
+          "japanese": "会社は今年過去最高の売上を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000805",
+          "english": "How did you achieve this result?",
+          "japanese": "どのようにしてこの結果を達成しましたか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000806",
+          "english": "They achieved their target ahead of schedule.",
+          "japanese": "彼らは予定より早く目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000807",
+          "english": "You can achieve anything you set your mind to.",
+          "japanese": "心に決めたことは何でも達成できます。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000808",
+          "english": "The team achieved an important milestone.",
+          "japanese": "チームは重要な節目を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000809",
+          "english": "She achieved fluency in Japanese.",
+          "japanese": "彼女は日本語の流暢さを達成しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000810",
+          "english": "We achieved our objectives for the quarter.",
+          "japanese": "私たちは四半期の目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000811",
+          "english": "He achieved recognition for his work.",
+          "japanese": "彼は仕事で認められました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000812",
+          "english": "The project achieved all its goals.",
+          "japanese": "プロジェクトはすべての目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000813",
+          "english": "They achieved peace through dialogue.",
+          "japanese": "彼らは対話を通じて平和を達成しました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000814",
+          "english": "She achieved her dream of becoming a doctor.",
+          "japanese": "彼女は医者になる夢を達成しました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000815",
+          "english": "We achieved better results than expected.",
+          "japanese": "期待以上の結果を達成しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000816",
+          "english": "The athlete achieved a personal best.",
+          "japanese": "その選手は自己ベストを達成しました。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000817",
+          "english": "Our company achieved carbon neutrality.",
+          "japanese": "当社はカーボンニュートラルを達成しました。",
+          "category": "環境"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000818",
+          "english": "He achieved fame at a young age.",
+          "japanese": "彼は若くして名声を得ました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000819",
+          "english": "The campaign achieved its fundraising goal.",
+          "japanese": "そのキャンペーンは資金調達目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000008-0008-0008-0008-000000000820",
+          "english": "She achieved balance between work and life.",
+          "japanese": "彼女は仕事と生活のバランスを達成しました。",
+          "category": "ライフスタイル"
+        }
+      ],
+      "createdAt": 793047600.000000
+    },
+    {
+      "id": "10000009-0009-0009-0009-000000000009",
+      "word": "improve",
+      "meaning": "改善する、向上させる",
+      "phonetic": "ɪmˈpruːv",
+      "sentences": [
+        {
+          "id": "10000009-0009-0009-0009-000000000901",
+          "english": "We need to improve our service quality.",
+          "japanese": "サービスの質を向上させる必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000902",
+          "english": "His English has improved significantly.",
+          "japanese": "彼の英語は大幅に上達しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000903",
+          "english": "Exercise can improve your health.",
+          "japanese": "運動は健康を改善できます。",
+          "category": "健康"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000904",
+          "english": "How can we improve this process?",
+          "japanese": "このプロセスをどう改善できますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000905",
+          "english": "The weather is improving.",
+          "japanese": "天気が良くなってきています。",
+          "category": "天気"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000906",
+          "english": "Reading regularly will improve your vocabulary.",
+          "japanese": "定期的に読書をすると語彙が増えます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000907",
+          "english": "We're working to improve customer satisfaction.",
+          "japanese": "顧客満足度の向上に取り組んでいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000908",
+          "english": "Practice helps improve your skills.",
+          "japanese": "練習はスキルの向上に役立ちます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000909",
+          "english": "The company improved its profit margin.",
+          "japanese": "会社は利益率を改善しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000910",
+          "english": "Sleep quality can improve with good habits.",
+          "japanese": "良い習慣で睡眠の質が向上します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000911",
+          "english": "We've improved our production efficiency.",
+          "japanese": "生産効率を改善しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000912",
+          "english": "Your writing has improved a lot.",
+          "japanese": "あなたの文章力はかなり向上しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000913",
+          "english": "This update will improve app performance.",
+          "japanese": "このアップデートはアプリの性能を向上させます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000914",
+          "english": "Her condition is gradually improving.",
+          "japanese": "彼女の状態は徐々に改善しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000915",
+          "english": "We're looking for ways to improve efficiency.",
+          "japanese": "効率を改善する方法を探しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000916",
+          "english": "Technology has improved our lives.",
+          "japanese": "技術は私たちの生活を向上させました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000917",
+          "english": "There's always room to improve.",
+          "japanese": "常に改善の余地があります。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000918",
+          "english": "The new system improved workflow.",
+          "japanese": "新しいシステムはワークフローを改善しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000919",
+          "english": "Regular feedback helps improve performance.",
+          "japanese": "定期的なフィードバックはパフォーマンス向上に役立ちます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000009-0009-0009-0009-000000000920",
+          "english": "I want to improve my cooking skills.",
+          "japanese": "料理のスキルを向上させたいです。",
+          "category": "料理"
+        }
+      ],
+      "createdAt": 793051200.000000
+    },
+    {
+      "id": "10000010-0010-0010-0010-000000000010",
+      "word": "experience",
+      "meaning": "経験、体験する",
+      "phonetic": "ɪkˈspɪə.ri.əns",
+      "sentences": [
+        {
+          "id": "10000010-0010-0010-0010-000000001001",
+          "english": "I had an amazing experience in Japan.",
+          "japanese": "日本で素晴らしい経験をしました。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001002",
+          "english": "Do you have any work experience?",
+          "japanese": "仕事の経験はありますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001003",
+          "english": "This job requires five years of experience.",
+          "japanese": "この仕事には5年の経験が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001004",
+          "english": "We experienced some technical difficulties.",
+          "japanese": "技術的な問題を経験しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001005",
+          "english": "Travel gives you valuable experiences.",
+          "japanese": "旅行は貴重な経験を与えてくれます。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001006",
+          "english": "She has extensive experience in marketing.",
+          "japanese": "彼女はマーケティングの豊富な経験があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001007",
+          "english": "It was a learning experience for everyone.",
+          "japanese": "それは皆にとって学びの経験でした。",
+          "category": "教育"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001008",
+          "english": "Have you ever experienced an earthquake?",
+          "japanese": "地震を経験したことがありますか？",
+          "category": "自然災害"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001009",
+          "english": "Our company values customer experience.",
+          "japanese": "当社は顧客体験を重視しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001010",
+          "english": "That was the worst experience of my life.",
+          "japanese": "それは私の人生で最悪の経験でした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001011",
+          "english": "We're looking for experienced candidates.",
+          "japanese": "経験豊富な候補者を探しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001012",
+          "english": "He experienced culture shock abroad.",
+          "japanese": "彼は海外で文化的ショックを経験しました。",
+          "category": "文化"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001013",
+          "english": "The museum offers an interactive experience.",
+          "japanese": "その博物館はインタラクティブな体験を提供します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001014",
+          "english": "Experience is the best teacher.",
+          "japanese": "経験は最良の教師です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001015",
+          "english": "I experienced homesickness when I studied abroad.",
+          "japanese": "留学中にホームシックを経験しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001016",
+          "english": "Customer experience is our top priority.",
+          "japanese": "顧客体験が私たちの最優先事項です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001017",
+          "english": "She gained valuable experience from the internship.",
+          "japanese": "彼女はインターンシップから貴重な経験を得ました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001018",
+          "english": "Have you experienced this problem before?",
+          "japanese": "以前にこの問題を経験したことがありますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001019",
+          "english": "The tour provides an authentic cultural experience.",
+          "japanese": "そのツアーは本物の文化体験を提供します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000010-0010-0010-0010-000000001020",
+          "english": "Every experience teaches us something.",
+          "japanese": "すべての経験が私たちに何かを教えてくれます。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793054800.000000
+    },
+    {
+      "id": "10000011-0011-0011-0011-000000000011",
+      "word": "increase",
+      "meaning": "増加する、増やす",
+      "phonetic": "ɪnˈkriːs",
+      "sentences": [
+        {
+          "id": "10000011-0011-0011-0011-000000001101",
+          "english": "Sales increased by 20% this year.",
+          "japanese": "売上は今年20%増加しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001102",
+          "english": "We need to increase productivity.",
+          "japanese": "生産性を向上させる必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001103",
+          "english": "The population is increasing rapidly.",
+          "japanese": "人口が急速に増加しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001104",
+          "english": "Prices have increased again.",
+          "japanese": "価格がまた上がりました。",
+          "category": "経済"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001105",
+          "english": "Exercise can increase your energy levels.",
+          "japanese": "運動はエネルギーレベルを高めることができます。",
+          "category": "健康"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001106",
+          "english": "The company plans to increase staff.",
+          "japanese": "会社はスタッフを増やす計画です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001107",
+          "english": "Traffic tends to increase during holidays.",
+          "japanese": "休日には交通量が増える傾向があります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001108",
+          "english": "We saw a significant increase in demand.",
+          "japanese": "需要の大幅な増加が見られました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001109",
+          "english": "Reading increases your knowledge.",
+          "japanese": "読書は知識を増やします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001110",
+          "english": "The temperature is expected to increase.",
+          "japanese": "気温が上昇すると予想されています。",
+          "category": "天気"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001111",
+          "english": "Our membership has increased steadily.",
+          "japanese": "会員数は着実に増加しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001112",
+          "english": "They increased their investment in technology.",
+          "japanese": "彼らは技術への投資を増やしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001113",
+          "english": "Pollution levels are increasing in the city.",
+          "japanese": "都市部の汚染レベルが増加しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001114",
+          "english": "The risk increases with age.",
+          "japanese": "リスクは年齢とともに増加します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001115",
+          "english": "We need to increase our market share.",
+          "japanese": "市場シェアを拡大する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001116",
+          "english": "Online shopping continues to increase.",
+          "japanese": "オンラインショッピングは増加し続けています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001117",
+          "english": "The budget was increased for next year.",
+          "japanese": "来年度の予算が増額されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001118",
+          "english": "Social media use has increased dramatically.",
+          "japanese": "ソーシャルメディアの使用が劇的に増加しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001119",
+          "english": "They increased security measures.",
+          "japanese": "彼らはセキュリティ対策を強化しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000011-0011-0011-0011-000000001120",
+          "english": "Website traffic increased after the campaign.",
+          "japanese": "キャンペーン後、ウェブサイトのトラフィックが増加しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793058400.000000
+    },
+    {
+      "id": "10000012-0012-0012-0012-000000000012",
+      "word": "require",
+      "meaning": "必要とする、要求する",
+      "phonetic": "rɪˈkwaɪər",
+      "sentences": [
+        {
+          "id": "10000012-0012-0012-0012-000000001201",
+          "english": "This job requires attention to detail.",
+          "japanese": "この仕事は細部への注意が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001202",
+          "english": "A visa is required for entry.",
+          "japanese": "入国にはビザが必要です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001203",
+          "english": "The project requires careful planning.",
+          "japanese": "プロジェクトには慎重な計画が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001204",
+          "english": "All students are required to attend.",
+          "japanese": "すべての学生が出席する必要があります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001205",
+          "english": "This task requires special skills.",
+          "japanese": "この作業には特別なスキルが必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001206",
+          "english": "Reservation is required for this restaurant.",
+          "japanese": "このレストランは予約が必要です。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001207",
+          "english": "The position requires five years of experience.",
+          "japanese": "そのポジションには5年の経験が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001208",
+          "english": "Safety equipment is required on site.",
+          "japanese": "現場では安全装備が必要です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001209",
+          "english": "The recipe requires fresh ingredients.",
+          "japanese": "そのレシピには新鮮な材料が必要です。",
+          "category": "料理"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001210",
+          "english": "Success requires hard work and dedication.",
+          "japanese": "成功には努力と献身が必要です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001211",
+          "english": "The app requires iOS 15 or later.",
+          "japanese": "アプリはiOS 15以降が必要です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001212",
+          "english": "This exam requires thorough preparation.",
+          "japanese": "この試験には徹底的な準備が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001213",
+          "english": "Registration is required before the deadline.",
+          "japanese": "期限前の登録が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001214",
+          "english": "The task requires teamwork.",
+          "japanese": "その作業にはチームワークが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001215",
+          "english": "Some assembly is required.",
+          "japanese": "組み立てが必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001216",
+          "english": "Learning a language requires patience.",
+          "japanese": "言語学習には忍耐が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001217",
+          "english": "The situation requires immediate action.",
+          "japanese": "状況は即座の行動を必要としています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001218",
+          "english": "Medical treatment may be required.",
+          "japanese": "医療処置が必要になる場合があります。",
+          "category": "医療"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001219",
+          "english": "The course requires weekly assignments.",
+          "japanese": "そのコースには毎週の課題が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000012-0012-0012-0012-000000001220",
+          "english": "This procedure requires authorization.",
+          "japanese": "この手続きには承認が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793062000.000000
+    },
+    {
+      "id": "10000013-0013-0013-0013-000000000013",
+      "word": "support",
+      "meaning": "支援する、サポート",
+      "phonetic": "səˈpɔːrt",
+      "sentences": [
+        {
+          "id": "10000013-0013-0013-0013-000000001301",
+          "english": "We support environmental protection.",
+          "japanese": "私たちは環境保護を支持します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001302",
+          "english": "Thank you for your continued support.",
+          "japanese": "継続的なサポートをありがとうございます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001303",
+          "english": "The team needs your support.",
+          "japanese": "チームはあなたのサポートが必要です。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001304",
+          "english": "Our company provides 24-hour technical support.",
+          "japanese": "当社は24時間技術サポートを提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001305",
+          "english": "Family support is very important.",
+          "japanese": "家族のサポートはとても重要です。",
+          "category": "家族"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001306",
+          "english": "The bridge is supported by strong pillars.",
+          "japanese": "橋は強固な柱によって支えられています。",
+          "category": "建築"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001307",
+          "english": "We support diversity in the workplace.",
+          "japanese": "私たちは職場の多様性を支持します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001308",
+          "english": "Customer support is available by email.",
+          "japanese": "カスタマーサポートはメールで利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001309",
+          "english": "She always supports her friends.",
+          "japanese": "彼女はいつも友達をサポートします。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001310",
+          "english": "The data supports our hypothesis.",
+          "japanese": "データは私たちの仮説を裏付けています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001311",
+          "english": "We need financial support for the project.",
+          "japanese": "プロジェクトには資金的な支援が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001312",
+          "english": "The app supports multiple languages.",
+          "japanese": "アプリは複数の言語をサポートしています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001313",
+          "english": "I support your decision completely.",
+          "japanese": "あなたの決定を完全に支持します。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001314",
+          "english": "The organization supports local communities.",
+          "japanese": "その組織は地域社会を支援しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001315",
+          "english": "Emotional support helps during difficult times.",
+          "japanese": "感情的なサポートは困難な時期に役立ちます。",
+          "category": "心理"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001316",
+          "english": "The evidence supports the claim.",
+          "japanese": "証拠はその主張を裏付けています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001317",
+          "english": "We offer free support for the first year.",
+          "japanese": "初年度は無料サポートを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001318",
+          "english": "Teachers support students in their learning.",
+          "japanese": "教師は学習において生徒をサポートします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001319",
+          "english": "The government supports small businesses.",
+          "japanese": "政府は中小企業を支援しています。",
+          "category": "政治"
+        },
+        {
+          "id": "10000013-0013-0013-0013-000000001320",
+          "english": "This software supports Windows and Mac.",
+          "japanese": "このソフトウェアはWindowsとMacをサポートしています。",
+          "category": "テクノロジー"
+        }
+      ],
+      "createdAt": 793065600.000000
+    },
+    {
+      "id": "10000014-0014-0014-0014-000000000014",
+      "word": "continue",
+      "meaning": "続ける、継続する",
+      "phonetic": "kənˈtɪn.juː",
+      "sentences": [
+        {
+          "id": "10000014-0014-0014-0014-000000001401",
+          "english": "Please continue with your work.",
+          "japanese": "仕事を続けてください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001402",
+          "english": "The meeting will continue after lunch.",
+          "japanese": "会議は昼食後も続きます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001403",
+          "english": "I'll continue studying Japanese.",
+          "japanese": "日本語の勉強を続けます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001404",
+          "english": "The rain continued all day.",
+          "japanese": "雨は一日中続きました。",
+          "category": "天気"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001405",
+          "english": "We will continue to improve our service.",
+          "japanese": "サービスの改善を続けます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001406",
+          "english": "Sales continue to grow.",
+          "japanese": "売上は成長を続けています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001407",
+          "english": "Please continue reading from page 50.",
+          "japanese": "50ページから読み続けてください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001408",
+          "english": "The problem continues to occur.",
+          "japanese": "問題は引き続き発生しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001409",
+          "english": "Let's continue this discussion tomorrow.",
+          "japanese": "この議論は明日続けましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001410",
+          "english": "The tradition continues to this day.",
+          "japanese": "その伝統は今日まで続いています。",
+          "category": "文化"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001411",
+          "english": "He continued working despite the difficulties.",
+          "japanese": "彼は困難にもかかわらず働き続けました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001412",
+          "english": "The program will continue next week.",
+          "japanese": "プログラムは来週も続きます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001413",
+          "english": "Traffic problems continue in the city.",
+          "japanese": "都市部の交通問題は続いています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001414",
+          "english": "Continue straight for two blocks.",
+          "japanese": "2ブロック先まで直進してください。",
+          "category": "道案内"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001415",
+          "english": "The show continues through September.",
+          "japanese": "ショーは9月まで続きます。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001416",
+          "english": "They continued their journey the next day.",
+          "japanese": "彼らは翌日旅を続けました。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001417",
+          "english": "We'll continue to monitor the situation.",
+          "japanese": "状況の監視を続けます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001418",
+          "english": "The story continues in the next chapter.",
+          "japanese": "物語は次の章で続きます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001419",
+          "english": "Construction will continue throughout summer.",
+          "japanese": "工事は夏の間ずっと続きます。",
+          "category": "建設"
+        },
+        {
+          "id": "10000014-0014-0014-0014-000000001420",
+          "english": "Please continue to practice daily.",
+          "japanese": "毎日練習を続けてください。",
+          "category": "教育"
+        }
+      ],
+      "createdAt": 793069200.000000
+    },
+    {
+      "id": "10000015-0015-0015-0015-000000000015",
+      "word": "suggest",
+      "meaning": "提案する、示唆する",
+      "phonetic": "səˈdʒest",
+      "sentences": [
+        {
+          "id": "10000015-0015-0015-0015-000000001501",
+          "english": "I suggest we take a break.",
+          "japanese": "休憩を取ることを提案します。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001502",
+          "english": "What do you suggest I do?",
+          "japanese": "どうすればいいと思いますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001503",
+          "english": "The data suggests a positive trend.",
+          "japanese": "データは良好な傾向を示唆しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001504",
+          "english": "May I suggest a different approach?",
+          "japanese": "別のアプローチを提案してもよろしいですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001505",
+          "english": "The doctor suggested more exercise.",
+          "japanese": "医師はもっと運動することを提案しました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001506",
+          "english": "Can you suggest a good restaurant?",
+          "japanese": "良いレストランを提案していただけますか？",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001507",
+          "english": "I suggest starting the meeting early.",
+          "japanese": "会議を早く始めることを提案します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001508",
+          "english": "The findings suggest further research is needed.",
+          "japanese": "調査結果はさらなる研究が必要であることを示唆しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001509",
+          "english": "He suggested visiting the museum.",
+          "japanese": "彼は博物館を訪れることを提案しました。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001510",
+          "english": "The symptoms suggest a mild infection.",
+          "japanese": "症状は軽い感染症を示唆しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001511",
+          "english": "I suggest you reconsider your decision.",
+          "japanese": "決定を再考することをお勧めします。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001512",
+          "english": "The teacher suggested additional practice.",
+          "japanese": "教師は追加の練習を提案しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001513",
+          "english": "May I suggest an alternative solution?",
+          "japanese": "代替案を提案してもよろしいですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001514",
+          "english": "The evidence suggests otherwise.",
+          "japanese": "証拠は別のことを示唆しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001515",
+          "english": "I strongly suggest you read this book.",
+          "japanese": "この本を読むことを強くお勧めします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001516",
+          "english": "They suggested postponing the event.",
+          "japanese": "彼らはイベントの延期を提案しました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001517",
+          "english": "Research suggests this method is effective.",
+          "japanese": "研究によるとこの方法は効果的です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001518",
+          "english": "The survey suggests customer satisfaction is high.",
+          "japanese": "調査は顧客満足度が高いことを示唆しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001519",
+          "english": "She suggested we try the new cafe.",
+          "japanese": "彼女は新しいカフェに行ってみることを提案しました。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000015-0015-0015-0015-000000001520",
+          "english": "I suggest booking in advance.",
+          "japanese": "事前予約をお勧めします。",
+          "category": "旅行"
+        }
+      ],
+      "createdAt": 793072800.000000
+    },
+    {
+      "id": "10000016-0016-0016-0016-000000000016",
+      "word": "approach",
+      "meaning": "アプローチ、接近する",
+      "phonetic": "əˈproʊtʃ",
+      "sentences": [
+        {
+          "id": "10000016-0016-0016-0016-000000001601",
+          "english": "We need a new approach to this problem.",
+          "japanese": "この問題には新しいアプローチが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001602",
+          "english": "Winter is approaching quickly.",
+          "japanese": "冬が急速に近づいています。",
+          "category": "天気"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001603",
+          "english": "Her approach to teaching is very effective.",
+          "japanese": "彼女の教育へのアプローチは非常に効果的です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001604",
+          "english": "The deadline is approaching.",
+          "japanese": "締め切りが近づいています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001605",
+          "english": "Let's try a different approach.",
+          "japanese": "別のアプローチを試してみましょう。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001606",
+          "english": "A stranger approached me on the street.",
+          "japanese": "見知らぬ人が通りで私に近づいてきました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001607",
+          "english": "The company has a customer-focused approach.",
+          "japanese": "会社は顧客重視のアプローチをとっています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001608",
+          "english": "We're approaching the final stage.",
+          "japanese": "最終段階に近づいています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001609",
+          "english": "This approach has proven successful.",
+          "japanese": "このアプローチは成功が証明されています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001610",
+          "english": "The plane is approaching the runway.",
+          "japanese": "飛行機が滑走路に接近しています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001611",
+          "english": "He took a cautious approach.",
+          "japanese": "彼は慎重なアプローチを取りました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001612",
+          "english": "The storm is approaching from the east.",
+          "japanese": "嵐が東から接近しています。",
+          "category": "天気"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001613",
+          "english": "I like your approach to problem-solving.",
+          "japanese": "あなたの問題解決へのアプローチが好きです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001614",
+          "english": "They approached the task systematically.",
+          "japanese": "彼らは体系的にその作業に取り組みました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001615",
+          "english": "A holistic approach works best here.",
+          "japanese": "総合的なアプローチがここでは最適です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001616",
+          "english": "As we approach the end of the year.",
+          "japanese": "年末が近づくにつれて。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001617",
+          "english": "The manager approached the issue carefully.",
+          "japanese": "マネージャーは問題に慎重に対処しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001618",
+          "english": "This innovative approach attracted investors.",
+          "japanese": "この革新的なアプローチは投資家を引きつけました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001619",
+          "english": "We're approaching maximum capacity.",
+          "japanese": "最大容量に近づいています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000016-0016-0016-0016-000000001620",
+          "english": "The team adopted a collaborative approach.",
+          "japanese": "チームは協力的なアプローチを採用しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793076400.000000
+    },
+    {
+      "id": "10000017-0017-0017-0017-000000000017",
+      "word": "establish",
+      "meaning": "設立する、確立する",
+      "phonetic": "ɪˈstæb.lɪʃ",
+      "sentences": [
+        {
+          "id": "10000017-0017-0017-0017-000000001701",
+          "english": "They established the company in 1990.",
+          "japanese": "彼らは1990年に会社を設立しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001702",
+          "english": "We need to establish clear goals.",
+          "japanese": "明確な目標を確立する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001703",
+          "english": "The museum was established in 1875.",
+          "japanese": "その博物館は1875年に設立されました。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001704",
+          "english": "She established herself as an expert.",
+          "japanese": "彼女は専門家としての地位を確立しました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001705",
+          "english": "Let's establish a routine.",
+          "japanese": "ルーティンを確立しましょう。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001706",
+          "english": "The report established the facts.",
+          "japanese": "報告書は事実を確認しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001707",
+          "english": "We've established a good relationship with clients.",
+          "japanese": "顧客と良好な関係を築きました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001708",
+          "english": "The university was established over 100 years ago.",
+          "japanese": "その大学は100年以上前に設立されました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001709",
+          "english": "They established new safety protocols.",
+          "japanese": "彼らは新しい安全手順を確立しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001710",
+          "english": "It's important to establish trust.",
+          "japanese": "信頼を確立することが重要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001711",
+          "english": "The organization established regional offices.",
+          "japanese": "組織は地域事務所を設立しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001712",
+          "english": "We need to establish priorities.",
+          "japanese": "優先順位を確立する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001713",
+          "english": "The investigation established his innocence.",
+          "japanese": "調査は彼の無罪を立証しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001714",
+          "english": "They established a scholarship fund.",
+          "japanese": "彼らは奨学金基金を設立しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001715",
+          "english": "The brand has established a strong presence.",
+          "japanese": "そのブランドは強い存在感を確立しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001716",
+          "english": "We've established standard operating procedures.",
+          "japanese": "標準作業手順を確立しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001717",
+          "english": "The study established a link between the variables.",
+          "japanese": "研究は変数間の関連を確立しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001718",
+          "english": "She established her own business.",
+          "japanese": "彼女は自分のビジネスを立ち上げました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001719",
+          "english": "The team established a new record.",
+          "japanese": "チームは新記録を樹立しました。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000017-0017-0017-0017-000000001720",
+          "english": "We need to establish contact with headquarters.",
+          "japanese": "本社と連絡を確立する必要があります。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793080000.000000
+    },
+    {
+      "id": "10000018-0018-0018-0018-000000000018",
+      "word": "recognize",
+      "meaning": "認識する、認める",
+      "phonetic": "ˈrek.əɡ.naɪz",
+      "sentences": [
+        {
+          "id": "10000018-0018-0018-0018-000000001801",
+          "english": "I didn't recognize you at first.",
+          "japanese": "最初あなただとわかりませんでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001802",
+          "english": "The company recognizes employee achievements.",
+          "japanese": "会社は従業員の功績を認めています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001803",
+          "english": "She was recognized for her contribution.",
+          "japanese": "彼女はその貢献を認められました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001804",
+          "english": "Do you recognize this voice?",
+          "japanese": "この声に聞き覚えがありますか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001805",
+          "english": "We recognize the importance of this issue.",
+          "japanese": "この問題の重要性を認識しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001806",
+          "english": "He is widely recognized as an expert.",
+          "japanese": "彼は専門家として広く認められています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001807",
+          "english": "The app can recognize faces.",
+          "japanese": "アプリは顔を認識できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001808",
+          "english": "I recognize the need for change.",
+          "japanese": "変化の必要性を認識しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001809",
+          "english": "She was recognized with an award.",
+          "japanese": "彼女は賞で認められました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001810",
+          "english": "The system recognizes voice commands.",
+          "japanese": "システムは音声コマンドを認識します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001811",
+          "english": "We must recognize our limitations.",
+          "japanese": "私たちは自分の限界を認識しなければなりません。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001812",
+          "english": "The brand is easily recognized worldwide.",
+          "japanese": "そのブランドは世界中で容易に認識されます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001813",
+          "english": "I recognize your handwriting.",
+          "japanese": "あなたの筆跡がわかります。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001814",
+          "english": "The government recognizes the problem.",
+          "japanese": "政府はその問題を認識しています。",
+          "category": "政治"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001815",
+          "english": "Her work is now recognized internationally.",
+          "japanese": "彼女の仕事は現在国際的に認められています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001816",
+          "english": "Can you recognize this landmark?",
+          "japanese": "このランドマークがわかりますか？",
+          "category": "旅行"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001817",
+          "english": "We recognize and value diversity.",
+          "japanese": "多様性を認識し評価しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001818",
+          "english": "The symptoms are easily recognized.",
+          "japanese": "症状は容易に認識されます。",
+          "category": "医療"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001819",
+          "english": "I barely recognized the old neighborhood.",
+          "japanese": "昔の近所がほとんどわかりませんでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000018-0018-0018-0018-000000001820",
+          "english": "The organization recognized her leadership.",
+          "japanese": "組織は彼女のリーダーシップを認めました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793083600.000000
+    },
+    {
+      "id": "10000019-0019-0019-0019-000000000019",
+      "word": "opportunity",
+      "meaning": "機会、チャンス",
+      "phonetic": "ˌɑː.pɚˈtuː.nə.ti",
+      "sentences": [
+        {
+          "id": "10000019-0019-0019-0019-000000001901",
+          "english": "This is a great opportunity to learn.",
+          "japanese": "これは学ぶ素晴らしい機会です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001902",
+          "english": "Don't miss this opportunity.",
+          "japanese": "この機会を逃さないでください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001903",
+          "english": "The job offers many growth opportunities.",
+          "japanese": "その仕事は多くの成長機会を提供します。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001904",
+          "english": "We're creating new business opportunities.",
+          "japanese": "新しいビジネスチャンスを創出しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001905",
+          "english": "Traveling provides opportunities to meet new people.",
+          "japanese": "旅行は新しい人と出会う機会を提供します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001906",
+          "english": "Equal opportunity is important to us.",
+          "japanese": "平等な機会は私たちにとって重要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001907",
+          "english": "She seized the opportunity immediately.",
+          "japanese": "彼女はすぐにその機会をつかみました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001908",
+          "english": "This program provides educational opportunities.",
+          "japanese": "このプログラムは教育の機会を提供します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001909",
+          "english": "Opportunity doesn't come twice.",
+          "japanese": "チャンスは二度と来ません。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001910",
+          "english": "The company offers internship opportunities.",
+          "japanese": "会社はインターンシップの機会を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001911",
+          "english": "We're exploring new market opportunities.",
+          "japanese": "新しい市場機会を探っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001912",
+          "english": "He took advantage of every opportunity.",
+          "japanese": "彼はあらゆる機会を活用しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001913",
+          "english": "The project creates employment opportunities.",
+          "japanese": "そのプロジェクトは雇用機会を創出します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001914",
+          "english": "This is a once-in-a-lifetime opportunity.",
+          "japanese": "これは一生に一度の機会です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001915",
+          "english": "Opportunities for advancement exist here.",
+          "japanese": "ここには昇進の機会があります。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001916",
+          "english": "The crisis presented new opportunities.",
+          "japanese": "危機は新しい機会をもたらしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001917",
+          "english": "Volunteers have opportunities to make a difference.",
+          "japanese": "ボランティアには変化をもたらす機会があります。",
+          "category": "社会"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001918",
+          "english": "Career opportunities are expanding.",
+          "japanese": "キャリアの機会が拡大しています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001919",
+          "english": "I appreciate the opportunity to speak today.",
+          "japanese": "今日お話しする機会をいただき感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000019-0019-0019-0019-000000001920",
+          "english": "Every challenge brings new opportunities.",
+          "japanese": "すべての挑戦が新しい機会をもたらします。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793087200.000000
+    },
+    {
+      "id": "10000020-0020-0020-0020-000000000020",
+      "word": "benefit",
+      "meaning": "利益、恩恵、役立つ",
+      "phonetic": "ˈben.ə.fɪt",
+      "sentences": [
+        {
+          "id": "10000020-0020-0020-0020-000000002001",
+          "english": "Exercise has many health benefits.",
+          "japanese": "運動には多くの健康上の利点があります。",
+          "category": "健康"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002002",
+          "english": "The company offers good employee benefits.",
+          "japanese": "会社は良い従業員福利厚生を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002003",
+          "english": "Who will benefit from this program?",
+          "japanese": "誰がこのプログラムから恩恵を受けますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002004",
+          "english": "The benefits outweigh the costs.",
+          "japanese": "利益がコストを上回ります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002005",
+          "english": "Education benefits society as a whole.",
+          "japanese": "教育は社会全体に利益をもたらします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002006",
+          "english": "We all benefit from teamwork.",
+          "japanese": "私たちは皆チームワークから恩恵を受けます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002007",
+          "english": "What are the benefits of this plan?",
+          "japanese": "この計画の利点は何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002008",
+          "english": "The community benefits from the new park.",
+          "japanese": "地域社会は新しい公園から恩恵を受けます。",
+          "category": "社会"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002009",
+          "english": "There's a mutual benefit in this arrangement.",
+          "japanese": "この取り決めには相互利益があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002010",
+          "english": "The package includes health and dental benefits.",
+          "japanese": "パッケージには健康保険と歯科保険が含まれています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002011",
+          "english": "Students will benefit from this workshop.",
+          "japanese": "学生はこのワークショップから恩恵を受けるでしょう。",
+          "category": "教育"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002012",
+          "english": "The benefit concert raised money for charity.",
+          "japanese": "チャリティーコンサートは資金を集めました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002013",
+          "english": "Technology benefits our daily lives.",
+          "japanese": "技術は私たちの日常生活に役立ちます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002014",
+          "english": "Retirement benefits are very important.",
+          "japanese": "退職金は非常に重要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002015",
+          "english": "The environment benefits from recycling.",
+          "japanese": "環境はリサイクルから恩恵を受けます。",
+          "category": "環境"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002016",
+          "english": "Members enjoy exclusive benefits.",
+          "japanese": "会員は特典を享受できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002017",
+          "english": "The new policy will benefit everyone.",
+          "japanese": "新しい方針は皆に利益をもたらすでしょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002018",
+          "english": "She explained the benefits of meditation.",
+          "japanese": "彼女は瞑想の利点を説明しました。",
+          "category": "健康"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002019",
+          "english": "Economic benefits are expected.",
+          "japanese": "経済的利益が期待されています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000020-0020-0020-0020-000000002020",
+          "english": "Both parties benefit from cooperation.",
+          "japanese": "双方が協力から恩恵を受けます。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793090800.000000
+    },
+    {
+      "id": "10000021-0021-0021-0021-000000000021",
+      "word": "challenge",
+      "meaning": "挑戦、課題",
+      "phonetic": "ˈtʃæl.ɪndʒ",
+      "sentences": [
+        {
+          "id": "10000021-0021-0021-0021-000000002101",
+          "english": "This project presents a big challenge.",
+          "japanese": "このプロジェクトは大きな挑戦を提示します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002102",
+          "english": "I love a good challenge.",
+          "japanese": "良い挑戦が大好きです。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002103",
+          "english": "The team faces many challenges.",
+          "japanese": "チームは多くの課題に直面しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002104",
+          "english": "She challenged me to do better.",
+          "japanese": "彼女は私にもっと良くするよう挑戦しました。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002105",
+          "english": "Climate change is a global challenge.",
+          "japanese": "気候変動は世界的な課題です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002106",
+          "english": "We welcome challenges and new ideas.",
+          "japanese": "挑戦と新しいアイデアを歓迎します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002107",
+          "english": "The biggest challenge is funding.",
+          "japanese": "最大の課題は資金調達です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002108",
+          "english": "He challenged the traditional approach.",
+          "japanese": "彼は伝統的なアプローチに異議を唱えました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002109",
+          "english": "Learning a new language is challenging.",
+          "japanese": "新しい言語を学ぶことは挑戦的です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002110",
+          "english": "We overcame every challenge together.",
+          "japanese": "私たちは一緒にすべての課題を克服しました。",
+          "category": "チームワーク"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002111",
+          "english": "The challenge motivated the team.",
+          "japanese": "その挑戦はチームを動機づけました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002112",
+          "english": "Economic challenges lie ahead.",
+          "japanese": "経済的課題が待ち受けています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002113",
+          "english": "She rose to the challenge.",
+          "japanese": "彼女は挑戦に立ち向かいました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002114",
+          "english": "Technology creates new challenges.",
+          "japanese": "技術は新しい課題を生み出します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002115",
+          "english": "The challenge seemed impossible at first.",
+          "japanese": "その挑戦は最初不可能に見えました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002116",
+          "english": "We challenged ourselves to do more.",
+          "japanese": "私たちはもっとやるように自分たちに挑戦しました。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002117",
+          "english": "Time management is a constant challenge.",
+          "japanese": "時間管理は常に課題です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002118",
+          "english": "The company addressed the challenges quickly.",
+          "japanese": "会社は迅速に課題に対処しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002119",
+          "english": "Every challenge is an opportunity to grow.",
+          "japanese": "すべての挑戦は成長の機会です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000021-0021-0021-0021-000000002120",
+          "english": "He challenged the decision in court.",
+          "japanese": "彼は法廷でその決定に異議を唱えました。",
+          "category": "法律"
+        }
+      ],
+      "createdAt": 793094400.000000
+    },
+    {
+      "id": "10000022-0022-0022-0022-000000000022",
+      "word": "situation",
+      "meaning": "状況、事態",
+      "phonetic": "ˌsɪt.ʃuˈeɪ.ʃən",
+      "sentences": [
+        {
+          "id": "10000022-0022-0022-0022-000000002201",
+          "english": "The situation is under control.",
+          "japanese": "状況は管理下にあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002202",
+          "english": "We need to assess the situation carefully.",
+          "japanese": "状況を慎重に評価する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002203",
+          "english": "This is an emergency situation.",
+          "japanese": "これは緊急事態です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002204",
+          "english": "The economic situation is improving.",
+          "japanese": "経済状況は改善しています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002205",
+          "english": "How would you handle this situation?",
+          "japanese": "あなたならこの状況をどう処理しますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002206",
+          "english": "The political situation remains tense.",
+          "japanese": "政治状況は緊迫したままです。",
+          "category": "政治"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002207",
+          "english": "We're monitoring the situation closely.",
+          "japanese": "状況を注意深く監視しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002208",
+          "english": "Every situation is different.",
+          "japanese": "すべての状況は異なります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002209",
+          "english": "The situation calls for immediate action.",
+          "japanese": "状況は即座の行動を求めています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002210",
+          "english": "She handled the difficult situation well.",
+          "japanese": "彼女は困難な状況をうまく処理しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002211",
+          "english": "The hotel is in a perfect situation.",
+          "japanese": "ホテルは完璧な場所にあります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002212",
+          "english": "I understand your situation completely.",
+          "japanese": "あなたの状況は完全に理解しています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002213",
+          "english": "The current situation requires patience.",
+          "japanese": "現在の状況は忍耐を必要とします。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002214",
+          "english": "It's a win-win situation for everyone.",
+          "japanese": "それは皆にとってウィンウィンの状況です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002215",
+          "english": "The situation changed overnight.",
+          "japanese": "状況は一夜で変わりました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002216",
+          "english": "We adapted to the new situation quickly.",
+          "japanese": "新しい状況に素早く適応しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002217",
+          "english": "The financial situation is stable.",
+          "japanese": "財務状況は安定しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002218",
+          "english": "What's the latest on the situation?",
+          "japanese": "状況の最新情報は何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002219",
+          "english": "The situation is more complex than expected.",
+          "japanese": "状況は予想より複雑です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000022-0022-0022-0022-000000002220",
+          "english": "They managed the crisis situation effectively.",
+          "japanese": "彼らは危機的状況を効果的に管理しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793098000.000000
+    },
+    {
+      "id": "10000023-0023-0023-0023-000000000023",
+      "word": "environment",
+      "meaning": "環境",
+      "phonetic": "ɪnˈvaɪ.rən.mənt",
+      "sentences": [
+        {
+          "id": "10000023-0023-0023-0023-000000002301",
+          "english": "We must protect the environment.",
+          "japanese": "環境を守らなければなりません。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002302",
+          "english": "The work environment is very friendly.",
+          "japanese": "職場環境はとても友好的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002303",
+          "english": "Pollution damages the environment.",
+          "japanese": "汚染は環境を破壊します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002304",
+          "english": "A positive learning environment is important.",
+          "japanese": "前向きな学習環境が重要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002305",
+          "english": "The company creates a safe environment.",
+          "japanese": "会社は安全な環境を作ります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002306",
+          "english": "Climate change affects our environment.",
+          "japanese": "気候変動は環境に影響を与えます。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002307",
+          "english": "Children thrive in a supportive environment.",
+          "japanese": "子供たちは支援的な環境で成長します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002308",
+          "english": "We're committed to environmental protection.",
+          "japanese": "環境保護に取り組んでいます。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002309",
+          "english": "The office environment is modern.",
+          "japanese": "オフィス環境は現代的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002310",
+          "english": "Every action impacts the environment.",
+          "japanese": "すべての行動が環境に影響します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002311",
+          "english": "We promote an inclusive environment.",
+          "japanese": "包括的な環境を促進しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002312",
+          "english": "The natural environment is beautiful here.",
+          "japanese": "ここの自然環境は美しいです。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002313",
+          "english": "Environmental issues concern everyone.",
+          "japanese": "環境問題は皆に関係します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002314",
+          "english": "The app runs in a secure environment.",
+          "japanese": "アプリは安全な環境で実行されます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002315",
+          "english": "We adapt to different environments.",
+          "japanese": "私たちは異なる環境に適応します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002316",
+          "english": "The business environment is competitive.",
+          "japanese": "ビジネス環境は競争的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002317",
+          "english": "Environmental awareness is growing.",
+          "japanese": "環境意識が高まっています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002318",
+          "english": "The marine environment needs protection.",
+          "japanese": "海洋環境は保護が必要です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002319",
+          "english": "We create a collaborative environment.",
+          "japanese": "協力的な環境を作ります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000023-0023-0023-0023-000000002320",
+          "english": "The urban environment is constantly changing.",
+          "japanese": "都市環境は常に変化しています。",
+          "category": "都市開発"
+        }
+      ],
+      "createdAt": 793101600.000000
+    },
+    {
+      "id": "10000024-0024-0024-0024-000000000024",
+      "word": "community",
+      "meaning": "コミュニティ、地域社会",
+      "phonetic": "kəˈmjuː.nə.ti",
+      "sentences": [
+        {
+          "id": "10000024-0024-0024-0024-000000002401",
+          "english": "Our community is very welcoming.",
+          "japanese": "私たちのコミュニティはとても温かいです。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002402",
+          "english": "Community support is essential.",
+          "japanese": "地域社会の支援は不可欠です。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002403",
+          "english": "We serve the local community.",
+          "japanese": "地域社会に奉仕しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002404",
+          "english": "The online community is growing.",
+          "japanese": "オンラインコミュニティが成長しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002405",
+          "english": "Community events bring people together.",
+          "japanese": "コミュニティイベントは人々を結びつけます。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002406",
+          "english": "She's an active community member.",
+          "japanese": "彼女は活発なコミュニティメンバーです。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002407",
+          "english": "The project benefits the whole community.",
+          "japanese": "プロジェクトはコミュニティ全体に利益をもたらします。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002408",
+          "english": "Community involvement is encouraged.",
+          "japanese": "コミュニティへの関与が奨励されています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002409",
+          "english": "We built a strong community here.",
+          "japanese": "ここに強いコミュニティを築きました。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002410",
+          "english": "The school serves the community well.",
+          "japanese": "学校は地域社会によく奉仕しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002411",
+          "english": "Community health is a priority.",
+          "japanese": "コミュニティの健康が優先事項です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002412",
+          "english": "They organized a community cleanup.",
+          "japanese": "彼らはコミュニティの清掃を組織しました。",
+          "category": "環境"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002413",
+          "english": "The business community supports this initiative.",
+          "japanese": "ビジネスコミュニティがこの取り組みを支持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002414",
+          "english": "Community gardens promote sustainability.",
+          "japanese": "コミュニティ菜園は持続可能性を促進します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002415",
+          "english": "We value community feedback.",
+          "japanese": "コミュニティのフィードバックを大切にしています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002416",
+          "english": "The community center opens daily.",
+          "japanese": "コミュニティセンターは毎日開いています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002417",
+          "english": "International community cooperation is vital.",
+          "japanese": "国際社会の協力が不可欠です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002418",
+          "english": "She volunteers in the community.",
+          "japanese": "彼女はコミュニティでボランティアをしています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002419",
+          "english": "Community spirit is strong here.",
+          "japanese": "ここではコミュニティ精神が強いです。",
+          "category": "社会"
+        },
+        {
+          "id": "10000024-0024-0024-0024-000000002420",
+          "english": "The community celebrates diversity.",
+          "japanese": "コミュニティは多様性を祝います。",
+          "category": "社会"
+        }
+      ],
+      "createdAt": 793105200.000000
+    },
+    {
+      "id": "10000025-0025-0025-0025-000000000025",
+      "word": "resource",
+      "meaning": "資源、リソース",
+      "phonetic": "ˈriː.sɔːrs",
+      "sentences": [
+        {
+          "id": "10000025-0025-0025-0025-000000002501",
+          "english": "Natural resources must be conserved.",
+          "japanese": "天然資源は保護されなければなりません。",
+          "category": "環境"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002502",
+          "english": "We have limited resources available.",
+          "japanese": "利用可能な資源が限られています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002503",
+          "english": "Human resources are our greatest asset.",
+          "japanese": "人的資源は私たちの最大の資産です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002504",
+          "english": "The library provides learning resources.",
+          "japanese": "図書館は学習リソースを提供します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002505",
+          "english": "We need to allocate resources wisely.",
+          "japanese": "リソースを賢く配分する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002506",
+          "english": "Water is a precious resource.",
+          "japanese": "水は貴重な資源です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002507",
+          "english": "The website offers many free resources.",
+          "japanese": "ウェブサイトは多くの無料リソースを提供します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002508",
+          "english": "Time is our most valuable resource.",
+          "japanese": "時間は最も価値のある資源です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002509",
+          "english": "The project requires additional resources.",
+          "japanese": "プロジェクトには追加のリソースが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002510",
+          "english": "Educational resources are available online.",
+          "japanese": "教育リソースはオンラインで利用できます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002511",
+          "english": "We manage our resources carefully.",
+          "japanese": "リソースを慎重に管理しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002512",
+          "english": "The country is rich in natural resources.",
+          "japanese": "その国は天然資源が豊富です。",
+          "category": "地理"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002513",
+          "english": "Financial resources are limited.",
+          "japanese": "財政的資源は限られています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002514",
+          "english": "The team pooled their resources.",
+          "japanese": "チームはリソースを集めました。",
+          "category": "チームワーク"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002515",
+          "english": "Energy resources are becoming scarce.",
+          "japanese": "エネルギー資源が不足してきています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002516",
+          "english": "She's a valuable resource for the team.",
+          "japanese": "彼女はチームにとって貴重なリソースです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002517",
+          "english": "Community resources support families.",
+          "japanese": "コミュニティリソースが家族を支援します。",
+          "category": "社会"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002518",
+          "english": "The system uses minimal resources.",
+          "japanese": "システムは最小限のリソースを使用します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002519",
+          "english": "We share resources across departments.",
+          "japanese": "部門間でリソースを共有しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000025-0025-0025-0025-000000002520",
+          "english": "Renewable resources are the future.",
+          "japanese": "再生可能資源が未来です。",
+          "category": "環境"
+        }
+      ],
+      "createdAt": 793108800.000000
+    },
+    {
+      "id": "10000026-0026-0026-0026-000000000026",
+      "word": "effective",
+      "meaning": "効果的な",
+      "phonetic": "ɪˈfek.tɪv",
+      "sentences": [
+        {
+          "id": "10000026-0026-0026-0026-000000002601",
+          "english": "This is an effective solution.",
+          "japanese": "これは効果的な解決策です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002602",
+          "english": "Communication is effective when clear.",
+          "japanese": "コミュニケーションは明確な時に効果的です。",
+          "category": "コミュニケーション"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002603",
+          "english": "The new policy is very effective.",
+          "japanese": "新しい方針は非常に効果的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002604",
+          "english": "We need more effective strategies.",
+          "japanese": "より効果的な戦略が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002605",
+          "english": "The medicine is highly effective.",
+          "japanese": "その薬は非常に効果的です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002606",
+          "english": "She's an effective team leader.",
+          "japanese": "彼女は効果的なチームリーダーです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002607",
+          "english": "This method proved effective.",
+          "japanese": "この方法は効果的であることが証明されました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002608",
+          "english": "The program is cost-effective.",
+          "japanese": "そのプログラムは費用対効果が高いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002609",
+          "english": "Effective immediately, the rule changes.",
+          "japanese": "直ちに有効となり、規則が変わります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002610",
+          "english": "Time management is most effective.",
+          "japanese": "時間管理が最も効果的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002611",
+          "english": "The campaign was extremely effective.",
+          "japanese": "キャンペーンは極めて効果的でした。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002612",
+          "english": "Effective communication prevents misunderstandings.",
+          "japanese": "効果的なコミュニケーションは誤解を防ぎます。",
+          "category": "コミュニケーション"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002613",
+          "english": "The treatment is safe and effective.",
+          "japanese": "その治療は安全で効果的です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002614",
+          "english": "We found an effective way to save time.",
+          "japanese": "時間を節約する効果的な方法を見つけました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002615",
+          "english": "The system is simple and effective.",
+          "japanese": "システムはシンプルで効果的です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002616",
+          "english": "She used effective negotiation techniques.",
+          "japanese": "彼女は効果的な交渉技術を使いました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002617",
+          "english": "This approach is less effective.",
+          "japanese": "このアプローチはあまり効果的ではありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002618",
+          "english": "The changes become effective next month.",
+          "japanese": "変更は来月から有効になります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002619",
+          "english": "Effective planning ensures success.",
+          "japanese": "効果的な計画が成功を保証します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000026-0026-0026-0026-000000002620",
+          "english": "The tool is effective for beginners.",
+          "japanese": "そのツールは初心者に効果的です。",
+          "category": "教育"
+        }
+      ],
+      "createdAt": 793112400.000000
+    },
+    {
+      "id": "10000027-0027-0027-0027-000000000027",
+      "word": "significant",
+      "meaning": "重要な、かなりの",
+      "phonetic": "sɪɡˈnɪf.ɪ.kənt",
+      "sentences": [
+        {
+          "id": "10000027-0027-0027-0027-000000002701",
+          "english": "This is a significant achievement.",
+          "japanese": "これは重要な成果です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002702",
+          "english": "We've made significant progress.",
+          "japanese": "大きな進歩を遂げました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002703",
+          "english": "There's a significant difference.",
+          "japanese": "かなりの違いがあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002704",
+          "english": "The project had a significant impact.",
+          "japanese": "プロジェクトは大きな影響を与えました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002705",
+          "english": "Sales showed significant growth.",
+          "japanese": "売上は著しい成長を示しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002706",
+          "english": "She made a significant contribution.",
+          "japanese": "彼女は重要な貢献をしました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002707",
+          "english": "The findings are statistically significant.",
+          "japanese": "調査結果は統計的に有意です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002708",
+          "english": "Significant changes are expected.",
+          "japanese": "大きな変化が予想されます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002709",
+          "english": "The cost reduction was significant.",
+          "japanese": "コスト削減はかなりのものでした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002710",
+          "english": "This represents a significant opportunity.",
+          "japanese": "これは重要な機会を表しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002711",
+          "english": "The improvement is quite significant.",
+          "japanese": "改善はかなり重要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002712",
+          "english": "She played a significant role.",
+          "japanese": "彼女は重要な役割を果たしました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002713",
+          "english": "There are significant challenges ahead.",
+          "japanese": "重要な課題が待ち受けています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002714",
+          "english": "The event was historically significant.",
+          "japanese": "そのイベントは歴史的に重要でした。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002715",
+          "english": "We saw significant improvements.",
+          "japanese": "大幅な改善が見られました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002716",
+          "english": "The delay caused significant problems.",
+          "japanese": "遅延は重大な問題を引き起こしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002717",
+          "english": "His research is scientifically significant.",
+          "japanese": "彼の研究は科学的に重要です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002718",
+          "english": "Significant resources were invested.",
+          "japanese": "かなりの資源が投資されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002719",
+          "english": "The discovery is very significant.",
+          "japanese": "その発見は非常に重要です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000027-0027-0027-0027-000000002720",
+          "english": "We face significant competition.",
+          "japanese": "激しい競争に直面しています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793116000.000000
+    },
+    {
+      "id": "10000028-0028-0028-0028-000000000028",
+      "word": "particular",
+      "meaning": "特定の、特別な",
+      "phonetic": "pɚˈtɪk.jə.lɚ",
+      "sentences": [
+        {
+          "id": "10000028-0028-0028-0028-000000002801",
+          "english": "Do you have any particular preference?",
+          "japanese": "特定の好みはありますか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002802",
+          "english": "This particular model is very popular.",
+          "japanese": "この特定のモデルは非常に人気です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002803",
+          "english": "In particular, I like the design.",
+          "japanese": "特にデザインが気に入っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002804",
+          "english": "She's very particular about quality.",
+          "japanese": "彼女は品質にとても厳しいです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002805",
+          "english": "Is there anything in particular you need?",
+          "japanese": "何か特に必要なものはありますか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002806",
+          "english": "This particular issue requires attention.",
+          "japanese": "この特定の問題は注意が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002807",
+          "english": "He's particular about his coffee.",
+          "japanese": "彼はコーヒーにこだわります。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002808",
+          "english": "No particular reason, just curious.",
+          "japanese": "特別な理由はなく、ただ好奇心からです。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002809",
+          "english": "This particular case is unique.",
+          "japanese": "この特定のケースはユニークです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002810",
+          "english": "The chef is particular about ingredients.",
+          "japanese": "シェフは食材にこだわります。",
+          "category": "料理"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002811",
+          "english": "I'm looking for a particular book.",
+          "japanese": "特定の本を探しています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002812",
+          "english": "This particular area is restricted.",
+          "japanese": "この特定のエリアは立ち入り禁止です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002813",
+          "english": "She has particular dietary requirements.",
+          "japanese": "彼女は特定の食事要件があります。",
+          "category": "健康"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002814",
+          "english": "Nothing particular happened today.",
+          "japanese": "今日は特に何も起こりませんでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002815",
+          "english": "This particular feature is new.",
+          "japanese": "この特定の機能は新しいです。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002816",
+          "english": "He's not particular about brands.",
+          "japanese": "彼はブランドにこだわりません。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002817",
+          "english": "What particular skills do you have?",
+          "japanese": "どんな特定のスキルをお持ちですか？",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002818",
+          "english": "This particular time is inconvenient.",
+          "japanese": "この特定の時間は都合が悪いです。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002819",
+          "english": "The artist has a particular style.",
+          "japanese": "その芸術家は独特のスタイルがあります。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000028-0028-0028-0028-000000002820",
+          "english": "I'm looking for someone particular.",
+          "japanese": "特定の誰かを探しています。",
+          "category": "日常会話"
+        }
+      ],
+      "createdAt": 793119600.000000
+    },
+    {
+      "id": "10000029-0029-0029-0029-000000000029",
+      "word": "influence",
+      "meaning": "影響、影響を与える",
+      "phonetic": "ˈɪn.flu.əns",
+      "sentences": [
+        {
+          "id": "10000029-0029-0029-0029-000000002901",
+          "english": "Parents have great influence on children.",
+          "japanese": "親は子供に大きな影響を与えます。",
+          "category": "家族"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002902",
+          "english": "The weather influences our mood.",
+          "japanese": "天気は私たちの気分に影響します。",
+          "category": "天気"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002903",
+          "english": "She's a positive influence on the team.",
+          "japanese": "彼女はチームに良い影響を与えています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002904",
+          "english": "Technology influences how we live.",
+          "japanese": "技術は私たちの生活に影響を与えます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002905",
+          "english": "His work influenced many artists.",
+          "japanese": "彼の作品は多くの芸術家に影響を与えました。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002906",
+          "english": "The decision was influenced by data.",
+          "japanese": "その決定はデータに影響されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002907",
+          "english": "He has considerable influence here.",
+          "japanese": "彼はここでかなりの影響力があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002908",
+          "english": "Social media influences public opinion.",
+          "japanese": "ソーシャルメディアは世論に影響します。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002909",
+          "english": "Culture influences behavior.",
+          "japanese": "文化は行動に影響を与えます。",
+          "category": "文化"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002910",
+          "english": "Her speech influenced many people.",
+          "japanese": "彼女のスピーチは多くの人に影響を与えました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002911",
+          "english": "Economic factors influence decisions.",
+          "japanese": "経済的要因が決定に影響します。",
+          "category": "経済"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002912",
+          "english": "He's under the influence of bad friends.",
+          "japanese": "彼は悪い友達の影響下にあります。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002913",
+          "english": "The book influenced my thinking.",
+          "japanese": "その本は私の考え方に影響を与えました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002914",
+          "english": "Market trends influence prices.",
+          "japanese": "市場動向が価格に影響します。",
+          "category": "経済"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002915",
+          "english": "She's an influential figure in politics.",
+          "japanese": "彼女は政界の影響力のある人物です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002916",
+          "english": "Don't let others influence your choices.",
+          "japanese": "他人にあなたの選択を影響させないでください。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002917",
+          "english": "The campaign influenced voter behavior.",
+          "japanese": "キャンペーンは有権者の行動に影響を与えました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002918",
+          "english": "Environmental factors influence health.",
+          "japanese": "環境要因が健康に影響します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002919",
+          "english": "The teacher influenced my career choice.",
+          "japanese": "その教師は私のキャリア選択に影響を与えました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000029-0029-0029-0029-000000002920",
+          "english": "Global events influence local markets.",
+          "japanese": "世界的なイベントが地域市場に影響します。",
+          "category": "経済"
+        }
+      ],
+      "createdAt": 793123200.000000
+    },
+    {
+      "id": "10000030-0030-0030-0030-000000000030",
+      "word": "progress",
+      "meaning": "進歩、進展する",
+      "phonetic": "ˈprɑː.ɡres",
+      "sentences": [
+        {
+          "id": "10000030-0030-0030-0030-000000003001",
+          "english": "We're making good progress.",
+          "japanese": "良い進歩を遂げています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003002",
+          "english": "Technology continues to progress rapidly.",
+          "japanese": "技術は急速に進歩し続けています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003003",
+          "english": "The project is in progress.",
+          "japanese": "プロジェクトは進行中です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003004",
+          "english": "Her English has shown great progress.",
+          "japanese": "彼女の英語は大きな進歩を見せています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003005",
+          "english": "Progress requires patience and effort.",
+          "japanese": "進歩には忍耐と努力が必要です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003006",
+          "english": "The work is progressing smoothly.",
+          "japanese": "作業は順調に進んでいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003007",
+          "english": "Medical progress saves lives.",
+          "japanese": "医療の進歩が命を救います。",
+          "category": "医療"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003008",
+          "english": "Let me update you on our progress.",
+          "japanese": "進捗状況をお知らせします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003009",
+          "english": "Scientific progress benefits society.",
+          "japanese": "科学の進歩は社会に利益をもたらします。",
+          "category": "科学"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003010",
+          "english": "We need to track progress carefully.",
+          "japanese": "進捗を注意深く追跡する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003011",
+          "english": "The construction is progressing well.",
+          "japanese": "建設は順調に進んでいます。",
+          "category": "建設"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003012",
+          "english": "Slow progress is still progress.",
+          "japanese": "遅い進歩もやはり進歩です。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003013",
+          "english": "The meeting is still in progress.",
+          "japanese": "会議はまだ進行中です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003014",
+          "english": "Social progress takes time.",
+          "japanese": "社会の進歩には時間がかかります。",
+          "category": "社会"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003015",
+          "english": "We celebrate every bit of progress.",
+          "japanese": "すべての進歩を祝います。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003016",
+          "english": "The disease is progressing rapidly.",
+          "japanese": "病気は急速に進行しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003017",
+          "english": "Economic progress varies by region.",
+          "japanese": "経済の進歩は地域によって異なります。",
+          "category": "経済"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003018",
+          "english": "Students track their own progress.",
+          "japanese": "学生は自分の進歩を追跡します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003019",
+          "english": "The talks are progressing positively.",
+          "japanese": "交渉は前向きに進んでいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000030-0030-0030-0030-000000003020",
+          "english": "Progress depends on teamwork.",
+          "japanese": "進歩はチームワークに依存します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793126800.000000
+    },
+    {
+      "id": "10000031-0031-0031-0031-000000000031",
+      "word": "determine",
+      "meaning": "決定する、決心する",
+      "phonetic": "dɪˈtɜː.mɪn",
+      "sentences": [
+        {
+          "id": "10000031-0031-0031-0031-000000003101",
+          "english": "We need to determine the cause.",
+          "japanese": "原因を特定する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003102",
+          "english": "Tests will determine the diagnosis.",
+          "japanese": "検査が診断を決定します。",
+          "category": "医療"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003103",
+          "english": "She's determined to succeed.",
+          "japanese": "彼女は成功を決心しています。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003104",
+          "english": "Multiple factors determine the outcome.",
+          "japanese": "複数の要因が結果を決定します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003105",
+          "english": "The survey will determine customer preferences.",
+          "japanese": "調査が顧客の好みを決定します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003106",
+          "english": "Your attitude determines your success.",
+          "japanese": "あなたの態度が成功を決定します。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003107",
+          "english": "We must determine the best approach.",
+          "japanese": "最良のアプローチを決定しなければなりません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003108",
+          "english": "He's determined to finish on time.",
+          "japanese": "彼は時間通りに終えることを決意しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003109",
+          "english": "Research will determine the answer.",
+          "japanese": "研究が答えを明らかにします。",
+          "category": "科学"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003110",
+          "english": "The committee will determine the winner.",
+          "japanese": "委員会が勝者を決定します。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003111",
+          "english": "Market demand determines prices.",
+          "japanese": "市場需要が価格を決定します。",
+          "category": "経済"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003112",
+          "english": "She determined to make a change.",
+          "japanese": "彼女は変化を起こすことを決心しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003113",
+          "english": "The investigation will determine responsibility.",
+          "japanese": "調査が責任を明らかにします。",
+          "category": "法律"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003114",
+          "english": "Quality determines customer satisfaction.",
+          "japanese": "品質が顧客満足度を決定します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003115",
+          "english": "We're determined to find a solution.",
+          "japanese": "解決策を見つけることを決意しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003116",
+          "english": "The results determine our next steps.",
+          "japanese": "結果が次のステップを決定します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003117",
+          "english": "Experience determines expertise.",
+          "japanese": "経験が専門性を決定します。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003118",
+          "english": "Tests determine student placement.",
+          "japanese": "テストが生徒の配置を決定します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003119",
+          "english": "She's a very determined person.",
+          "japanese": "彼女は非常に決意の固い人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000031-0031-0031-0031-000000003120",
+          "english": "The data will determine the strategy.",
+          "japanese": "データが戦略を決定します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793130400.000000
+    },
+    {
+      "id": "10000032-0032-0032-0032-000000000032",
+      "word": "involve",
+      "meaning": "関係する、含む",
+      "phonetic": "ɪnˈvɑːlv",
+      "sentences": [
+        {
+          "id": "10000032-0032-0032-0032-000000003201",
+          "english": "The project involves many people.",
+          "japanese": "プロジェクトは多くの人が関わっています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003202",
+          "english": "Does the job involve travel?",
+          "japanese": "その仕事は出張が含まれますか？",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003203",
+          "english": "Everyone should be involved in decisions.",
+          "japanese": "誰もが意思決定に関与すべきです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003204",
+          "english": "The process involves several steps.",
+          "japanese": "そのプロセスにはいくつかのステップが含まれます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003205",
+          "english": "We want to involve the community.",
+          "japanese": "コミュニティを巻き込みたいです。",
+          "category": "社会"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003206",
+          "english": "The task involves careful planning.",
+          "japanese": "その作業には慎重な計画が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003207",
+          "english": "He's heavily involved in the project.",
+          "japanese": "彼はプロジェクトに深く関わっています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003208",
+          "english": "Learning involves making mistakes.",
+          "japanese": "学習には間違いが伴います。",
+          "category": "教育"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003209",
+          "english": "The role involves customer interaction.",
+          "japanese": "その役割には顧客対応が含まれます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003210",
+          "english": "She's not involved in the decision.",
+          "japanese": "彼女はその決定に関与していません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003211",
+          "english": "The recipe involves simple ingredients.",
+          "japanese": "そのレシピにはシンプルな材料が含まれます。",
+          "category": "料理"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003212",
+          "english": "Success involves hard work.",
+          "japanese": "成功には努力が伴います。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003213",
+          "english": "We involve employees in planning.",
+          "japanese": "計画に従業員を参加させます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003214",
+          "english": "The incident involved several vehicles.",
+          "japanese": "その事故には複数の車両が関係しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003215",
+          "english": "Teaching involves patience and creativity.",
+          "japanese": "教えることには忍耐と創造性が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003216",
+          "english": "The investigation involves many agencies.",
+          "japanese": "調査には多くの機関が関与しています。",
+          "category": "法律"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003217",
+          "english": "Don't involve me in this.",
+          "japanese": "これに私を巻き込まないでください。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003218",
+          "english": "The procedure involves some risk.",
+          "japanese": "その手順にはいくらかのリスクが伴います。",
+          "category": "医療"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003219",
+          "english": "Parents are involved in school activities.",
+          "japanese": "親は学校活動に関与しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000032-0032-0032-0032-000000003220",
+          "english": "The solution involves cooperation.",
+          "japanese": "その解決策には協力が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793134000.000000
+    },
+    {
+      "id": "10000033-0033-0033-0033-000000000033",
+      "word": "maintain",
+      "meaning": "維持する、保つ",
+      "phonetic": "meɪnˈteɪn",
+      "sentences": [
+        {
+          "id": "10000033-0033-0033-0033-000000003301",
+          "english": "We maintain high quality standards.",
+          "japanese": "高品質基準を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003302",
+          "english": "It's important to maintain good health.",
+          "japanese": "健康を維持することが重要です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003303",
+          "english": "The building is well maintained.",
+          "japanese": "その建物は良く保たれています。",
+          "category": "建築"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003304",
+          "english": "She maintains a positive attitude.",
+          "japanese": "彼女は前向きな態度を保っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003305",
+          "english": "We must maintain customer trust.",
+          "japanese": "顧客の信頼を維持しなければなりません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003306",
+          "english": "Regular exercise helps maintain fitness.",
+          "japanese": "定期的な運動は体力を維持するのに役立ちます。",
+          "category": "健康"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003307",
+          "english": "The company maintains a strong reputation.",
+          "japanese": "会社は強い評判を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003308",
+          "english": "He maintained his innocence throughout.",
+          "japanese": "彼は終始無実を主張しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003309",
+          "english": "We maintain contact with former clients.",
+          "japanese": "以前の顧客と連絡を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003310",
+          "english": "The system requires regular maintenance.",
+          "japanese": "システムは定期的なメンテナンスが必要です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003311",
+          "english": "They maintain a clean environment.",
+          "japanese": "彼らは清潔な環境を維持しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003312",
+          "english": "I maintain that I was right.",
+          "japanese": "私は自分が正しかったと主張します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003313",
+          "english": "The park is maintained by volunteers.",
+          "japanese": "公園はボランティアによって維持されています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003314",
+          "english": "Maintain a safe distance from the vehicle.",
+          "japanese": "車両から安全な距離を保ってください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003315",
+          "english": "She maintains good relationships with colleagues.",
+          "japanese": "彼女は同僚と良好な関係を保っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003316",
+          "english": "The database is maintained daily.",
+          "japanese": "データベースは毎日メンテナンスされています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003317",
+          "english": "We maintain strict confidentiality.",
+          "japanese": "厳格な機密保持を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003318",
+          "english": "The garden is beautifully maintained.",
+          "japanese": "庭は美しく手入れされています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003319",
+          "english": "They maintain inventory levels carefully.",
+          "japanese": "彼らは在庫レベルを慎重に維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000033-0033-0033-0033-000000003320",
+          "english": "Maintain focus on your goals.",
+          "japanese": "目標に集中し続けてください。",
+          "category": "励まし"
+        }
+      ],
+      "createdAt": 793137600.000000
+    },
+    {
+      "id": "10000034-0034-0034-0034-000000000034",
+      "word": "identify",
+      "meaning": "特定する、識別する",
+      "phonetic": "aɪˈden.tə.faɪ",
+      "sentences": [
+        {
+          "id": "10000034-0034-0034-0034-000000003401",
+          "english": "We need to identify the problem.",
+          "japanese": "問題を特定する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003402",
+          "english": "Can you identify this plant?",
+          "japanese": "この植物を識別できますか？",
+          "category": "自然"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003403",
+          "english": "Please identify yourself at the entrance.",
+          "japanese": "入口で身分証明をしてください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003404",
+          "english": "The test identifies learning gaps.",
+          "japanese": "テストは学習のギャップを特定します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003405",
+          "english": "We identified several opportunities.",
+          "japanese": "いくつかの機会を特定しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003406",
+          "english": "She identified with the character.",
+          "japanese": "彼女はその人物に共感しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003407",
+          "english": "The system identifies security threats.",
+          "japanese": "システムはセキュリティ脅威を識別します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003408",
+          "english": "Researchers identified a new species.",
+          "japanese": "研究者は新種を発見しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003409",
+          "english": "He was identified as the suspect.",
+          "japanese": "彼は容疑者として特定されました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003410",
+          "english": "The survey identifies customer needs.",
+          "japanese": "調査は顧客ニーズを特定します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003411",
+          "english": "We must identify our target audience.",
+          "japanese": "ターゲット層を特定しなければなりません。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003412",
+          "english": "The app identifies songs by sound.",
+          "japanese": "アプリは音で曲を識別します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003413",
+          "english": "They identified key challenges.",
+          "japanese": "彼らは重要な課題を特定しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003414",
+          "english": "Blood tests identify various conditions.",
+          "japanese": "血液検査は様々な症状を特定します。",
+          "category": "医療"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003415",
+          "english": "I identify as an introvert.",
+          "japanese": "私は内向的な人間だと自認しています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003416",
+          "english": "The team identified areas for improvement.",
+          "japanese": "チームは改善が必要な領域を特定しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003417",
+          "english": "Cameras identify license plates.",
+          "japanese": "カメラはナンバープレートを識別します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003418",
+          "english": "The report identified trends.",
+          "japanese": "レポートは傾向を特定しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003419",
+          "english": "She identified the root cause.",
+          "japanese": "彼女は根本原因を特定しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000034-0034-0034-0034-000000003420",
+          "english": "We identified potential risks early.",
+          "japanese": "潜在的なリスクを早期に特定しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793141200.000000
+    },
+    {
+      "id": "10000035-0035-0035-0035-000000000035",
+      "word": "demonstrate",
+      "meaning": "実証する、示す",
+      "phonetic": "ˈdem.ən.streɪt",
+      "sentences": [
+        {
+          "id": "10000035-0035-0035-0035-000000003501",
+          "english": "Let me demonstrate how it works.",
+          "japanese": "どのように機能するか実演しましょう。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003502",
+          "english": "The results demonstrate significant improvement.",
+          "japanese": "結果は大幅な改善を示しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003503",
+          "english": "She demonstrated great skill.",
+          "japanese": "彼女は優れたスキルを示しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003504",
+          "english": "The experiment demonstrates the theory.",
+          "japanese": "実験は理論を実証します。",
+          "category": "科学"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003505",
+          "english": "We'll demonstrate the new features.",
+          "japanese": "新機能を実演します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003506",
+          "english": "They demonstrated against the policy.",
+          "japanese": "彼らは政策に反対してデモを行いました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003507",
+          "english": "The data demonstrates a clear trend.",
+          "japanese": "データは明確な傾向を示しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003508",
+          "english": "He demonstrated exceptional leadership.",
+          "japanese": "彼は卓越したリーダーシップを示しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003509",
+          "english": "Can you demonstrate the technique?",
+          "japanese": "その技術を実演していただけますか？",
+          "category": "教育"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003510",
+          "english": "The study demonstrates effectiveness.",
+          "japanese": "研究は有効性を実証しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003511",
+          "english": "She demonstrated courage under pressure.",
+          "japanese": "彼女はプレッシャーの中で勇気を示しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003512",
+          "english": "The chef demonstrated cooking methods.",
+          "japanese": "シェフは調理法を実演しました。",
+          "category": "料理"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003513",
+          "english": "Students demonstrate their understanding.",
+          "japanese": "学生は理解を示します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003514",
+          "english": "The product demonstration was impressive.",
+          "japanese": "製品デモンストレーションは印象的でした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003515",
+          "english": "Actions demonstrate commitment.",
+          "japanese": "行動がコミットメントを示します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003516",
+          "english": "The findings demonstrate causation.",
+          "japanese": "調査結果は因果関係を実証しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003517",
+          "english": "He demonstrated the software features.",
+          "japanese": "彼はソフトウェアの機能を実演しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003518",
+          "english": "The team demonstrated excellent teamwork.",
+          "japanese": "チームは優れたチームワークを示しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003519",
+          "english": "History demonstrates the pattern.",
+          "japanese": "歴史はそのパターンを示しています。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000035-0035-0035-0035-000000003520",
+          "english": "She demonstrated patience with students.",
+          "japanese": "彼女は生徒に対して忍耐を示しました。",
+          "category": "教育"
+        }
+      ],
+      "createdAt": 793144800.000000
+    },
+    {
+      "id": "10000036-0036-0036-0036-000000000036",
+      "word": "relevant",
+      "meaning": "関連性のある、適切な",
+      "phonetic": "ˈrel.ə.vənt",
+      "sentences": [
+        {
+          "id": "10000036-0036-0036-0036-000000003601",
+          "english": "Is this information relevant?",
+          "japanese": "この情報は関連性がありますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003602",
+          "english": "We need relevant experience for this job.",
+          "japanese": "この仕事には関連する経験が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003603",
+          "english": "The data is highly relevant to our study.",
+          "japanese": "データは我々の研究に非常に関連しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003604",
+          "english": "Please provide only relevant documents.",
+          "japanese": "関連する文書のみを提供してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003605",
+          "english": "That's not relevant to our discussion.",
+          "japanese": "それは私たちの議論に関係ありません。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003606",
+          "english": "The course teaches relevant skills.",
+          "japanese": "コースは関連するスキルを教えます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003607",
+          "english": "Keep your answers relevant to the question.",
+          "japanese": "質問に関連する答えを述べてください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003608",
+          "english": "All relevant parties will be notified.",
+          "japanese": "すべての関係者に通知されます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003609",
+          "english": "The information is no longer relevant.",
+          "japanese": "その情報はもう関連性がありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003610",
+          "english": "She has relevant expertise in this area.",
+          "japanese": "彼女はこの分野で関連する専門知識を持っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003611",
+          "english": "The article provides relevant insights.",
+          "japanese": "その記事は関連する洞察を提供します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003612",
+          "english": "Is this still relevant in today's context?",
+          "japanese": "これは今日の状況でまだ関連性がありますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003613",
+          "english": "We focus on relevant content.",
+          "japanese": "関連するコンテンツに焦点を当てています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003614",
+          "english": "The search shows relevant results.",
+          "japanese": "検索は関連する結果を表示します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003615",
+          "english": "Previous experience is relevant but not required.",
+          "japanese": "以前の経験は関連しますが必須ではありません。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003616",
+          "english": "The evidence is relevant to the case.",
+          "japanese": "その証拠は事件に関連しています。",
+          "category": "法律"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003617",
+          "english": "We discuss only relevant topics.",
+          "japanese": "関連するトピックのみを議論します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003618",
+          "english": "This training is relevant for all staff.",
+          "japanese": "この研修はすべてのスタッフに関連します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003619",
+          "english": "The book remains relevant today.",
+          "japanese": "その本は今日でも関連性を保っています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000036-0036-0036-0036-000000003620",
+          "english": "Include all relevant details in your report.",
+          "japanese": "レポートにすべての関連する詳細を含めてください。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793148400.000000
+    },
+    {
+      "id": "10000037-0037-0037-0037-000000000037",
+      "word": "analyze",
+      "meaning": "分析する",
+      "phonetic": "ˈæn.əl.aɪz",
+      "sentences": [
+        {
+          "id": "10000037-0037-0037-0037-000000003701",
+          "english": "We need to analyze the data carefully.",
+          "japanese": "データを慎重に分析する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003702",
+          "english": "The team will analyze customer feedback.",
+          "japanese": "チームは顧客フィードバックを分析します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003703",
+          "english": "Scientists analyze blood samples.",
+          "japanese": "科学者は血液サンプルを分析します。",
+          "category": "医療"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003704",
+          "english": "Let's analyze the situation first.",
+          "japanese": "まず状況を分析しましょう。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003705",
+          "english": "The software analyzes market trends.",
+          "japanese": "ソフトウェアは市場動向を分析します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003706",
+          "english": "Students learn to analyze literature.",
+          "japanese": "学生は文学を分析することを学びます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003707",
+          "english": "We analyzed the results thoroughly.",
+          "japanese": "結果を徹底的に分析しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003708",
+          "english": "The report analyzes economic factors.",
+          "japanese": "レポートは経済要因を分析します。",
+          "category": "経済"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003709",
+          "english": "Experts analyze the impact.",
+          "japanese": "専門家は影響を分析します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003710",
+          "english": "We use tools to analyze performance.",
+          "japanese": "パフォーマンスを分析するためのツールを使用します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003711",
+          "english": "The system can analyze patterns.",
+          "japanese": "システムはパターンを分析できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003712",
+          "english": "She analyzed the problem logically.",
+          "japanese": "彼女は論理的に問題を分析しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003713",
+          "english": "Researchers analyze historical documents.",
+          "japanese": "研究者は歴史的文書を分析します。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003714",
+          "english": "They analyze competitors' strategies.",
+          "japanese": "彼らは競合他社の戦略を分析します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003715",
+          "english": "The detective analyzed the evidence.",
+          "japanese": "刑事は証拠を分析しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003716",
+          "english": "We analyze user behavior online.",
+          "japanese": "オンラインでユーザー行動を分析します。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003717",
+          "english": "Financial analysts analyze stocks.",
+          "japanese": "金融アナリストは株式を分析します。",
+          "category": "金融"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003718",
+          "english": "The lab analyzes water quality.",
+          "japanese": "研究所は水質を分析します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003719",
+          "english": "Teachers analyze student progress.",
+          "japanese": "教師は生徒の進歩を分析します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000037-0037-0037-0037-000000003720",
+          "english": "The tool analyzes website traffic.",
+          "japanese": "ツールはウェブサイトのトラフィックを分析します。",
+          "category": "テクノロジー"
+        }
+      ],
+      "createdAt": 793152000.000000
+    },
+    {
+      "id": "10000038-0038-0038-0038-000000000038",
+      "word": "appropriate",
+      "meaning": "適切な",
+      "phonetic": "əˈproʊ.pri.ət",
+      "sentences": [
+        {
+          "id": "10000038-0038-0038-0038-000000003801",
+          "english": "Please wear appropriate clothing.",
+          "japanese": "適切な服装を着用してください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003802",
+          "english": "Is this an appropriate time to talk?",
+          "japanese": "これは話すのに適切な時間ですか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003803",
+          "english": "We'll take appropriate action.",
+          "japanese": "適切な措置を講じます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003804",
+          "english": "The response was entirely appropriate.",
+          "japanese": "その対応は完全に適切でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003805",
+          "english": "Choose an appropriate gift.",
+          "japanese": "適切な贈り物を選んでください。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003806",
+          "english": "That's not appropriate behavior.",
+          "japanese": "それは適切な行動ではありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003807",
+          "english": "We use appropriate technology.",
+          "japanese": "適切な技術を使用します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003808",
+          "english": "The punishment should be appropriate.",
+          "japanese": "罰は適切であるべきです。",
+          "category": "法律"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003809",
+          "english": "Select the most appropriate answer.",
+          "japanese": "最も適切な答えを選んでください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003810",
+          "english": "He made an appropriate comment.",
+          "japanese": "彼は適切なコメントをしました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003811",
+          "english": "The company allocates appropriate resources.",
+          "japanese": "会社は適切なリソースを配分します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003812",
+          "english": "This movie is not appropriate for children.",
+          "japanese": "この映画は子供には適切ではありません。",
+          "category": "エンターテイメント"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003813",
+          "english": "We provide appropriate training.",
+          "japanese": "適切なトレーニングを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003814",
+          "english": "The tone was appropriate for the occasion.",
+          "japanese": "その口調はその場に適切でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003815",
+          "english": "Apply appropriate safety measures.",
+          "japanese": "適切な安全対策を適用してください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003816",
+          "english": "The level is appropriate for beginners.",
+          "japanese": "レベルは初心者に適切です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003817",
+          "english": "They made appropriate arrangements.",
+          "japanese": "彼らは適切な手配をしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003818",
+          "english": "The price seems appropriate.",
+          "japanese": "価格は適切に思えます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003819",
+          "english": "Use appropriate language in meetings.",
+          "japanese": "会議では適切な言葉を使ってください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000038-0038-0038-0038-000000003820",
+          "english": "The solution is appropriate for our needs.",
+          "japanese": "その解決策は私たちのニーズに適しています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793155600.000000
+    },
+    {
+      "id": "10000039-0039-0039-0039-000000000039",
+      "word": "responsible",
+      "meaning": "責任がある",
+      "phonetic": "rɪˈspɑːn.sə.bəl",
+      "sentences": [
+        {
+          "id": "10000039-0039-0039-0039-000000003901",
+          "english": "Who is responsible for this project?",
+          "japanese": "誰がこのプロジェクトの責任者ですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003902",
+          "english": "We must be responsible citizens.",
+          "japanese": "私たちは責任ある市民でなければなりません。",
+          "category": "社会"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003903",
+          "english": "She's responsible for sales.",
+          "japanese": "彼女は営業を担当しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003904",
+          "english": "Parents are responsible for their children.",
+          "japanese": "親は子供に対して責任があります。",
+          "category": "家族"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003905",
+          "english": "He's a very responsible person.",
+          "japanese": "彼は非常に責任感のある人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003906",
+          "english": "The company is environmentally responsible.",
+          "japanese": "会社は環境に対して責任を持っています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003907",
+          "english": "I'm not responsible for the delay.",
+          "japanese": "遅延については私の責任ではありません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003908",
+          "english": "Each team member has responsible tasks.",
+          "japanese": "各チームメンバーには責任ある仕事があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003909",
+          "english": "Act responsible at all times.",
+          "japanese": "常に責任を持って行動してください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003910",
+          "english": "The driver was responsible for the accident.",
+          "japanese": "運転手は事故の責任がありました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003911",
+          "english": "We promote responsible consumption.",
+          "japanese": "責任ある消費を促進しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003912",
+          "english": "She's responsible and trustworthy.",
+          "japanese": "彼女は責任感があり信頼できます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003913",
+          "english": "The manager is responsible for hiring.",
+          "japanese": "マネージャーは採用に責任があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003914",
+          "english": "Responsible leadership is essential.",
+          "japanese": "責任あるリーダーシップが不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003915",
+          "english": "We must hold people responsible.",
+          "japanese": "人々に責任を持たせなければなりません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003916",
+          "english": "This position requires a responsible person.",
+          "japanese": "このポジションには責任感のある人が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003917",
+          "english": "The department is responsible for quality.",
+          "japanese": "その部門は品質に責任があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003918",
+          "english": "We practice responsible tourism.",
+          "japanese": "責任ある観光を実践しています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003919",
+          "english": "Everyone is responsible for safety.",
+          "japanese": "誰もが安全に責任があります。",
+          "category": "安全"
+        },
+        {
+          "id": "10000039-0039-0039-0039-000000003920",
+          "english": "She demonstrated responsible behavior.",
+          "japanese": "彼女は責任ある行動を示しました。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793159200.000000
+    },
+    {
+      "id": "10000040-0040-0040-0040-000000000040",
+      "word": "contribute",
+      "meaning": "貢献する、寄与する",
+      "phonetic": "kənˈtrɪb.juːt",
+      "sentences": [
+        {
+          "id": "10000040-0040-0040-0040-000000004001",
+          "english": "Everyone can contribute ideas.",
+          "japanese": "誰でもアイデアを提供できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004002",
+          "english": "She contributes to the team's success.",
+          "japanese": "彼女はチームの成功に貢献しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004003",
+          "english": "Many factors contribute to health.",
+          "japanese": "多くの要因が健康に寄与します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004004",
+          "english": "Would you like to contribute?",
+          "japanese": "貢献していただけますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004005",
+          "english": "The company contributes to charity.",
+          "japanese": "会社は慈善活動に寄付しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004006",
+          "english": "He contributed valuable insights.",
+          "japanese": "彼は貴重な洞察を提供しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004007",
+          "english": "Hard work contributes to success.",
+          "japanese": "努力が成功に貢献します。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004008",
+          "english": "We contribute to community projects.",
+          "japanese": "コミュニティプロジェクトに貢献しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004009",
+          "english": "Members contribute monthly fees.",
+          "japanese": "メンバーは月会費を納めています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004010",
+          "english": "Each person contributes differently.",
+          "japanese": "各人は異なる形で貢献します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004011",
+          "english": "Volunteers contribute their time.",
+          "japanese": "ボランティアは時間を提供します。",
+          "category": "社会"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004012",
+          "english": "Pollution contributes to climate change.",
+          "japanese": "汚染は気候変動に寄与します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004013",
+          "english": "She contributed an article to the magazine.",
+          "japanese": "彼女は雑誌に記事を寄稿しました。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004014",
+          "english": "Technology contributes to efficiency.",
+          "japanese": "技術は効率向上に貢献します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004015",
+          "english": "Everyone's contribution is valuable.",
+          "japanese": "皆の貢献は価値があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004016",
+          "english": "He contributed significantly to research.",
+          "japanese": "彼は研究に大きく貢献しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004017",
+          "english": "We contribute to open source projects.",
+          "japanese": "オープンソースプロジェクトに貢献しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004018",
+          "english": "Exercise contributes to well-being.",
+          "japanese": "運動は健康に寄与します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004019",
+          "english": "Students contribute to class discussions.",
+          "japanese": "学生は授業の議論に貢献します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000040-0040-0040-0040-000000004020",
+          "english": "Your support contributes greatly.",
+          "japanese": "あなたのサポートは大いに貢献します。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793162800.000000
+    },
+    {
+      "id": "10000041-0041-0041-0041-000000000041",
+      "word": "communicate",
+      "meaning": "伝える、コミュニケーションする",
+      "phonetic": "kəˈmjuː.nɪ.keɪt",
+      "sentences": [
+        {
+          "id": "10000041-0041-0041-0041-000000004101",
+          "english": "We need to communicate effectively.",
+          "japanese": "効果的にコミュニケーションする必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004102",
+          "english": "She communicates clearly with clients.",
+          "japanese": "彼女はクライアントと明確にコミュニケーションします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004103",
+          "english": "They communicate via email.",
+          "japanese": "彼らはメールで連絡を取り合います。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004104",
+          "english": "Good leaders communicate their vision.",
+          "japanese": "良いリーダーはビジョンを伝えます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004105",
+          "english": "Please communicate any changes immediately.",
+          "japanese": "変更があればすぐに伝えてください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004106",
+          "english": "The team communicates regularly.",
+          "japanese": "チームは定期的にコミュニケーションをとります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004107",
+          "english": "Animals communicate in different ways.",
+          "japanese": "動物は異なる方法でコミュニケーションします。",
+          "category": "自然"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004108",
+          "english": "We communicate our policies clearly.",
+          "japanese": "方針を明確に伝えています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004109",
+          "english": "He struggles to communicate his feelings.",
+          "japanese": "彼は感情を伝えるのに苦労しています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004110",
+          "english": "The app helps people communicate globally.",
+          "japanese": "アプリは世界中の人々がコミュニケーションするのを助けます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004111",
+          "english": "Parents and teachers should communicate often.",
+          "japanese": "親と教師は頻繁にコミュニケーションをとるべきです。",
+          "category": "教育"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004112",
+          "english": "We communicate updates to all staff.",
+          "japanese": "すべてのスタッフに更新情報を伝えます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004113",
+          "english": "Body language communicates a lot.",
+          "japanese": "ボディランゲージは多くを伝えます。",
+          "category": "コミュニケーション"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004114",
+          "english": "The rooms communicate with each other.",
+          "japanese": "部屋は互いにつながっています。",
+          "category": "建築"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004115",
+          "english": "She communicates well in English.",
+          "japanese": "彼女は英語でうまくコミュニケーションします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004116",
+          "english": "The system communicates status updates.",
+          "japanese": "システムはステータスの更新を伝えます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004117",
+          "english": "We communicate expectations from the start.",
+          "japanese": "最初から期待を伝えます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004118",
+          "english": "Effective teams communicate openly.",
+          "japanese": "効果的なチームはオープンにコミュニケーションします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004119",
+          "english": "Technology has changed how we communicate.",
+          "japanese": "技術は私たちのコミュニケーション方法を変えました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000041-0041-0041-0041-000000004120",
+          "english": "Doctors must communicate clearly with patients.",
+          "japanese": "医師は患者と明確にコミュニケーションしなければなりません。",
+          "category": "医療"
+        }
+      ],
+      "createdAt": 793166400.000000
+    },
+    {
+      "id": "10000042-0042-0042-0042-000000000042",
+      "word": "efficient",
+      "meaning": "効率的な",
+      "phonetic": "ɪˈfɪʃ.ənt",
+      "sentences": [
+        {
+          "id": "10000042-0042-0042-0042-000000004201",
+          "english": "We need a more efficient system.",
+          "japanese": "より効率的なシステムが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004202",
+          "english": "She's very efficient at her work.",
+          "japanese": "彼女は仕事がとても効率的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004203",
+          "english": "This method is energy efficient.",
+          "japanese": "この方法はエネルギー効率が良いです。",
+          "category": "環境"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004204",
+          "english": "The process is fast and efficient.",
+          "japanese": "プロセスは迅速で効率的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004205",
+          "english": "Efficient planning saves time.",
+          "japanese": "効率的な計画は時間を節約します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004206",
+          "english": "The car is fuel efficient.",
+          "japanese": "その車は燃費が良いです。",
+          "category": "自動車"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004207",
+          "english": "We provide efficient customer service.",
+          "japanese": "効率的な顧客サービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004208",
+          "english": "The team works in an efficient manner.",
+          "japanese": "チームは効率的に働きます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004209",
+          "english": "This is the most efficient route.",
+          "japanese": "これが最も効率的なルートです。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004210",
+          "english": "The software is very efficient.",
+          "japanese": "そのソフトウェアは非常に効率的です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004211",
+          "english": "Efficient communication is key.",
+          "japanese": "効率的なコミュニケーションが鍵です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004212",
+          "english": "The machine operates efficiently.",
+          "japanese": "機械は効率的に動作します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004213",
+          "english": "We implemented efficient procedures.",
+          "japanese": "効率的な手順を実装しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004214",
+          "english": "Efficient workers are highly valued.",
+          "japanese": "効率的な労働者は高く評価されます。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004215",
+          "english": "The design is simple and efficient.",
+          "japanese": "デザインはシンプルで効率的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004216",
+          "english": "Public transport is more efficient.",
+          "japanese": "公共交通機関の方が効率的です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004217",
+          "english": "The new system is cost efficient.",
+          "japanese": "新しいシステムはコスト効率が良いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004218",
+          "english": "Efficient management improves results.",
+          "japanese": "効率的な管理は結果を改善します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004219",
+          "english": "LED lights are more efficient.",
+          "japanese": "LED照明はより効率的です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000042-0042-0042-0042-000000004220",
+          "english": "We strive for efficient operations.",
+          "japanese": "効率的な運営を目指しています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793170000.000000
+    },
+    {
+      "id": "10000043-0043-0043-0043-000000000043",
+      "word": "flexible",
+      "meaning": "柔軟な",
+      "phonetic": "ˈflek.sə.bəl",
+      "sentences": [
+        {
+          "id": "10000043-0043-0043-0043-000000004301",
+          "english": "We offer flexible working hours.",
+          "japanese": "柔軟な勤務時間を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004302",
+          "english": "She has a flexible schedule.",
+          "japanese": "彼女は柔軟なスケジュールを持っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004303",
+          "english": "The plan is very flexible.",
+          "japanese": "その計画は非常に柔軟です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004304",
+          "english": "Yoga makes you more flexible.",
+          "japanese": "ヨガは体を柔軟にします。",
+          "category": "健康"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004305",
+          "english": "We need a flexible approach.",
+          "japanese": "柔軟なアプローチが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004306",
+          "english": "The company has flexible policies.",
+          "japanese": "会社には柔軟な方針があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004307",
+          "english": "Be flexible about the date.",
+          "japanese": "日付については柔軟に対応してください。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004308",
+          "english": "The material is very flexible.",
+          "japanese": "その素材は非常に柔軟です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004309",
+          "english": "Remote work offers flexible options.",
+          "japanese": "リモートワークは柔軟な選択肢を提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004310",
+          "english": "She's flexible and adaptable.",
+          "japanese": "彼女は柔軟で適応力があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004311",
+          "english": "The system is designed to be flexible.",
+          "japanese": "システムは柔軟に設計されています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004312",
+          "english": "We maintain a flexible budget.",
+          "japanese": "柔軟な予算を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004313",
+          "english": "Flexible thinking leads to innovation.",
+          "japanese": "柔軟な思考が革新につながります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004314",
+          "english": "The payment terms are flexible.",
+          "japanese": "支払い条件は柔軟です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004315",
+          "english": "Gymnasts are extremely flexible.",
+          "japanese": "体操選手は非常に柔軟です。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004316",
+          "english": "We offer flexible membership options.",
+          "japanese": "柔軟な会員オプションを提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004317",
+          "english": "The schedule is quite flexible.",
+          "japanese": "スケジュールはかなり柔軟です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004318",
+          "english": "Flexible learning suits different styles.",
+          "japanese": "柔軟な学習は異なるスタイルに適しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004319",
+          "english": "The rules are somewhat flexible.",
+          "japanese": "規則は多少柔軟です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000043-0043-0043-0043-000000004320",
+          "english": "Stay flexible in your planning.",
+          "japanese": "計画では柔軟性を保ってください。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793173600.000000
+    },
+    {
+      "id": "10000044-0044-0044-0044-000000000044",
+      "word": "priority",
+      "meaning": "優先事項",
+      "phonetic": "praɪˈɔːr.ə.ti",
+      "sentences": [
+        {
+          "id": "10000044-0044-0044-0044-000000004401",
+          "english": "Safety is our top priority.",
+          "japanese": "安全が最優先事項です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004402",
+          "english": "What are your priorities?",
+          "japanese": "あなたの優先事項は何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004403",
+          "english": "Customer service is a priority.",
+          "japanese": "顧客サービスは優先事項です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004404",
+          "english": "We need to prioritize tasks.",
+          "japanese": "タスクに優先順位をつける必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004405",
+          "english": "Education should be a priority.",
+          "japanese": "教育は優先事項であるべきです。",
+          "category": "教育"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004406",
+          "english": "This project has high priority.",
+          "japanese": "このプロジェクトは優先度が高いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004407",
+          "english": "Family is my first priority.",
+          "japanese": "家族が第一の優先事項です。",
+          "category": "家族"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004408",
+          "english": "We list tasks by priority.",
+          "japanese": "優先順位でタスクをリストアップします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004409",
+          "english": "Health is a top priority.",
+          "japanese": "健康が最優先です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004410",
+          "english": "The issue requires immediate priority.",
+          "japanese": "その問題は即座の優先対応が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004411",
+          "english": "We adjust priorities as needed.",
+          "japanese": "必要に応じて優先順位を調整します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004412",
+          "english": "Quality is our priority.",
+          "japanese": "品質が私たちの優先事項です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004413",
+          "english": "The team discusses priorities weekly.",
+          "japanese": "チームは毎週優先事項を議論します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004414",
+          "english": "Environmental protection is a global priority.",
+          "japanese": "環境保護は世界的な優先事項です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004415",
+          "english": "Set your priorities clearly.",
+          "japanese": "優先順位を明確に設定してください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004416",
+          "english": "The company shifted its priorities.",
+          "japanese": "会社は優先事項を変更しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004417",
+          "english": "Budget constraints affect priorities.",
+          "japanese": "予算の制約が優先順位に影響します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004418",
+          "english": "We handle priority orders first.",
+          "japanese": "優先注文を最初に処理します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004419",
+          "english": "The manager sets priorities for the team.",
+          "japanese": "マネージャーはチームの優先事項を設定します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000044-0044-0044-0044-000000004420",
+          "english": "Different priorities create conflict.",
+          "japanese": "異なる優先事項が対立を生みます。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793177200.000000
+    },
+    {
+      "id": "10000045-0045-0045-0045-000000000045",
+      "word": "perspective",
+      "meaning": "視点、見方",
+      "phonetic": "pɚˈspek.tɪv",
+      "sentences": [
+        {
+          "id": "10000045-0045-0045-0045-000000004501",
+          "english": "Try to see things from my perspective.",
+          "japanese": "私の視点から物事を見てみてください。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004502",
+          "english": "Different perspectives are valuable.",
+          "japanese": "異なる視点は価値があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004503",
+          "english": "She has a unique perspective.",
+          "japanese": "彼女は独特な見方をしています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004504",
+          "english": "The artist uses perspective skillfully.",
+          "japanese": "その芸術家は遠近法を巧みに使います。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004505",
+          "english": "We need a broader perspective.",
+          "japanese": "より広い視野が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004506",
+          "english": "Travel changes your perspective.",
+          "japanese": "旅行は視点を変えます。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004507",
+          "english": "Keep things in perspective.",
+          "japanese": "物事を正しい視点で見てください。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004508",
+          "english": "His perspective is always interesting.",
+          "japanese": "彼の視点はいつも興味深いです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004509",
+          "english": "The problem needs a new perspective.",
+          "japanese": "問題には新しい視点が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004510",
+          "english": "Historical perspective is important.",
+          "japanese": "歴史的視点は重要です。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004511",
+          "english": "She offers a fresh perspective.",
+          "japanese": "彼女は新鮮な視点を提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004512",
+          "english": "From this perspective, it makes sense.",
+          "japanese": "この視点からすれば、理にかなっています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004513",
+          "english": "Multiple perspectives enrich discussions.",
+          "japanese": "複数の視点が議論を豊かにします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004514",
+          "english": "The book provides a cultural perspective.",
+          "japanese": "その本は文化的視点を提供します。",
+          "category": "文化"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004515",
+          "english": "Time gives you perspective.",
+          "japanese": "時間が経てば視点が得られます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004516",
+          "english": "We value diverse perspectives.",
+          "japanese": "多様な視点を大切にしています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004517",
+          "english": "The painting has good perspective.",
+          "japanese": "その絵は遠近法が良いです。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004518",
+          "english": "Experience changes your perspective.",
+          "japanese": "経験は視点を変えます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004519",
+          "english": "Consider the customer's perspective.",
+          "japanese": "顧客の視点を考慮してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000045-0045-0045-0045-000000004520",
+          "english": "A global perspective is essential.",
+          "japanese": "グローバルな視点が不可欠です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793180800.000000
+    },
+    {
+      "id": "10000046-0046-0046-0046-000000000046",
+      "word": "accomplish",
+      "meaning": "達成する、成し遂げる",
+      "phonetic": "əˈkɑːm.plɪʃ",
+      "sentences": [
+        {
+          "id": "10000046-0046-0046-0046-000000004601",
+          "english": "She accomplished her goals.",
+          "japanese": "彼女は目標を達成しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004602",
+          "english": "We accomplished the mission successfully.",
+          "japanese": "任務を成功裏に遂行しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004603",
+          "english": "What did you accomplish today?",
+          "japanese": "今日は何を達成しましたか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004604",
+          "english": "Together we can accomplish anything.",
+          "japanese": "一緒なら何でも成し遂げられます。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004605",
+          "english": "The team accomplished remarkable results.",
+          "japanese": "チームは素晴らしい成果を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004606",
+          "english": "He's an accomplished musician.",
+          "japanese": "彼は熟練した音楽家です。",
+          "category": "音楽"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004607",
+          "english": "We accomplished more than expected.",
+          "japanese": "予想以上のことを成し遂げました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004608",
+          "english": "She's accomplished in many fields.",
+          "japanese": "彼女は多くの分野で優れています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004609",
+          "english": "The project was accomplished on time.",
+          "japanese": "プロジェクトは時間通りに完了しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004610",
+          "english": "Hard work helps accomplish dreams.",
+          "japanese": "努力が夢の実現を助けます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004611",
+          "english": "They accomplished great things.",
+          "japanese": "彼らは偉大なことを成し遂げました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004612",
+          "english": "What do you hope to accomplish?",
+          "japanese": "何を達成したいですか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004613",
+          "english": "The task was accomplished efficiently.",
+          "japanese": "作業は効率的に完了しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004614",
+          "english": "She's an accomplished speaker.",
+          "japanese": "彼女は熟練した演説家です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004615",
+          "english": "We accomplished our objectives.",
+          "japanese": "目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004616",
+          "english": "The mission was finally accomplished.",
+          "japanese": "任務はついに達成されました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004617",
+          "english": "He accomplished much in his life.",
+          "japanese": "彼は人生で多くを成し遂げました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004618",
+          "english": "Small steps accomplish big goals.",
+          "japanese": "小さな一歩が大きな目標を達成します。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004619",
+          "english": "The team accomplished their targets.",
+          "japanese": "チームは目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000046-0046-0046-0046-000000004620",
+          "english": "She's proud of what she accomplished.",
+          "japanese": "彼女は自分の成果を誇りに思っています。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793184400.000000
+    },
+    {
+      "id": "10000047-0047-0047-0047-000000000047",
+      "word": "implement",
+      "meaning": "実施する、実装する",
+      "phonetic": "ˈɪm.plə.ment",
+      "sentences": [
+        {
+          "id": "10000047-0047-0047-0047-000000004701",
+          "english": "We'll implement the new policy soon.",
+          "japanese": "新しい方針をすぐに実施します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004702",
+          "english": "The system was implemented successfully.",
+          "japanese": "システムは正常に実装されました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004703",
+          "english": "They implemented safety measures.",
+          "japanese": "彼らは安全対策を実施しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004704",
+          "english": "Let's implement your suggestions.",
+          "japanese": "あなたの提案を実施しましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004705",
+          "english": "The changes will be implemented next month.",
+          "japanese": "変更は来月実施されます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004706",
+          "english": "We implemented cost-cutting measures.",
+          "japanese": "コスト削減策を実施しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004707",
+          "english": "The plan is ready to implement.",
+          "japanese": "計画は実施の準備ができています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004708",
+          "english": "Schools implemented new curriculum.",
+          "japanese": "学校は新しいカリキュラムを実施しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004709",
+          "english": "The company implements green practices.",
+          "japanese": "会社は環境に配慮した実践を実施しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004710",
+          "english": "How will you implement this strategy?",
+          "japanese": "この戦略をどう実施しますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004711",
+          "english": "We implemented feedback from users.",
+          "japanese": "ユーザーからのフィードバックを実装しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004712",
+          "english": "The government implemented reforms.",
+          "japanese": "政府は改革を実施しました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004713",
+          "english": "They implemented quality control.",
+          "japanese": "彼らは品質管理を実施しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004714",
+          "english": "The feature was implemented quickly.",
+          "japanese": "機能は素早く実装されました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004715",
+          "english": "We're implementing a new system.",
+          "japanese": "新しいシステムを導入しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004716",
+          "english": "The hospital implemented new protocols.",
+          "japanese": "病院は新しいプロトコルを実施しました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004717",
+          "english": "Implementation takes time and effort.",
+          "japanese": "実装には時間と努力がかかります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004718",
+          "english": "They implemented security upgrades.",
+          "japanese": "彼らはセキュリティアップグレードを実施しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004719",
+          "english": "The team implements best practices.",
+          "japanese": "チームはベストプラクティスを実施します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000047-0047-0047-0047-000000004720",
+          "english": "We implemented changes gradually.",
+          "japanese": "変更を段階的に実施しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793188000.000000
+    },
+    {
+      "id": "10000048-0048-0048-0048-000000000048",
+      "word": "encourage",
+      "meaning": "励ます、促す",
+      "phonetic": "ɪnˈkɜː.ɪdʒ",
+      "sentences": [
+        {
+          "id": "10000048-0048-0048-0048-000000004801",
+          "english": "Teachers encourage students to ask questions.",
+          "japanese": "教師は生徒に質問するよう促します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004802",
+          "english": "We encourage feedback from customers.",
+          "japanese": "顧客からのフィードバックを奨励しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004803",
+          "english": "She encouraged me to try again.",
+          "japanese": "彼女は私に再挑戦するよう励ましました。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004804",
+          "english": "The results are very encouraging.",
+          "japanese": "結果は非常に励みになります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004805",
+          "english": "Parents should encourage children.",
+          "japanese": "親は子供を励ますべきです。",
+          "category": "家族"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004806",
+          "english": "We encourage innovation and creativity.",
+          "japanese": "革新と創造性を奨励しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004807",
+          "english": "His words were very encouraging.",
+          "japanese": "彼の言葉は大変励みになりました。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004808",
+          "english": "The company encourages work-life balance.",
+          "japanese": "会社はワークライフバランスを推奨しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004809",
+          "english": "Encourage others to participate.",
+          "japanese": "他の人に参加を促してください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004810",
+          "english": "The program encourages healthy habits.",
+          "japanese": "プログラムは健康的な習慣を促進します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004811",
+          "english": "We encourage teamwork and collaboration.",
+          "japanese": "チームワークと協力を奨励しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004812",
+          "english": "They encouraged volunteers to join.",
+          "japanese": "彼らはボランティアに参加を促しました。",
+          "category": "社会"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004813",
+          "english": "The news is encouraging for investors.",
+          "japanese": "そのニュースは投資家にとって励みになります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004814",
+          "english": "Managers should encourage employees.",
+          "japanese": "マネージャーは従業員を励ますべきです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004815",
+          "english": "We encourage sustainable practices.",
+          "japanese": "持続可能な実践を奨励しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004816",
+          "english": "Her success encouraged me greatly.",
+          "japanese": "彼女の成功は私を大いに励ましました。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004817",
+          "english": "The school encourages critical thinking.",
+          "japanese": "学校は批判的思考を奨励しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004818",
+          "english": "We encourage open communication.",
+          "japanese": "オープンなコミュニケーションを奨励しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004819",
+          "english": "Exercise encourages better sleep.",
+          "japanese": "運動はより良い睡眠を促します。",
+          "category": "健康"
+        },
+        {
+          "id": "10000048-0048-0048-0048-000000004820",
+          "english": "They encourage diversity in hiring.",
+          "japanese": "彼らは採用における多様性を奨励しています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793191600.000000
+    },
+    {
+      "id": "10000049-0049-0049-0049-000000000049",
+      "word": "organize",
+      "meaning": "組織する、整理する",
+      "phonetic": "ˈɔːr.ɡən.aɪz",
+      "sentences": [
+        {
+          "id": "10000049-0049-0049-0049-000000004901",
+          "english": "We need to organize the files.",
+          "japanese": "ファイルを整理する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004902",
+          "english": "She's very organized.",
+          "japanese": "彼女はとても几帳面です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004903",
+          "english": "They organized a charity event.",
+          "japanese": "彼らはチャリティーイベントを組織しました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004904",
+          "english": "Let's organize a meeting.",
+          "japanese": "ミーティングを手配しましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004905",
+          "english": "I need to organize my schedule.",
+          "japanese": "スケジュールを整理する必要があります。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004906",
+          "english": "The team organized the project well.",
+          "japanese": "チームはプロジェクトをうまく組織しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004907",
+          "english": "Workers organized a union.",
+          "japanese": "労働者は組合を組織しました。",
+          "category": "労働"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004908",
+          "english": "Please organize the data by date.",
+          "japanese": "日付でデータを整理してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004909",
+          "english": "She organizes community activities.",
+          "japanese": "彼女はコミュニティ活動を組織しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004910",
+          "english": "We organize training sessions monthly.",
+          "japanese": "毎月研修会を開催しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004911",
+          "english": "The app helps organize tasks.",
+          "japanese": "アプリはタスクの整理に役立ちます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004912",
+          "english": "They're organizing a protest.",
+          "japanese": "彼らは抗議活動を組織しています。",
+          "category": "政治"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004913",
+          "english": "I organize my thoughts before speaking.",
+          "japanese": "話す前に考えを整理します。",
+          "category": "コミュニケーション"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004914",
+          "english": "The conference was well organized.",
+          "japanese": "会議はよく組織されていました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004915",
+          "english": "She organizes her workspace daily.",
+          "japanese": "彼女は毎日職場を整理します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004916",
+          "english": "We organize information systematically.",
+          "japanese": "情報を体系的に整理します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004917",
+          "english": "They organized volunteers efficiently.",
+          "japanese": "彼らはボランティアを効率的に組織しました。",
+          "category": "社会"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004918",
+          "english": "Let me organize my ideas first.",
+          "japanese": "まずアイデアを整理させてください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004919",
+          "english": "The library organizes books by category.",
+          "japanese": "図書館は本をカテゴリー別に整理します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000049-0049-0049-0049-000000004920",
+          "english": "We organized a surprise party.",
+          "japanese": "サプライズパーティーを企画しました。",
+          "category": "イベント"
+        }
+      ],
+      "createdAt": 793195200.000000
+    },
+    {
+      "id": "10000050-0050-0050-0050-000000000050",
+      "word": "evaluate",
+      "meaning": "評価する",
+      "phonetic": "ɪˈvæl.ju.eɪt",
+      "sentences": [
+        {
+          "id": "10000050-0050-0050-0050-000000005001",
+          "english": "We need to evaluate the results.",
+          "japanese": "結果を評価する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005002",
+          "english": "Teachers evaluate student performance.",
+          "japanese": "教師は生徒のパフォーマンスを評価します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005003",
+          "english": "Let's evaluate all options.",
+          "japanese": "すべての選択肢を評価しましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005004",
+          "english": "The system evaluates risk automatically.",
+          "japanese": "システムは自動的にリスクを評価します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005005",
+          "english": "We evaluate employees annually.",
+          "japanese": "従業員を毎年評価します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005006",
+          "english": "Experts evaluate the damage.",
+          "japanese": "専門家が被害を評価します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005007",
+          "english": "Please evaluate this proposal.",
+          "japanese": "この提案を評価してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005008",
+          "english": "The team evaluated several solutions.",
+          "japanese": "チームはいくつかの解決策を評価しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005009",
+          "english": "We evaluate customer satisfaction regularly.",
+          "japanese": "顧客満足度を定期的に評価します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005010",
+          "english": "Doctors evaluate symptoms carefully.",
+          "japanese": "医師は症状を慎重に評価します。",
+          "category": "医療"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005011",
+          "english": "The committee will evaluate applications.",
+          "japanese": "委員会は応募を評価します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005012",
+          "english": "We're evaluating the program's effectiveness.",
+          "japanese": "プログラムの有効性を評価しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005013",
+          "english": "Scientists evaluate data objectively.",
+          "japanese": "科学者は客観的にデータを評価します。",
+          "category": "科学"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005014",
+          "english": "The report evaluates market trends.",
+          "japanese": "レポートは市場動向を評価します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005015",
+          "english": "She evaluated the situation quickly.",
+          "japanese": "彼女は状況を素早く評価しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005016",
+          "english": "We evaluate products before purchase.",
+          "japanese": "購入前に製品を評価します。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005017",
+          "english": "The study evaluates treatment effectiveness.",
+          "japanese": "研究は治療の有効性を評価します。",
+          "category": "医療"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005018",
+          "english": "Managers evaluate team performance.",
+          "japanese": "マネージャーはチームのパフォーマンスを評価します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005019",
+          "english": "We need time to evaluate the offer.",
+          "japanese": "申し出を評価する時間が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000050-0050-0050-0050-000000005020",
+          "english": "The survey evaluates customer needs.",
+          "japanese": "調査は顧客ニーズを評価します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793198800.000000
+    },
+    {
+      "id": "10000051-0051-0051-0051-000000000051",
+      "word": "assume",
+      "meaning": "仮定する、想定する",
+      "phonetic": "əˈsuːm",
+      "sentences": [
+        {
+          "id": "10000051-0051-0051-0051-000000005101",
+          "english": "Don't assume anything without proof.",
+          "japanese": "証拠なしに何も仮定しないでください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005102",
+          "english": "I assume you're coming to the meeting.",
+          "japanese": "会議に来ると思います。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005103",
+          "english": "She will assume the role next month.",
+          "japanese": "彼女は来月その役職に就きます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005104",
+          "english": "Let's assume the best case scenario.",
+          "japanese": "最善のシナリオを想定しましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005105",
+          "english": "He assumed responsibility for the error.",
+          "japanese": "彼は過ちの責任を引き受けました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005106",
+          "english": "We can't assume everyone agrees.",
+          "japanese": "全員が同意すると仮定できません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005107",
+          "english": "The company assumed all costs.",
+          "japanese": "会社はすべての費用を負担しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005108",
+          "english": "I assume you know the rules.",
+          "japanese": "ルールを知っていると思います。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005109",
+          "english": "They assumed control of the project.",
+          "japanese": "彼らはプロジェクトの管理を引き継ぎました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005110",
+          "english": "Let's not assume the worst.",
+          "japanese": "最悪の事態を想定しないようにしましょう。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005111",
+          "english": "She assumed a confident posture.",
+          "japanese": "彼女は自信のある姿勢をとりました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005112",
+          "english": "The study assumes certain conditions.",
+          "japanese": "研究は特定の条件を想定しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005113",
+          "english": "You shouldn't assume people's intentions.",
+          "japanese": "人の意図を決めつけるべきではありません。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005114",
+          "english": "He assumed the position of CEO.",
+          "japanese": "彼はCEOの地位に就きました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005115",
+          "english": "We assume delivery within three days.",
+          "japanese": "3日以内の配達を想定しています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005116",
+          "english": "It's safe to assume they'll agree.",
+          "japanese": "彼らが同意すると考えて問題ありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005117",
+          "english": "The theory assumes basic knowledge.",
+          "japanese": "その理論は基本知識を前提としています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005118",
+          "english": "Never assume you know everything.",
+          "japanese": "すべてを知っていると思わないでください。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005119",
+          "english": "They assumed the project would succeed.",
+          "japanese": "彼らはプロジェクトが成功すると想定しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000051-0051-0051-0051-000000005120",
+          "english": "The plan assumes full cooperation.",
+          "japanese": "計画は完全な協力を前提としています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793202400.000000
+    },
+    {
+      "id": "10000052-0052-0052-0052-000000000052",
+      "word": "transfer",
+      "meaning": "移す、転送する",
+      "phonetic": "trænsˈfɜːr",
+      "sentences": [
+        {
+          "id": "10000052-0052-0052-0052-000000005201",
+          "english": "Please transfer the funds today.",
+          "japanese": "今日資金を送金してください。",
+          "category": "金融"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005202",
+          "english": "He was transferred to another department.",
+          "japanese": "彼は別の部署に異動しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005203",
+          "english": "The file transfer is complete.",
+          "japanese": "ファイル転送が完了しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005204",
+          "english": "I need to transfer at the next station.",
+          "japanese": "次の駅で乗り換える必要があります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005205",
+          "english": "The patient was transferred to ICU.",
+          "japanese": "患者はICUに移されました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005206",
+          "english": "We can transfer your call.",
+          "japanese": "お電話をおつなぎします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005207",
+          "english": "She transferred schools last year.",
+          "japanese": "彼女は昨年転校しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005208",
+          "english": "The company transferred ownership.",
+          "japanese": "会社は所有権を譲渡しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005209",
+          "english": "Transfer the data to the new system.",
+          "japanese": "データを新システムに移してください。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005210",
+          "english": "They offer free transfers to the airport.",
+          "japanese": "空港への無料送迎を提供しています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005211",
+          "english": "The skills transfer to other jobs.",
+          "japanese": "スキルは他の仕事に応用できます。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005212",
+          "english": "He requested a transfer to Tokyo.",
+          "japanese": "彼は東京への転勤を希望しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005213",
+          "english": "The transfer process is simple.",
+          "japanese": "移行プロセスは簡単です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005214",
+          "english": "They transferred power peacefully.",
+          "japanese": "彼らは平和的に政権を移譲しました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005215",
+          "english": "Transfer students need special orientation.",
+          "japanese": "転入生には特別なオリエンテーションが必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005216",
+          "english": "Bank transfers take one business day.",
+          "japanese": "銀行振込には1営業日かかります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005217",
+          "english": "She transferred her knowledge to the team.",
+          "japanese": "彼女は知識をチームに伝えました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005218",
+          "english": "The transfer fee is waived.",
+          "japanese": "振込手数料は免除されます。",
+          "category": "金融"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005219",
+          "english": "We'll transfer you to customer service.",
+          "japanese": "カスタマーサービスにおつなぎします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000052-0052-0052-0052-000000005220",
+          "english": "Heat transfers through the metal.",
+          "japanese": "熱が金属を通じて伝わります。",
+          "category": "科学"
+        }
+      ],
+      "createdAt": 793206000.000000
+    },
+    {
+      "id": "10000053-0053-0053-0053-000000000053",
+      "word": "cooperate",
+      "meaning": "協力する",
+      "phonetic": "koʊˈɑː.pə.reɪt",
+      "sentences": [
+        {
+          "id": "10000053-0053-0053-0053-000000005301",
+          "english": "We need to cooperate with each other.",
+          "japanese": "お互いに協力する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005302",
+          "english": "The companies cooperate on research.",
+          "japanese": "両社は研究で協力しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005303",
+          "english": "Please cooperate with the investigation.",
+          "japanese": "調査にご協力ください。",
+          "category": "法律"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005304",
+          "english": "Countries must cooperate globally.",
+          "japanese": "各国は世界的に協力しなければなりません。",
+          "category": "政治"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005305",
+          "english": "The team cooperates effectively.",
+          "japanese": "チームは効果的に協力します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005306",
+          "english": "They refused to cooperate.",
+          "japanese": "彼らは協力を拒否しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005307",
+          "english": "Students cooperate on group projects.",
+          "japanese": "学生はグループプロジェクトで協力します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005308",
+          "english": "We appreciate your cooperation.",
+          "japanese": "ご協力に感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005309",
+          "english": "The departments cooperate closely.",
+          "japanese": "部門は緊密に協力します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005310",
+          "english": "Success requires everyone to cooperate.",
+          "japanese": "成功には全員の協力が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005311",
+          "english": "They cooperated fully with authorities.",
+          "japanese": "彼らは当局に全面的に協力しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005312",
+          "english": "Organizations cooperate for common goals.",
+          "japanese": "組織は共通の目標のために協力します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005313",
+          "english": "Will you cooperate with us?",
+          "japanese": "私たちに協力していただけますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005314",
+          "english": "The weather cooperated for the event.",
+          "japanese": "天気がイベントに協力的でした。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005315",
+          "english": "Neighbors should cooperate more.",
+          "japanese": "隣人はもっと協力すべきです。",
+          "category": "社会"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005316",
+          "english": "The witness cooperated with police.",
+          "japanese": "目撃者は警察に協力しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005317",
+          "english": "International cooperation is essential.",
+          "japanese": "国際協力が不可欠です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005318",
+          "english": "They cooperated to solve the problem.",
+          "japanese": "彼らは問題解決のために協力しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005319",
+          "english": "The firms cooperate on technology.",
+          "japanese": "企業は技術で協力しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000053-0053-0053-0053-000000005320",
+          "english": "Everyone must cooperate for safety.",
+          "japanese": "安全のために全員が協力しなければなりません。",
+          "category": "安全"
+        }
+      ],
+      "createdAt": 793209600.000000
+    },
+    {
+      "id": "10000054-0054-0054-0054-000000000054",
+      "word": "tradition",
+      "meaning": "伝統",
+      "phonetic": "trəˈdɪʃ.ən",
+      "sentences": [
+        {
+          "id": "10000054-0054-0054-0054-000000005401",
+          "english": "This is an old family tradition.",
+          "japanese": "これは古い家族の伝統です。",
+          "category": "家族"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005402",
+          "english": "We follow Japanese traditions.",
+          "japanese": "日本の伝統に従っています。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005403",
+          "english": "The festival celebrates local traditions.",
+          "japanese": "祭りは地域の伝統を祝います。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005404",
+          "english": "Breaking tradition can be difficult.",
+          "japanese": "伝統を破るのは難しいことがあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005405",
+          "english": "The company has a long tradition.",
+          "japanese": "会社には長い伝統があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005406",
+          "english": "They maintain cultural traditions.",
+          "japanese": "彼らは文化的伝統を維持しています。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005407",
+          "english": "This tradition dates back centuries.",
+          "japanese": "この伝統は何世紀も前に遡ります。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005408",
+          "english": "Wedding traditions vary by culture.",
+          "japanese": "結婚の伝統は文化によって異なります。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005409",
+          "english": "It's a Christmas tradition in our family.",
+          "japanese": "それは私たちの家族のクリスマスの伝統です。",
+          "category": "家族"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005410",
+          "english": "The school preserves old traditions.",
+          "japanese": "学校は古い伝統を保存しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005411",
+          "english": "Tradition meets modern innovation.",
+          "japanese": "伝統が現代の革新と出会います。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005412",
+          "english": "They honor ancestral traditions.",
+          "japanese": "彼らは祖先の伝統を尊重します。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005413",
+          "english": "The tradition continues today.",
+          "japanese": "その伝統は今日も続いています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005414",
+          "english": "We respect local traditions.",
+          "japanese": "地域の伝統を尊重します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005415",
+          "english": "Tradition and change coexist.",
+          "japanese": "伝統と変化が共存します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005416",
+          "english": "The tea ceremony is a Japanese tradition.",
+          "japanese": "茶道は日本の伝統です。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005417",
+          "english": "They started a new tradition.",
+          "japanese": "彼らは新しい伝統を始めました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005418",
+          "english": "Oral traditions pass down stories.",
+          "japanese": "口承伝統が物語を伝えます。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005419",
+          "english": "The tradition has deep meaning.",
+          "japanese": "その伝統には深い意味があります。",
+          "category": "文化"
+        },
+        {
+          "id": "10000054-0054-0054-0054-000000005420",
+          "english": "Holiday traditions bring families together.",
+          "japanese": "休日の伝統が家族を結びつけます。",
+          "category": "家族"
+        }
+      ],
+      "createdAt": 793213200.000000
+    },
+    {
+      "id": "10000055-0055-0055-0055-000000000055",
+      "word": "fundamental",
+      "meaning": "基本的な、根本的な",
+      "phonetic": "ˌfʌn.dəˈmen.təl",
+      "sentences": [
+        {
+          "id": "10000055-0055-0055-0055-000000005501",
+          "english": "This is a fundamental principle.",
+          "japanese": "これは基本原則です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005502",
+          "english": "Education is a fundamental right.",
+          "japanese": "教育は基本的権利です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005503",
+          "english": "We need fundamental change.",
+          "japanese": "根本的な変化が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005504",
+          "english": "Trust is fundamental to relationships.",
+          "japanese": "信頼は関係の基礎です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005505",
+          "english": "Learn the fundamental concepts first.",
+          "japanese": "まず基本概念を学んでください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005506",
+          "english": "There's a fundamental difference.",
+          "japanese": "根本的な違いがあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005507",
+          "english": "The course covers fundamental skills.",
+          "japanese": "コースは基礎スキルをカバーします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005508",
+          "english": "This is fundamental to our success.",
+          "japanese": "これは私たちの成功の基礎です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005509",
+          "english": "They address fundamental issues.",
+          "japanese": "彼らは根本的な問題に取り組みます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005510",
+          "english": "Human rights are fundamental.",
+          "japanese": "人権は基本的なものです。",
+          "category": "政治"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005511",
+          "english": "The book explains fundamental theory.",
+          "japanese": "その本は基礎理論を説明します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005512",
+          "english": "Communication is fundamental in business.",
+          "japanese": "ビジネスではコミュニケーションが基本です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005513",
+          "english": "We made fundamental improvements.",
+          "japanese": "根本的な改善を行いました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005514",
+          "english": "The problem is fundamental.",
+          "japanese": "問題は根本的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005515",
+          "english": "These are fundamental values.",
+          "japanese": "これらは基本的な価値観です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005516",
+          "english": "Respect is fundamental in society.",
+          "japanese": "尊重は社会の基本です。",
+          "category": "社会"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005517",
+          "english": "The research examines fundamental questions.",
+          "japanese": "研究は根本的な疑問を調べます。",
+          "category": "科学"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005518",
+          "english": "Safety is fundamental to operations.",
+          "japanese": "安全は業務の基本です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005519",
+          "english": "They focus on fundamental principles.",
+          "japanese": "彼らは基本原則に焦点を当てます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000055-0055-0055-0055-000000005520",
+          "english": "This course teaches fundamental programming.",
+          "japanese": "このコースは基礎プログラミングを教えます。",
+          "category": "教育"
+        }
+      ],
+      "createdAt": 793216800.000000
+    },
+    {
+      "id": "10000056-0056-0056-0056-000000000056",
+      "word": "obtain",
+      "meaning": "得る、入手する",
+      "phonetic": "əbˈteɪn",
+      "sentences": [
+        {
+          "id": "10000056-0056-0056-0056-000000005601",
+          "english": "How can I obtain a visa?",
+          "japanese": "どのようにビザを取得できますか？",
+          "category": "旅行"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005602",
+          "english": "She obtained excellent results.",
+          "japanese": "彼女は優れた結果を得ました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005603",
+          "english": "We need to obtain permission first.",
+          "japanese": "まず許可を得る必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005604",
+          "english": "He obtained a university degree.",
+          "japanese": "彼は大学の学位を取得しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005605",
+          "english": "You can obtain information online.",
+          "japanese": "オンラインで情報を入手できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005606",
+          "english": "They obtained funding for research.",
+          "japanese": "彼らは研究資金を獲得しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005607",
+          "english": "The company obtained new clients.",
+          "japanese": "会社は新しい顧客を獲得しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005608",
+          "english": "I obtained the documents yesterday.",
+          "japanese": "昨日書類を入手しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005609",
+          "english": "Where did you obtain this information?",
+          "japanese": "どこでこの情報を得ましたか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005610",
+          "english": "She obtained a driver's license.",
+          "japanese": "彼女は運転免許証を取得しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005611",
+          "english": "We obtained approval from management.",
+          "japanese": "経営陣から承認を得ました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005612",
+          "english": "The data was obtained through surveys.",
+          "japanese": "データは調査を通じて得られました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005613",
+          "english": "He obtained citizenship last year.",
+          "japanese": "彼は昨年市民権を取得しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005614",
+          "english": "They obtained a patent for the invention.",
+          "japanese": "彼らは発明の特許を取得しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005615",
+          "english": "Obtaining consent is mandatory.",
+          "japanese": "同意を得ることは必須です。",
+          "category": "法律"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005616",
+          "english": "We obtained all necessary permits.",
+          "japanese": "必要な許可をすべて取得しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005617",
+          "english": "She obtained the certificate easily.",
+          "japanese": "彼女は簡単に証明書を取得しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005618",
+          "english": "They obtained valuable experience.",
+          "japanese": "彼らは貴重な経験を得ました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005619",
+          "english": "The team obtained crucial evidence.",
+          "japanese": "チームは重要な証拠を入手しました。",
+          "category": "法律"
+        },
+        {
+          "id": "10000056-0056-0056-0056-000000005620",
+          "english": "Products can be obtained at stores.",
+          "japanese": "製品は店舗で入手できます。",
+          "category": "買い物"
+        }
+      ],
+      "createdAt": 793220400.000000
+    },
+    {
+      "id": "10000057-0057-0057-0057-000000000057",
+      "word": "purchase",
+      "meaning": "購入する、購入",
+      "phonetic": "ˈpɜː.tʃəs",
+      "sentences": [
+        {
+          "id": "10000057-0057-0057-0057-000000005701",
+          "english": "I'd like to purchase this item.",
+          "japanese": "この商品を購入したいです。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005702",
+          "english": "The purchase was completed successfully.",
+          "japanese": "購入が正常に完了しました。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005703",
+          "english": "Keep your purchase receipt.",
+          "japanese": "購入レシートを保管してください。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005704",
+          "english": "They purchased new equipment.",
+          "japanese": "彼らは新しい設備を購入しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005705",
+          "english": "Online purchases are convenient.",
+          "japanese": "オンライン購入は便利です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005706",
+          "english": "The company purchased a building.",
+          "japanese": "会社は建物を購入しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005707",
+          "english": "You can purchase tickets online.",
+          "japanese": "オンラインでチケットを購入できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005708",
+          "english": "She made a large purchase.",
+          "japanese": "彼女は大きな買い物をしました。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005709",
+          "english": "The purchase price includes tax.",
+          "japanese": "購入価格には税金が含まれます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005710",
+          "english": "We purchased software licenses.",
+          "japanese": "ソフトウェアライセンスを購入しました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005711",
+          "english": "What did you purchase?",
+          "japanese": "何を購入しましたか？",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005712",
+          "english": "They purchased supplies in bulk.",
+          "japanese": "彼らは大量に消耗品を購入しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005713",
+          "english": "The purchase department handles orders.",
+          "japanese": "購買部が注文を処理します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005714",
+          "english": "We offer purchase assistance.",
+          "japanese": "購入サポートを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005715",
+          "english": "He purchased a new car.",
+          "japanese": "彼は新車を購入しました。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005716",
+          "english": "The purchase was a good investment.",
+          "japanese": "その購入は良い投資でした。",
+          "category": "金融"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005717",
+          "english": "They purchased the company last year.",
+          "japanese": "彼らは昨年その会社を買収しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005718",
+          "english": "Purchase orders need approval.",
+          "japanese": "発注書には承認が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005719",
+          "english": "She regretted the purchase.",
+          "japanese": "彼女は購入を後悔しました。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000057-0057-0057-0057-000000005720",
+          "english": "We purchased materials locally.",
+          "japanese": "地元で材料を購入しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793224000.000000
+    },
+    {
+      "id": "10000058-0058-0058-0058-000000000058",
+      "word": "reliable",
+      "meaning": "信頼できる",
+      "phonetic": "rɪˈlaɪ.ə.bəl",
+      "sentences": [
+        {
+          "id": "10000058-0058-0058-0058-000000005801",
+          "english": "She's a very reliable person.",
+          "japanese": "彼女は非常に信頼できる人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005802",
+          "english": "We need reliable information.",
+          "japanese": "信頼できる情報が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005803",
+          "english": "This car is very reliable.",
+          "japanese": "この車は非常に信頼性があります。",
+          "category": "自動車"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005804",
+          "english": "He's a reliable employee.",
+          "japanese": "彼は信頼できる従業員です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005805",
+          "english": "The service is fast and reliable.",
+          "japanese": "サービスは速くて信頼できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005806",
+          "english": "We use reliable suppliers.",
+          "japanese": "信頼できる供給業者を使用しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005807",
+          "english": "Is this source reliable?",
+          "japanese": "この情報源は信頼できますか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005808",
+          "english": "The system is highly reliable.",
+          "japanese": "システムは非常に信頼性が高いです。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005809",
+          "english": "They provide reliable support.",
+          "japanese": "彼らは信頼できるサポートを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005810",
+          "english": "We need a reliable solution.",
+          "japanese": "信頼できる解決策が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005811",
+          "english": "The data is not reliable.",
+          "japanese": "データは信頼できません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005812",
+          "english": "She's proven to be reliable.",
+          "japanese": "彼女は信頼できることが証明されています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005813",
+          "english": "The equipment is quite reliable.",
+          "japanese": "設備はかなり信頼性があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005814",
+          "english": "We offer reliable delivery.",
+          "japanese": "信頼できる配送を提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005815",
+          "english": "Public transport is generally reliable.",
+          "japanese": "公共交通機関は一般的に信頼できます。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005816",
+          "english": "He's always been reliable.",
+          "japanese": "彼はいつも信頼できました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005817",
+          "english": "The internet connection is reliable.",
+          "japanese": "インターネット接続は安定しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005818",
+          "english": "We prioritize reliable quality.",
+          "japanese": "信頼できる品質を優先します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005819",
+          "english": "The test produces reliable results.",
+          "japanese": "テストは信頼できる結果を生み出します。",
+          "category": "科学"
+        },
+        {
+          "id": "10000058-0058-0058-0058-000000005820",
+          "english": "Choose a reliable brand.",
+          "japanese": "信頼できるブランドを選んでください。",
+          "category": "買い物"
+        }
+      ],
+      "createdAt": 793227600.000000
+    },
+    {
+      "id": "10000059-0059-0059-0059-000000000059",
+      "word": "accurate",
+      "meaning": "正確な",
+      "phonetic": "ˈæk.jər.ət",
+      "sentences": [
+        {
+          "id": "10000059-0059-0059-0059-000000005901",
+          "english": "The information must be accurate.",
+          "japanese": "情報は正確でなければなりません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005902",
+          "english": "She gave an accurate description.",
+          "japanese": "彼女は正確な説明をしました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005903",
+          "english": "The test is highly accurate.",
+          "japanese": "テストは非常に正確です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005904",
+          "english": "We need accurate measurements.",
+          "japanese": "正確な測定が必要です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005905",
+          "english": "Is this translation accurate?",
+          "japanese": "この翻訳は正確ですか？",
+          "category": "教育"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005906",
+          "english": "The forecast wasn't very accurate.",
+          "japanese": "予報はあまり正確ではありませんでした。",
+          "category": "天気"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005907",
+          "english": "Please provide accurate data.",
+          "japanese": "正確なデータを提供してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005908",
+          "english": "The report is thoroughly accurate.",
+          "japanese": "報告書は完全に正確です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005909",
+          "english": "He's known for accurate predictions.",
+          "japanese": "彼は正確な予測で知られています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005910",
+          "english": "The clock is very accurate.",
+          "japanese": "時計は非常に正確です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005911",
+          "english": "We maintain accurate records.",
+          "japanese": "正確な記録を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005912",
+          "english": "The map is accurate and detailed.",
+          "japanese": "地図は正確で詳細です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005913",
+          "english": "She gave an accurate estimate.",
+          "japanese": "彼女は正確な見積もりを出しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005914",
+          "english": "The GPS is remarkably accurate.",
+          "japanese": "GPSは驚くほど正確です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005915",
+          "english": "Accurate documentation is essential.",
+          "japanese": "正確な文書化が不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005916",
+          "english": "The instrument provides accurate readings.",
+          "japanese": "機器は正確な測定値を提供します。",
+          "category": "科学"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005917",
+          "english": "His account was perfectly accurate.",
+          "japanese": "彼の説明は完全に正確でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005918",
+          "english": "We ensure accurate billing.",
+          "japanese": "正確な請求を保証します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005919",
+          "english": "The sensor is extremely accurate.",
+          "japanese": "センサーは極めて正確です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000059-0059-0059-0059-000000005920",
+          "english": "Accurate timing is crucial.",
+          "japanese": "正確なタイミングが重要です。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793231200.000000
+    },
+    {
+      "id": "10000060-0060-0060-0060-000000000060",
+      "word": "appreciate",
+      "meaning": "感謝する、正しく理解する",
+      "phonetic": "əˈpriː.ʃi.eɪt",
+      "sentences": [
+        {
+          "id": "10000060-0060-0060-0060-000000006001",
+          "english": "I appreciate your help.",
+          "japanese": "あなたの助けに感謝します。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006002",
+          "english": "We appreciate your patience.",
+          "japanese": "ご辛抱いただき感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006003",
+          "english": "She appreciates good music.",
+          "japanese": "彼女は良い音楽を理解します。",
+          "category": "音楽"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006004",
+          "english": "I'd appreciate your feedback.",
+          "japanese": "フィードバックをいただけると嬉しいです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006005",
+          "english": "The value has appreciated significantly.",
+          "japanese": "価値が大幅に上昇しました。",
+          "category": "金融"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006006",
+          "english": "We truly appreciate your business.",
+          "japanese": "お取引に心から感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006007",
+          "english": "He appreciates fine art.",
+          "japanese": "彼は美術を理解します。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006008",
+          "english": "I don't think you appreciate the problem.",
+          "japanese": "あなたは問題を正しく理解していないと思います。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006009",
+          "english": "They appreciate hard work.",
+          "japanese": "彼らは努力を評価します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006010",
+          "english": "I appreciate your concern.",
+          "japanese": "ご心配いただき感謝します。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006011",
+          "english": "The property will appreciate over time.",
+          "japanese": "不動産は時間とともに価値が上がります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006012",
+          "english": "We appreciate all suggestions.",
+          "japanese": "すべての提案に感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006013",
+          "english": "She doesn't appreciate being interrupted.",
+          "japanese": "彼女は中断されるのを嫌います。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006014",
+          "english": "I appreciate good food.",
+          "japanese": "私は良い食べ物を味わいます。",
+          "category": "料理"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006015",
+          "english": "Your support is greatly appreciated.",
+          "japanese": "あなたのサポートは大変感謝されています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006016",
+          "english": "He appreciates quality craftsmanship.",
+          "japanese": "彼は高品質な職人技を評価します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006017",
+          "english": "We appreciate your understanding.",
+          "japanese": "ご理解いただき感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006018",
+          "english": "I appreciate the opportunity.",
+          "japanese": "機会をいただき感謝します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006019",
+          "english": "She appreciates nature's beauty.",
+          "japanese": "彼女は自然の美しさを理解します。",
+          "category": "自然"
+        },
+        {
+          "id": "10000060-0060-0060-0060-000000006020",
+          "english": "I'd really appreciate it.",
+          "japanese": "本当に感謝します。",
+          "category": "日常会話"
+        }
+      ],
+      "createdAt": 793234800.000000
+    },
+    {
+      "id": "10000061-0061-0061-0061-000000000061",
+      "word": "concentrate",
+      "meaning": "集中する",
+      "phonetic": "ˈkɑːn.sən.treɪt",
+      "sentences": [
+        {
+          "id": "10000061-0061-0061-0061-000000006101",
+          "english": "I need to concentrate on my work.",
+          "japanese": "仕事に集中する必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006102",
+          "english": "Please concentrate during the lesson.",
+          "japanese": "授業中は集中してください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006103",
+          "english": "She can't concentrate with noise.",
+          "japanese": "彼女は騒音があると集中できません。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006104",
+          "english": "Let's concentrate on the main issue.",
+          "japanese": "主要な問題に集中しましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006105",
+          "english": "It's hard to concentrate when tired.",
+          "japanese": "疲れていると集中するのは難しいです。",
+          "category": "健康"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006106",
+          "english": "The company concentrates on quality.",
+          "japanese": "会社は品質に注力しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006107",
+          "english": "Concentrate the solution before use.",
+          "japanese": "使用前に溶液を濃縮してください。",
+          "category": "科学"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006108",
+          "english": "He concentrated his efforts on the project.",
+          "japanese": "彼はプロジェクトに努力を集中させました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006109",
+          "english": "I'm trying to concentrate.",
+          "japanese": "集中しようとしています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006110",
+          "english": "Meditation helps you concentrate.",
+          "japanese": "瞑想は集中力を高めます。",
+          "category": "健康"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006111",
+          "english": "Power is concentrated in few hands.",
+          "japanese": "権力は少数の手に集中しています。",
+          "category": "政治"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006112",
+          "english": "We must concentrate our resources.",
+          "japanese": "リソースを集中させなければなりません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006113",
+          "english": "Students need to concentrate better.",
+          "japanese": "学生はもっと集中する必要があります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006114",
+          "english": "The population concentrates in cities.",
+          "japanese": "人口は都市に集中しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006115",
+          "english": "Concentrate on one task at a time.",
+          "japanese": "一度に一つのタスクに集中してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006116",
+          "english": "She concentrated juice for the recipe.",
+          "japanese": "彼女はレシピのためにジュースを濃縮しました。",
+          "category": "料理"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006117",
+          "english": "Wealth is highly concentrated.",
+          "japanese": "富は高度に集中しています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006118",
+          "english": "He concentrates well under pressure.",
+          "japanese": "彼はプレッシャー下でよく集中します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006119",
+          "english": "The team concentrated their attack.",
+          "japanese": "チームは攻撃を集中させました。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000061-0061-0061-0061-000000006120",
+          "english": "I can't concentrate with this headache.",
+          "japanese": "この頭痛では集中できません。",
+          "category": "健康"
+        }
+      ],
+      "createdAt": 793238400.000000
+    },
+    {
+      "id": "10000062-0062-0062-0062-000000000062",
+      "word": "convenient",
+      "meaning": "便利な",
+      "phonetic": "kənˈviː.ni.ənt",
+      "sentences": [
+        {
+          "id": "10000062-0062-0062-0062-000000006201",
+          "english": "The location is very convenient.",
+          "japanese": "場所はとても便利です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006202",
+          "english": "Online shopping is convenient.",
+          "japanese": "オンラインショッピングは便利です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006203",
+          "english": "Is this time convenient for you?",
+          "japanese": "この時間はご都合よろしいですか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006204",
+          "english": "The hotel is in a convenient location.",
+          "japanese": "ホテルは便利な場所にあります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006205",
+          "english": "Credit cards are very convenient.",
+          "japanese": "クレジットカードはとても便利です。",
+          "category": "金融"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006206",
+          "english": "The store offers convenient hours.",
+          "japanese": "店は便利な営業時間です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006207",
+          "english": "This app is extremely convenient.",
+          "japanese": "このアプリは極めて便利です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006208",
+          "english": "Choose the most convenient option.",
+          "japanese": "最も便利な選択肢を選んでください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006209",
+          "english": "Public transport is convenient here.",
+          "japanese": "ここでは公共交通機関が便利です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006210",
+          "english": "The service is fast and convenient.",
+          "japanese": "サービスは速くて便利です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006211",
+          "english": "It's convenient to have everything nearby.",
+          "japanese": "すべてが近くにあると便利です。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006212",
+          "english": "The new system is more convenient.",
+          "japanese": "新しいシステムはより便利です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006213",
+          "english": "Convenient payment methods are available.",
+          "japanese": "便利な支払い方法が利用できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006214",
+          "english": "The apartment is conveniently located.",
+          "japanese": "アパートは便利な場所にあります。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006215",
+          "english": "When would be convenient?",
+          "japanese": "いつがご都合よろしいですか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006216",
+          "english": "The service offers convenient delivery.",
+          "japanese": "サービスは便利な配達を提供します。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006217",
+          "english": "It's convenient for commuting.",
+          "japanese": "通勤に便利です。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006218",
+          "english": "The parking is very convenient.",
+          "japanese": "駐車場はとても便利です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006219",
+          "english": "Technology makes life more convenient.",
+          "japanese": "技術は生活をより便利にします。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000062-0062-0062-0062-000000006220",
+          "english": "The feature is quite convenient.",
+          "japanese": "その機能はかなり便利です。",
+          "category": "テクノロジー"
+        }
+      ],
+      "createdAt": 793242000.000000
+    },
+    {
+      "id": "10000063-0063-0063-0063-000000000063",
+      "word": "consistent",
+      "meaning": "一貫した、矛盾のない",
+      "phonetic": "kənˈsɪs.tənt",
+      "sentences": [
+        {
+          "id": "10000063-0063-0063-0063-000000006301",
+          "english": "We need consistent quality.",
+          "japanese": "一貫した品質が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006302",
+          "english": "Her performance is consistently good.",
+          "japanese": "彼女のパフォーマンスは一貫して良いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006303",
+          "english": "The results are consistent with predictions.",
+          "japanese": "結果は予測と一致しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006304",
+          "english": "Be consistent in your approach.",
+          "japanese": "アプローチに一貫性を持ってください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006305",
+          "english": "The data shows consistent patterns.",
+          "japanese": "データは一貫したパターンを示しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006306",
+          "english": "He's a consistent performer.",
+          "japanese": "彼は安定したパフォーマーです。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006307",
+          "english": "We maintain consistent standards.",
+          "japanese": "一貫した基準を維持しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006308",
+          "english": "The story is consistent throughout.",
+          "japanese": "話は全体を通して一貫しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006309",
+          "english": "Consistent practice leads to improvement.",
+          "japanese": "継続的な練習が上達につながります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006310",
+          "english": "The brand delivers consistent quality.",
+          "japanese": "そのブランドは一貫した品質を提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006311",
+          "english": "Their messaging is consistent.",
+          "japanese": "彼らのメッセージングは一貫しています。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006312",
+          "english": "The findings are consistent.",
+          "japanese": "調査結果は一致しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006313",
+          "english": "Parents should be consistent with rules.",
+          "japanese": "親は規則に一貫性を持つべきです。",
+          "category": "家族"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006314",
+          "english": "The team shows consistent effort.",
+          "japanese": "チームは一貫した努力を示します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006315",
+          "english": "We need consistent communication.",
+          "japanese": "一貫したコミュニケーションが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006316",
+          "english": "The weather has been consistently warm.",
+          "japanese": "天気は一貫して暖かいです。",
+          "category": "天気"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006317",
+          "english": "She's consistently punctual.",
+          "japanese": "彼女は常に時間を守ります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006318",
+          "english": "The evidence is consistent.",
+          "japanese": "証拠は矛盾していません。",
+          "category": "法律"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006319",
+          "english": "They provide consistent service.",
+          "japanese": "彼らは一貫したサービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000063-0063-0063-0063-000000006320",
+          "english": "Consistency is key to success.",
+          "japanese": "一貫性が成功の鍵です。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793245600.000000
+    },
+    {
+      "id": "10000064-0064-0064-0064-000000000064",
+      "word": "reasonable",
+      "meaning": "合理的な、妥当な",
+      "phonetic": "ˈriː.zən.ə.bəl",
+      "sentences": [
+        {
+          "id": "10000064-0064-0064-0064-000000006401",
+          "english": "The price is very reasonable.",
+          "japanese": "価格は非常に妥当です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006402",
+          "english": "That's a reasonable suggestion.",
+          "japanese": "それは合理的な提案です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006403",
+          "english": "Be reasonable about your expectations.",
+          "japanese": "期待については現実的にしてください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006404",
+          "english": "He's a reasonable person.",
+          "japanese": "彼は理性的な人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006405",
+          "english": "The request seems reasonable.",
+          "japanese": "要求は妥当に思えます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006406",
+          "english": "We offer reasonable rates.",
+          "japanese": "妥当な料金を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006407",
+          "english": "It's reasonable to assume success.",
+          "japanese": "成功を想定するのは妥当です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006408",
+          "english": "The deadline is reasonable.",
+          "japanese": "締め切りは妥当です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006409",
+          "english": "She made a reasonable offer.",
+          "japanese": "彼女は妥当な申し出をしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006410",
+          "english": "Let's find a reasonable solution.",
+          "japanese": "妥当な解決策を見つけましょう。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006411",
+          "english": "The explanation is reasonable.",
+          "japanese": "説明は合理的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006412",
+          "english": "They charge reasonable fees.",
+          "japanese": "彼らは妥当な料金を請求します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006413",
+          "english": "It's a reasonable distance to walk.",
+          "japanese": "歩くには妥当な距離です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006414",
+          "english": "The terms are reasonable.",
+          "japanese": "条件は妥当です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006415",
+          "english": "Let's be reasonable about this.",
+          "japanese": "これについて理性的になりましょう。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006416",
+          "english": "The quality is reasonable for the price.",
+          "japanese": "価格の割に品質は妥当です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006417",
+          "english": "She's always reasonable in negotiations.",
+          "japanese": "彼女は交渉で常に理性的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006418",
+          "english": "That's a reasonable amount of time.",
+          "japanese": "それは妥当な時間です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006419",
+          "english": "The proposal sounds reasonable.",
+          "japanese": "提案は妥当に聞こえます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000064-0064-0064-0064-000000006420",
+          "english": "We need a reasonable compromise.",
+          "japanese": "妥当な妥協点が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793249200.000000
+    },
+    {
+      "id": "10000065-0065-0065-0065-000000000065",
+      "word": "essential",
+      "meaning": "不可欠な、本質的な",
+      "phonetic": "ɪˈsen.ʃəl",
+      "sentences": [
+        {
+          "id": "10000065-0065-0065-0065-000000006501",
+          "english": "Water is essential for life.",
+          "japanese": "水は生命に不可欠です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006502",
+          "english": "Good communication is essential.",
+          "japanese": "良いコミュニケーションは不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006503",
+          "english": "It's essential to read the instructions.",
+          "japanese": "説明書を読むことは必須です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006504",
+          "english": "These are essential items.",
+          "japanese": "これらは必需品です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006505",
+          "english": "Teamwork is essential for success.",
+          "japanese": "成功にはチームワークが不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006506",
+          "english": "The essential facts are clear.",
+          "japanese": "本質的な事実は明確です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006507",
+          "english": "Pack only essential items.",
+          "japanese": "必要なものだけを詰めてください。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006508",
+          "english": "Exercise is essential for health.",
+          "japanese": "運動は健康に不可欠です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006509",
+          "english": "It's essential that you attend.",
+          "japanese": "出席することが必須です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006510",
+          "english": "Education is essential for development.",
+          "japanese": "教育は発展に不可欠です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006511",
+          "english": "Time management is essential.",
+          "japanese": "時間管理は必須です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006512",
+          "english": "The essential information is here.",
+          "japanese": "必要な情報はここにあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006513",
+          "english": "Sleep is essential for recovery.",
+          "japanese": "睡眠は回復に不可欠です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006514",
+          "english": "These skills are essential.",
+          "japanese": "これらのスキルは必須です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006515",
+          "english": "Trust is essential in relationships.",
+          "japanese": "関係には信頼が不可欠です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006516",
+          "english": "The essential point is clear.",
+          "japanese": "要点は明確です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006517",
+          "english": "Safety equipment is essential.",
+          "japanese": "安全装備は必須です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006518",
+          "english": "It's essential to plan ahead.",
+          "japanese": "事前に計画することが不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006519",
+          "english": "This feature is essential.",
+          "japanese": "この機能は必須です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000065-0065-0065-0065-000000006520",
+          "english": "Oxygen is essential for breathing.",
+          "japanese": "酸素は呼吸に不可欠です。",
+          "category": "科学"
+        }
+      ],
+      "createdAt": 793252800.000000
+    },
+    {
+      "id": "10000066-0066-0066-0066-000000000066",
+      "word": "objective",
+      "meaning": "客観的な、目的",
+      "phonetic": "əbˈdʒek.tɪv",
+      "sentences": [
+        {
+          "id": "10000066-0066-0066-0066-000000006601",
+          "english": "Our objective is to improve quality.",
+          "japanese": "我々の目的は品質を改善することです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006602",
+          "english": "Try to be objective.",
+          "japanese": "客観的になるようにしてください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006603",
+          "english": "What are your main objectives?",
+          "japanese": "主な目標は何ですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006604",
+          "english": "The report is objective and fair.",
+          "japanese": "レポートは客観的で公平です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006605",
+          "english": "We achieved our objectives.",
+          "japanese": "目標を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006606",
+          "english": "Scientific research must be objective.",
+          "japanese": "科学研究は客観的でなければなりません。",
+          "category": "科学"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006607",
+          "english": "The objective evidence supports this.",
+          "japanese": "客観的な証拠がこれを裏付けます。",
+          "category": "法律"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006608",
+          "english": "Set clear objectives for the team.",
+          "japanese": "チームに明確な目標を設定してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006609",
+          "english": "It's hard to remain objective.",
+          "japanese": "客観的でいるのは難しいです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006610",
+          "english": "The primary objective was reached.",
+          "japanese": "主要な目的が達成されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006611",
+          "english": "We need an objective opinion.",
+          "japanese": "客観的な意見が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006612",
+          "english": "The objective analysis was helpful.",
+          "japanese": "客観的な分析が役に立ちました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006613",
+          "english": "Define your objectives clearly.",
+          "japanese": "目標を明確に定義してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006614",
+          "english": "Journalists should be objective.",
+          "japanese": "ジャーナリストは客観的であるべきです。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006615",
+          "english": "The project has specific objectives.",
+          "japanese": "プロジェクトには特定の目標があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006616",
+          "english": "An objective assessment is necessary.",
+          "japanese": "客観的な評価が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006617",
+          "english": "The objective facts are undeniable.",
+          "japanese": "客観的事実は否定できません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006618",
+          "english": "We share common objectives.",
+          "japanese": "共通の目標を共有しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006619",
+          "english": "The study uses objective measures.",
+          "japanese": "研究は客観的な尺度を使用します。",
+          "category": "科学"
+        },
+        {
+          "id": "10000066-0066-0066-0066-000000006620",
+          "english": "His objective was to help others.",
+          "japanese": "彼の目的は他人を助けることでした。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793256400.000000
+    },
+    {
+      "id": "10000067-0067-0067-0067-000000000067",
+      "word": "individual",
+      "meaning": "個人、個々の",
+      "phonetic": "ˌɪn.dəˈvɪdʒ.u.əl",
+      "sentences": [
+        {
+          "id": "10000067-0067-0067-0067-000000006701",
+          "english": "Every individual is unique.",
+          "japanese": "すべての個人はユニークです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006702",
+          "english": "We offer individual attention.",
+          "japanese": "個別の対応を提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006703",
+          "english": "Individual needs vary greatly.",
+          "japanese": "個々のニーズは大きく異なります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006704",
+          "english": "She's a talented individual.",
+          "japanese": "彼女は才能ある個人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006705",
+          "english": "Individual rights are protected.",
+          "japanese": "個人の権利は保護されています。",
+          "category": "法律"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006706",
+          "english": "The course offers individual tutoring.",
+          "japanese": "コースは個別指導を提供します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006707",
+          "english": "Each individual case is different.",
+          "japanese": "個々のケースはそれぞれ異なります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006708",
+          "english": "We value individual contributions.",
+          "japanese": "個人の貢献を大切にしています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006709",
+          "english": "Individual performance is tracked.",
+          "japanese": "個人のパフォーマンスが追跡されます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006710",
+          "english": "The restaurant has individual tables.",
+          "japanese": "レストランには個別のテーブルがあります。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006711",
+          "english": "Individual freedom is important.",
+          "japanese": "個人の自由は重要です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006712",
+          "english": "We offer individual packages.",
+          "japanese": "個別パッケージを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006713",
+          "english": "Each individual has different strengths.",
+          "japanese": "各個人には異なる強みがあります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006714",
+          "english": "The program is tailored to individuals.",
+          "japanese": "プログラムは個人に合わせて調整されます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006715",
+          "english": "Individual opinions matter.",
+          "japanese": "個人の意見は重要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006716",
+          "english": "The products are sold individually.",
+          "japanese": "製品は個別に販売されています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006717",
+          "english": "Individual responsibility is key.",
+          "japanese": "個人の責任が鍵です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006718",
+          "english": "She's a remarkable individual.",
+          "japanese": "彼女は非凡な個人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006719",
+          "english": "We respect individual choices.",
+          "japanese": "個人の選択を尊重します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000067-0067-0067-0067-000000006720",
+          "english": "Individual sessions are available.",
+          "japanese": "個別セッションが利用できます。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793260000.000000
+    },
+    {
+      "id": "10000068-0068-0068-0068-000000000068",
+      "word": "furthermore",
+      "meaning": "さらに、その上",
+      "phonetic": "ˌfɜː.ðɚˈmɔːr",
+      "sentences": [
+        {
+          "id": "10000068-0068-0068-0068-000000006801",
+          "english": "Furthermore, we need more time.",
+          "japanese": "さらに、もっと時間が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006802",
+          "english": "The plan is expensive. Furthermore, it's risky.",
+          "japanese": "計画は高額です。さらに、リスクがあります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006803",
+          "english": "Furthermore, this violates policy.",
+          "japanese": "さらに、これは方針に違反しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006804",
+          "english": "It's late. Furthermore, it's raining.",
+          "japanese": "遅いです。さらに、雨が降っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006805",
+          "english": "Furthermore, I disagree with the approach.",
+          "japanese": "さらに、私はそのアプローチに反対です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006806",
+          "english": "The product is cheap. Furthermore, it's durable.",
+          "japanese": "製品は安いです。さらに、耐久性があります。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006807",
+          "english": "Furthermore, research supports this.",
+          "japanese": "さらに、研究がこれを支持しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006808",
+          "english": "He's qualified. Furthermore, he's experienced.",
+          "japanese": "彼は資格があります。さらに、経験豊富です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006809",
+          "english": "Furthermore, costs are increasing.",
+          "japanese": "さらに、コストが増加しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006810",
+          "english": "It's convenient. Furthermore, it's affordable.",
+          "japanese": "便利です。さらに、手頃です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006811",
+          "english": "Furthermore, safety is a concern.",
+          "japanese": "さらに、安全性が懸念事項です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006812",
+          "english": "The method works. Furthermore, it's simple.",
+          "japanese": "方法は有効です。さらに、シンプルです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006813",
+          "english": "Furthermore, this benefits everyone.",
+          "japanese": "さらに、これは皆に利益をもたらします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006814",
+          "english": "It's healthy. Furthermore, it tastes good.",
+          "japanese": "健康的です。さらに、美味しいです。",
+          "category": "健康"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006815",
+          "english": "Furthermore, we have evidence.",
+          "japanese": "さらに、証拠があります。",
+          "category": "法律"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006816",
+          "english": "The system is fast. Furthermore, it's reliable.",
+          "japanese": "システムは速いです。さらに、信頼性があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006817",
+          "english": "Furthermore, competition is intense.",
+          "japanese": "さらに、競争が激しいです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006818",
+          "english": "She's skilled. Furthermore, she's dedicated.",
+          "japanese": "彼女は熟練しています。さらに、献身的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006819",
+          "english": "Furthermore, time is running out.",
+          "japanese": "さらに、時間がなくなっています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000068-0068-0068-0068-000000006820",
+          "english": "The location is perfect. Furthermore, it's quiet.",
+          "japanese": "場所は完璧です。さらに、静かです。",
+          "category": "不動産"
+        }
+      ],
+      "createdAt": 793263600.000000
+    },
+    {
+      "id": "10000069-0069-0069-0069-000000000069",
+      "word": "therefore",
+      "meaning": "それゆえ、したがって",
+      "phonetic": "ˈðer.fɔːr",
+      "sentences": [
+        {
+          "id": "10000069-0069-0069-0069-000000006901",
+          "english": "It's raining; therefore, I'll stay home.",
+          "japanese": "雨が降っています。したがって、家にいます。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006902",
+          "english": "She's qualified; therefore, she got the job.",
+          "japanese": "彼女は資格があります。それゆえ、仕事を得ました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006903",
+          "english": "The product failed; therefore, we refunded.",
+          "japanese": "製品が故障しました。したがって、返金しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006904",
+          "english": "I think; therefore, I am.",
+          "japanese": "我思う、故に我あり。",
+          "category": "哲学"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006905",
+          "english": "Therefore, we must act now.",
+          "japanese": "したがって、今行動しなければなりません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006906",
+          "english": "Sales dropped; therefore, we adjusted prices.",
+          "japanese": "売上が減りました。そのため、価格を調整しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006907",
+          "english": "The risk is high; therefore, be careful.",
+          "japanese": "リスクが高いです。したがって、注意してください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006908",
+          "english": "Therefore, the answer is clear.",
+          "japanese": "したがって、答えは明確です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006909",
+          "english": "He studied hard; therefore, he passed.",
+          "japanese": "彼は一生懸命勉強しました。したがって、合格しました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006910",
+          "english": "Therefore, we recommend this option.",
+          "japanese": "したがって、このオプションをお勧めします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006911",
+          "english": "The evidence is conclusive; therefore, guilty.",
+          "japanese": "証拠は決定的です。したがって、有罪です。",
+          "category": "法律"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006912",
+          "english": "Therefore, no changes are needed.",
+          "japanese": "したがって、変更は必要ありません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006913",
+          "english": "Demand increased; therefore, prices rose.",
+          "japanese": "需要が増えました。したがって、価格が上がりました。",
+          "category": "経済"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006914",
+          "english": "Therefore, we conclude the meeting.",
+          "japanese": "したがって、会議を終了します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006915",
+          "english": "The system crashed; therefore, we lost data.",
+          "japanese": "システムがクラッシュしました。そのため、データが失われました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006916",
+          "english": "Therefore, the project was cancelled.",
+          "japanese": "したがって、プロジェクトはキャンセルされました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006917",
+          "english": "Results improved; therefore, we continue.",
+          "japanese": "結果が改善しました。したがって、続けます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006918",
+          "english": "Therefore, your request is approved.",
+          "japanese": "したがって、あなたの要求は承認されます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006919",
+          "english": "The deadline passed; therefore, it's late.",
+          "japanese": "締め切りが過ぎました。したがって、遅れています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000069-0069-0069-0069-000000006920",
+          "english": "Therefore, we need a new strategy.",
+          "japanese": "したがって、新しい戦略が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793267200.000000
+    },
+    {
+      "id": "10000070-0070-0070-0070-000000000070",
+      "word": "however",
+      "meaning": "しかしながら",
+      "phonetic": "haʊˈev.ɚ",
+      "sentences": [
+        {
+          "id": "10000070-0070-0070-0070-000000007001",
+          "english": "I like it. However, it's too expensive.",
+          "japanese": "気に入っています。しかし、高すぎます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007002",
+          "english": "The plan is good. However, we lack funds.",
+          "japanese": "計画は良いです。しかし、資金が不足しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007003",
+          "english": "However, there's a problem.",
+          "japanese": "しかしながら、問題があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007004",
+          "english": "It's difficult. However, not impossible.",
+          "japanese": "難しいです。しかし、不可能ではありません。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007005",
+          "english": "We tried. However, we failed.",
+          "japanese": "試みました。しかし、失敗しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007006",
+          "english": "The weather was bad. However, we enjoyed it.",
+          "japanese": "天気は悪かったです。しかし、楽しみました。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007007",
+          "english": "However you do it is fine.",
+          "japanese": "どのようにやっても構いません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007008",
+          "english": "Sales rose. However, profits fell.",
+          "japanese": "売上は上がりました。しかし、利益は減りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007009",
+          "english": "However hard I try, I can't succeed.",
+          "japanese": "どんなに努力しても、成功できません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007010",
+          "english": "The task is complete. However, check again.",
+          "japanese": "作業は完了しました。しかし、再確認してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007011",
+          "english": "I agree. However, we need more data.",
+          "japanese": "同意します。しかし、もっとデータが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007012",
+          "english": "It's late. However, I'll finish tonight.",
+          "japanese": "遅いです。しかし、今夜終わらせます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007013",
+          "english": "However small, every effort counts.",
+          "japanese": "どんなに小さくても、すべての努力が重要です。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007014",
+          "english": "The product works. However, it's slow.",
+          "japanese": "製品は動作します。しかし、遅いです。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007015",
+          "english": "However we decide, some will disagree.",
+          "japanese": "どのように決定しても、反対する人がいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007016",
+          "english": "Results improved. However, not enough.",
+          "japanese": "結果は改善しました。しかし、十分ではありません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007017",
+          "english": "I understand. However, I can't help.",
+          "japanese": "理解します。しかし、手伝えません。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007018",
+          "english": "The service is good. However, it's costly.",
+          "japanese": "サービスは良いです。しかし、費用がかかります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007019",
+          "english": "However much it costs, we need it.",
+          "japanese": "いくらかかっても、必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000070-0070-0070-0070-000000007020",
+          "english": "Time passed. However, nothing changed.",
+          "japanese": "時間が経ちました。しかし、何も変わりませんでした。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793270800.000000
+    },
+    {
+      "id": "10000071-0071-0071-0071-000000000071",
+      "word": "although",
+      "meaning": "〜だけれども",
+      "phonetic": "ɔːlˈðoʊ",
+      "sentences": [
+        {
+          "id": "10000071-0071-0071-0071-000000007101",
+          "english": "Although it's late, I'll finish.",
+          "japanese": "遅いですが、終わらせます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007102",
+          "english": "Although tired, she continued working.",
+          "japanese": "疲れていましたが、彼女は働き続けました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007103",
+          "english": "I bought it although it was expensive.",
+          "japanese": "高かったですが、買いました。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007104",
+          "english": "Although small, the room is comfortable.",
+          "japanese": "小さいですが、部屋は快適です。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007105",
+          "english": "We succeeded although we faced challenges.",
+          "japanese": "困難に直面しましたが、成功しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007106",
+          "english": "Although young, he's very talented.",
+          "japanese": "若いですが、彼は非常に才能があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007107",
+          "english": "I like it, although it has flaws.",
+          "japanese": "欠点はありますが、気に入っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007108",
+          "english": "Although we tried, we couldn't finish.",
+          "japanese": "試みましたが、終われませんでした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007109",
+          "english": "The store is open although it's Sunday.",
+          "japanese": "日曜日ですが、店は開いています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007110",
+          "english": "Although difficult, it's worth trying.",
+          "japanese": "難しいですが、試す価値があります。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007111",
+          "english": "I enjoy my job, although it's stressful.",
+          "japanese": "ストレスはありますが、仕事を楽しんでいます。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007112",
+          "english": "Although raining, they went out.",
+          "japanese": "雨でしたが、外出しました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007113",
+          "english": "The plan works, although imperfectly.",
+          "japanese": "不完全ですが、計画は機能します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007114",
+          "english": "Although I agreed, I have concerns.",
+          "japanese": "同意しましたが、懸念があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007115",
+          "english": "She smiled although she was sad.",
+          "japanese": "悲しかったですが、彼女は笑いました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007116",
+          "english": "Although warned, he ignored it.",
+          "japanese": "警告されましたが、彼は無視しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007117",
+          "english": "The service is good, although slow.",
+          "japanese": "遅いですが、サービスは良いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007118",
+          "english": "Although qualified, she wasn't hired.",
+          "japanese": "資格がありましたが、採用されませんでした。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007119",
+          "english": "I'll attend although I'm busy.",
+          "japanese": "忙しいですが、出席します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000071-0071-0071-0071-000000007120",
+          "english": "Although uncertain, we must decide.",
+          "japanese": "不確かですが、決定しなければなりません。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793274400.000000
+    },
+    {
+      "id": "10000072-0072-0072-0072-000000000072",
+      "word": "various",
+      "meaning": "様々な",
+      "phonetic": "ˈver.i.əs",
+      "sentences": [
+        {
+          "id": "10000072-0072-0072-0072-000000007201",
+          "english": "We offer various options.",
+          "japanese": "様々なオプションを提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007202",
+          "english": "The store sells various products.",
+          "japanese": "店は様々な製品を販売しています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007203",
+          "english": "There are various ways to solve this.",
+          "japanese": "これを解決する様々な方法があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007204",
+          "english": "People come from various backgrounds.",
+          "japanese": "人々は様々な背景から来ています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007205",
+          "english": "The menu has various dishes.",
+          "japanese": "メニューには様々な料理があります。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007206",
+          "english": "We tested various solutions.",
+          "japanese": "様々な解決策をテストしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007207",
+          "english": "Various factors influence the outcome.",
+          "japanese": "様々な要因が結果に影響します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007208",
+          "english": "The course covers various topics.",
+          "japanese": "コースは様々なトピックをカバーします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007209",
+          "english": "We have various sizes available.",
+          "japanese": "様々なサイズが利用できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007210",
+          "english": "Various opinions were expressed.",
+          "japanese": "様々な意見が表明されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007211",
+          "english": "The city offers various attractions.",
+          "japanese": "その都市は様々なアトラクションを提供します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007212",
+          "english": "Students have various learning styles.",
+          "japanese": "学生には様々な学習スタイルがあります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007213",
+          "english": "Various methods can be used.",
+          "japanese": "様々な方法を使用できます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007214",
+          "english": "The company serves various industries.",
+          "japanese": "会社は様々な業界にサービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007215",
+          "english": "Various colors are available.",
+          "japanese": "様々な色が利用できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007216",
+          "english": "We considered various alternatives.",
+          "japanese": "様々な代替案を検討しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007217",
+          "english": "Various cultures coexist here.",
+          "japanese": "様々な文化がここで共存しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007218",
+          "english": "The app has various features.",
+          "japanese": "アプリには様々な機能があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007219",
+          "english": "Various problems arose.",
+          "japanese": "様々な問題が生じました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000072-0072-0072-0072-000000007220",
+          "english": "We use various tools for analysis.",
+          "japanese": "分析に様々なツールを使用します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793278000.000000
+    },
+    {
+      "id": "10000073-0073-0073-0073-000000000073",
+      "word": "similar",
+      "meaning": "似ている",
+      "phonetic": "ˈsɪm.ə.lɚ",
+      "sentences": [
+        {
+          "id": "10000073-0073-0073-0073-000000007301",
+          "english": "The two products are very similar.",
+          "japanese": "2つの製品は非常に似ています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007302",
+          "english": "We have similar interests.",
+          "japanese": "私たちは似た興味を持っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007303",
+          "english": "The results are similar to last year.",
+          "japanese": "結果は昨年と似ています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007304",
+          "english": "Her situation is similar to mine.",
+          "japanese": "彼女の状況は私の状況と似ています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007305",
+          "english": "The buildings look similar.",
+          "japanese": "建物は似て見えます。",
+          "category": "建築"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007306",
+          "english": "They have similar backgrounds.",
+          "japanese": "彼らは似た背景を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007307",
+          "english": "The symptoms are similar.",
+          "japanese": "症状は似ています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007308",
+          "english": "We face similar challenges.",
+          "japanese": "似た課題に直面しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007309",
+          "english": "The two cities are quite similar.",
+          "japanese": "2つの都市はかなり似ています。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007310",
+          "english": "Their opinions are similar.",
+          "japanese": "彼らの意見は似ています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007311",
+          "english": "The taste is similar to chicken.",
+          "japanese": "味は鶏肉に似ています。",
+          "category": "料理"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007312",
+          "english": "We offer similar services.",
+          "japanese": "似たサービスを提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007313",
+          "english": "The patterns are remarkably similar.",
+          "japanese": "パターンは驚くほど似ています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007314",
+          "english": "Their experiences are similar.",
+          "japanese": "彼らの経験は似ています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007315",
+          "english": "The design is similar to ours.",
+          "japanese": "デザインは私たちのものに似ています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007316",
+          "english": "They reached similar conclusions.",
+          "japanese": "彼らは似た結論に達しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007317",
+          "english": "The situations are not similar.",
+          "japanese": "状況は似ていません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007318",
+          "english": "We have similar goals.",
+          "japanese": "似た目標を持っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007319",
+          "english": "The twins look very similar.",
+          "japanese": "双子はとても似ています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000073-0073-0073-0073-000000007320",
+          "english": "Similar problems occur frequently.",
+          "japanese": "似た問題が頻繁に発生します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793281600.000000
+    },
+    {
+      "id": "10000074-0074-0074-0074-000000000074",
+      "word": "numerous",
+      "meaning": "多数の",
+      "phonetic": "ˈnuː.mə.rəs",
+      "sentences": [
+        {
+          "id": "10000074-0074-0074-0074-000000007401",
+          "english": "We received numerous complaints.",
+          "japanese": "多数の苦情を受け取りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007402",
+          "english": "She has numerous awards.",
+          "japanese": "彼女は多数の賞を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007403",
+          "english": "There are numerous options available.",
+          "japanese": "多数の選択肢があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007404",
+          "english": "Numerous studies support this theory.",
+          "japanese": "多数の研究がこの理論を支持しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007405",
+          "english": "The city has numerous attractions.",
+          "japanese": "その都市には多数のアトラクションがあります。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007406",
+          "english": "We face numerous challenges.",
+          "japanese": "多数の課題に直面しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007407",
+          "english": "Numerous people attended the event.",
+          "japanese": "多数の人がイベントに参加しました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007408",
+          "english": "The book has numerous examples.",
+          "japanese": "その本には多数の例があります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007409",
+          "english": "We offer numerous benefits.",
+          "japanese": "多数の特典を提供しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007410",
+          "english": "Numerous factors contribute to success.",
+          "japanese": "多数の要因が成功に貢献します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007411",
+          "english": "She made numerous contributions.",
+          "japanese": "彼女は多数の貢献をしました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007412",
+          "english": "The store has numerous locations.",
+          "japanese": "その店には多数の店舗があります。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007413",
+          "english": "Numerous opportunities exist.",
+          "japanese": "多数の機会が存在します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007414",
+          "english": "He has numerous responsibilities.",
+          "japanese": "彼は多数の責任を負っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007415",
+          "english": "Numerous errors were found.",
+          "japanese": "多数のエラーが見つかりました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007416",
+          "english": "The program offers numerous features.",
+          "japanese": "プログラムは多数の機能を提供します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007417",
+          "english": "Numerous applications were submitted.",
+          "japanese": "多数の応募がありました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007418",
+          "english": "They have numerous clients.",
+          "japanese": "彼らには多数のクライアントがいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007419",
+          "english": "Numerous improvements were made.",
+          "japanese": "多数の改善が行われました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000074-0074-0074-0074-000000007420",
+          "english": "The area has numerous restaurants.",
+          "japanese": "そのエリアには多数のレストランがあります。",
+          "category": "旅行"
+        }
+      ],
+      "createdAt": 793285200.000000
+    },
+    {
+      "id": "10000075-0075-0075-0075-000000000075",
+      "word": "immediate",
+      "meaning": "即座の、直接の",
+      "phonetic": "ɪˈmiː.di.ət",
+      "sentences": [
+        {
+          "id": "10000075-0075-0075-0075-000000007501",
+          "english": "We need an immediate response.",
+          "japanese": "即座の対応が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007502",
+          "english": "The problem requires immediate attention.",
+          "japanese": "問題は即座の注意が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007503",
+          "english": "There's an immediate danger.",
+          "japanese": "即座の危険があります。",
+          "category": "安全"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007504",
+          "english": "She showed immediate improvement.",
+          "japanese": "彼女はすぐに改善を示しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007505",
+          "english": "We need immediate action.",
+          "japanese": "即座の行動が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007506",
+          "english": "The impact was immediate.",
+          "japanese": "影響は即座でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007507",
+          "english": "Contact us for immediate assistance.",
+          "japanese": "即座の支援については連絡してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007508",
+          "english": "The results were immediate.",
+          "japanese": "結果は即座でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007509",
+          "english": "He's my immediate supervisor.",
+          "japanese": "彼は私の直属の上司です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007510",
+          "english": "The immediate area was evacuated.",
+          "japanese": "直近のエリアが避難しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007511",
+          "english": "I need immediate help.",
+          "japanese": "すぐに助けが必要です。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007512",
+          "english": "The immediate priority is safety.",
+          "japanese": "最優先事項は安全です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007513",
+          "english": "We saw immediate results.",
+          "japanese": "すぐに結果が見られました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007514",
+          "english": "The immediate family was notified.",
+          "japanese": "近親者に通知されました。",
+          "category": "家族"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007515",
+          "english": "Take immediate steps to resolve this.",
+          "japanese": "これを解決するために即座の措置を講じてください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007516",
+          "english": "The change had immediate effects.",
+          "japanese": "変更はすぐに効果がありました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007517",
+          "english": "Immediate payment is required.",
+          "japanese": "即座の支払いが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007518",
+          "english": "The immediate concern is cost.",
+          "japanese": "直近の懸念はコストです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007519",
+          "english": "She felt immediate relief.",
+          "japanese": "彼女は即座に安堵を感じました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000075-0075-0075-0075-000000007520",
+          "english": "The situation needs immediate resolution.",
+          "japanese": "状況は即座の解決が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793288800.000000
+    },
+    {
+      "id": "10000076-0076-0076-0076-000000000076",
+      "word": "obvious",
+      "meaning": "明白な",
+      "phonetic": "ˈɑːb.vi.əs",
+      "sentences": [
+        {
+          "id": "10000076-0076-0076-0076-000000007601",
+          "english": "The answer is obvious.",
+          "japanese": "答えは明白です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007602",
+          "english": "It's obvious that he's lying.",
+          "japanese": "彼が嘘をついているのは明らかです。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007603",
+          "english": "The solution is obvious.",
+          "japanese": "解決策は明白です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007604",
+          "english": "For obvious reasons, we declined.",
+          "japanese": "明白な理由で、辞退しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007605",
+          "english": "The mistake is quite obvious.",
+          "japanese": "間違いはかなり明白です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007606",
+          "english": "It's obvious she's talented.",
+          "japanese": "彼女が才能があるのは明らかです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007607",
+          "english": "The benefits are obvious.",
+          "japanese": "利点は明白です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007608",
+          "english": "This is an obvious choice.",
+          "japanese": "これは明白な選択です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007609",
+          "english": "The danger is obvious.",
+          "japanese": "危険は明白です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007610",
+          "english": "It should be obvious by now.",
+          "japanese": "今頃は明白であるはずです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007611",
+          "english": "The difference is obvious.",
+          "japanese": "違いは明白です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007612",
+          "english": "Her disappointment was obvious.",
+          "japanese": "彼女の失望は明らかでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007613",
+          "english": "The problem is obvious to everyone.",
+          "japanese": "問題は誰にでも明白です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007614",
+          "english": "It's obvious we need help.",
+          "japanese": "助けが必要なのは明らかです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007615",
+          "english": "The advantages are obvious.",
+          "japanese": "利点は明白です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007616",
+          "english": "His nervousness was obvious.",
+          "japanese": "彼の緊張は明白でした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007617",
+          "english": "The truth is obvious.",
+          "japanese": "真実は明白です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007618",
+          "english": "It's obvious they're related.",
+          "japanese": "彼らが親戚であるのは明らかです。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007619",
+          "english": "The outcome was obvious.",
+          "japanese": "結果は明白でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000076-0076-0076-0076-000000007620",
+          "english": "For obvious reasons, I can't say.",
+          "japanese": "明白な理由で、言えません。",
+          "category": "日常会話"
+        }
+      ],
+      "createdAt": 793292400.000000
+    },
+    {
+      "id": "10000077-0077-0077-0077-000000000077",
+      "word": "entire",
+      "meaning": "全体の",
+      "phonetic": "ɪnˈtaɪr",
+      "sentences": [
+        {
+          "id": "10000077-0077-0077-0077-000000007701",
+          "english": "The entire team worked hard.",
+          "japanese": "チーム全体が一生懸命働きました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007702",
+          "english": "I read the entire book.",
+          "japanese": "本全体を読みました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007703",
+          "english": "The entire building was evacuated.",
+          "japanese": "建物全体が避難しました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007704",
+          "english": "We spent the entire day there.",
+          "japanese": "そこで一日中過ごしました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007705",
+          "english": "The entire project was cancelled.",
+          "japanese": "プロジェクト全体がキャンセルされました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007706",
+          "english": "She ate the entire pizza.",
+          "japanese": "彼女はピザ全部を食べました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007707",
+          "english": "The entire country was affected.",
+          "japanese": "国全体が影響を受けました。",
+          "category": "政治"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007708",
+          "english": "We covered the entire curriculum.",
+          "japanese": "カリキュラム全体をカバーしました。",
+          "category": "教育"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007709",
+          "english": "The entire family attended.",
+          "japanese": "家族全員が出席しました。",
+          "category": "家族"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007710",
+          "english": "It took the entire morning.",
+          "japanese": "午前中全部かかりました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007711",
+          "english": "The entire system crashed.",
+          "japanese": "システム全体がクラッシュしました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007712",
+          "english": "We reviewed the entire document.",
+          "japanese": "文書全体を見直しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007713",
+          "english": "The entire process is automated.",
+          "japanese": "プロセス全体が自動化されています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007714",
+          "english": "She owns the entire company.",
+          "japanese": "彼女は会社全体を所有しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007715",
+          "english": "The entire area was flooded.",
+          "japanese": "エリア全体が浸水しました。",
+          "category": "自然災害"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007716",
+          "english": "We walked the entire distance.",
+          "japanese": "全行程を歩きました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007717",
+          "english": "The entire staff was informed.",
+          "japanese": "スタッフ全員に通知されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007718",
+          "english": "It affected the entire organization.",
+          "japanese": "組織全体に影響しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007719",
+          "english": "The entire event was recorded.",
+          "japanese": "イベント全体が記録されました。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000077-0077-0077-0077-000000007720",
+          "english": "We cleaned the entire house.",
+          "japanese": "家全体を掃除しました。",
+          "category": "日常会話"
+        }
+      ],
+      "createdAt": 793296000.000000
+    },
+    {
+      "id": "10000078-0078-0078-0078-000000000078",
+      "word": "previous",
+      "meaning": "前の、以前の",
+      "phonetic": "ˈpriː.vi.əs",
+      "sentences": [
+        {
+          "id": "10000078-0078-0078-0078-000000007801",
+          "english": "The previous owner sold it.",
+          "japanese": "前の所有者が売りました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007802",
+          "english": "Please refer to the previous page.",
+          "japanese": "前のページを参照してください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007803",
+          "english": "Sales are higher than previous years.",
+          "japanese": "売上は前年より高いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007804",
+          "english": "My previous job was different.",
+          "japanese": "前の仕事は違いました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007805",
+          "english": "We discussed this in previous meetings.",
+          "japanese": "以前の会議でこれを議論しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007806",
+          "english": "The previous version had problems.",
+          "japanese": "前のバージョンには問題がありました。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007807",
+          "english": "She mentioned this in her previous email.",
+          "japanese": "彼女は前のメールでこれに言及しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007808",
+          "english": "Results improved from previous attempts.",
+          "japanese": "前回の試みより結果が改善しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007809",
+          "english": "The previous manager left last month.",
+          "japanese": "前のマネージャーは先月辞めました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007810",
+          "english": "This model is better than previous ones.",
+          "japanese": "このモデルは前のものより良いです。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007811",
+          "english": "As stated in the previous chapter.",
+          "japanese": "前の章で述べたように。",
+          "category": "教育"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007812",
+          "english": "The previous system was outdated.",
+          "japanese": "前のシステムは時代遅れでした。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007813",
+          "english": "We learned from previous mistakes.",
+          "japanese": "以前の間違いから学びました。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007814",
+          "english": "The previous tenant moved out.",
+          "japanese": "前の入居者が退去しました。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007815",
+          "english": "Compare this to previous data.",
+          "japanese": "これを前のデータと比較してください。",
+          "category": "科学"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007816",
+          "english": "The previous deadline was extended.",
+          "japanese": "前の締め切りが延長されました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007817",
+          "english": "She returned to her previous position.",
+          "japanese": "彼女は前のポジションに戻りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007818",
+          "english": "The previous record was broken.",
+          "japanese": "前の記録が破られました。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007819",
+          "english": "We've solved previous issues.",
+          "japanese": "以前の問題を解決しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000078-0078-0078-0078-000000007820",
+          "english": "Build on previous knowledge.",
+          "japanese": "以前の知識を基にしてください。",
+          "category": "教育"
+        }
+      ],
+      "createdAt": 793299600.000000
+    },
+    {
+      "id": "10000079-0079-0079-0079-000000000079",
+      "word": "current",
+      "meaning": "現在の",
+      "phonetic": "ˈkɜː.ənt",
+      "sentences": [
+        {
+          "id": "10000079-0079-0079-0079-000000007901",
+          "english": "What's the current situation?",
+          "japanese": "現在の状況は何ですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007902",
+          "english": "She's my current boss.",
+          "japanese": "彼女は私の現在の上司です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007903",
+          "english": "The current system works well.",
+          "japanese": "現在のシステムはうまく機能しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007904",
+          "english": "Current events are discussed daily.",
+          "japanese": "時事問題は毎日議論されています。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007905",
+          "english": "What's your current address?",
+          "japanese": "現在の住所は何ですか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007906",
+          "english": "The current price is reasonable.",
+          "japanese": "現在の価格は妥当です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007907",
+          "english": "Current technology is impressive.",
+          "japanese": "現在の技術は印象的です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007908",
+          "english": "The current trend is positive.",
+          "japanese": "現在の傾向はポジティブです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007909",
+          "english": "We're satisfied with current results.",
+          "japanese": "現在の結果に満足しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007910",
+          "english": "The ocean has strong currents.",
+          "japanese": "海には強い潮流があります。",
+          "category": "自然"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007911",
+          "english": "Current members get a discount.",
+          "japanese": "現会員は割引を受けられます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007912",
+          "english": "The current version is stable.",
+          "japanese": "現在のバージョンは安定しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007913",
+          "english": "Check the current balance.",
+          "japanese": "現在の残高を確認してください。",
+          "category": "金融"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007914",
+          "english": "The current leader is strong.",
+          "japanese": "現在のリーダーは強力です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007915",
+          "english": "Current research supports this.",
+          "japanese": "現在の研究がこれを支持しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007916",
+          "english": "What's the current status?",
+          "japanese": "現在の状態は何ですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007917",
+          "english": "The current market is competitive.",
+          "japanese": "現在の市場は競争的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007918",
+          "english": "Electric current flows through wires.",
+          "japanese": "電流が配線を流れます。",
+          "category": "科学"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007919",
+          "english": "Current employees are valued.",
+          "japanese": "現在の従業員は大切にされています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000079-0079-0079-0079-000000007920",
+          "english": "The current plan needs revision.",
+          "japanese": "現在の計画には修正が必要です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793303200.000000
+    },
+    {
+      "id": "10000080-0080-0080-0080-000000000080",
+      "word": "potential",
+      "meaning": "潜在的な、可能性",
+      "phonetic": "pəˈten.ʃəl",
+      "sentences": [
+        {
+          "id": "10000080-0080-0080-0080-000000008001",
+          "english": "She has great potential.",
+          "japanese": "彼女は大きな可能性を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008002",
+          "english": "There's a potential problem.",
+          "japanese": "潜在的な問題があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008003",
+          "english": "The product has market potential.",
+          "japanese": "製品には市場性があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008004",
+          "english": "We're meeting potential clients.",
+          "japanese": "潜在的な顧客と会っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008005",
+          "english": "The area has development potential.",
+          "japanese": "そのエリアには開発の可能性があります。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008006",
+          "english": "Identify potential risks early.",
+          "japanese": "潜在的なリスクを早期に特定してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008007",
+          "english": "The project shows potential.",
+          "japanese": "プロジェクトは有望です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008008",
+          "english": "Every child has potential.",
+          "japanese": "すべての子供には可能性があります。",
+          "category": "教育"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008009",
+          "english": "There are potential benefits.",
+          "japanese": "潜在的な利点があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008010",
+          "english": "We see great potential here.",
+          "japanese": "ここに大きな可能性を見ています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008011",
+          "english": "Potential customers are interested.",
+          "japanese": "潜在的な顧客が関心を持っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008012",
+          "english": "The plan has potential drawbacks.",
+          "japanese": "計画には潜在的な欠点があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008013",
+          "english": "He hasn't reached his potential.",
+          "japanese": "彼はまだ潜在能力に達していません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008014",
+          "english": "The investment has high potential.",
+          "japanese": "投資は高い可能性があります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008015",
+          "english": "We're exploring potential solutions.",
+          "japanese": "潜在的な解決策を探っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008016",
+          "english": "The potential is enormous.",
+          "japanese": "可能性は莫大です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008017",
+          "english": "Potential hazards were identified.",
+          "japanese": "潜在的な危険が特定されました。",
+          "category": "安全"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008018",
+          "english": "The technology has potential applications.",
+          "japanese": "技術には潜在的な応用があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008019",
+          "english": "She's a potential candidate.",
+          "japanese": "彼女は有力な候補者です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000080-0080-0080-0080-000000008020",
+          "english": "We're realizing our potential.",
+          "japanese": "私たちは可能性を実現しています。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793306800.000000
+    },
+    {
+      "id": "10000081-0081-0081-0081-000000000081",
+      "word": "aware",
+      "meaning": "気づいている",
+      "phonetic": "əˈwer",
+      "sentences": [
+        {
+          "id": "10000081-0081-0081-0081-000000008101",
+          "english": "I'm aware of the problem.",
+          "japanese": "問題に気づいています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008102",
+          "english": "Are you aware of the risks?",
+          "japanese": "リスクを認識していますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008103",
+          "english": "She's very aware of current trends.",
+          "japanese": "彼女は現在のトレンドをよく知っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008104",
+          "english": "We need to be more aware.",
+          "japanese": "もっと注意深くする必要があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008105",
+          "english": "He wasn't aware of the change.",
+          "japanese": "彼は変更に気づいていませんでした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008106",
+          "english": "Be aware of your surroundings.",
+          "japanese": "周囲に注意してください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008107",
+          "english": "I'm fully aware of the situation.",
+          "japanese": "状況を完全に認識しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008108",
+          "english": "They made us aware of the deadline.",
+          "japanese": "彼らは締め切りを知らせてくれました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008109",
+          "english": "Environmentally aware consumers prefer this.",
+          "japanese": "環境意識の高い消費者はこれを好みます。",
+          "category": "環境"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008110",
+          "english": "As far as I'm aware, it's correct.",
+          "japanese": "私が知る限り、それは正しいです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008111",
+          "english": "The public is aware of the issue.",
+          "japanese": "一般市民はその問題を認識しています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008112",
+          "english": "She became aware of her mistake.",
+          "japanese": "彼女は自分の間違いに気づきました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008113",
+          "english": "We're aware of your concerns.",
+          "japanese": "あなたの懸念を認識しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008114",
+          "english": "Stay aware of market changes.",
+          "japanese": "市場の変化に注意してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008115",
+          "english": "He's politically aware.",
+          "japanese": "彼は政治的に意識が高いです。",
+          "category": "政治"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008116",
+          "english": "Awareness is growing.",
+          "japanese": "認識が高まっています。",
+          "category": "社会"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008117",
+          "english": "Please make everyone aware.",
+          "japanese": "全員に周知してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008118",
+          "english": "I wasn't aware you were coming.",
+          "japanese": "来ることを知りませんでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008119",
+          "english": "Be aware that rules changed.",
+          "japanese": "規則が変更されたことに注意してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000081-0081-0081-0081-000000008120",
+          "english": "Health-aware people exercise regularly.",
+          "japanese": "健康意識の高い人は定期的に運動します。",
+          "category": "健康"
+        }
+      ],
+      "createdAt": 793310400.000000
+    },
+    {
+      "id": "10000082-0082-0082-0082-000000000082",
+      "word": "specific",
+      "meaning": "具体的な、特定の",
+      "phonetic": "spəˈsɪf.ɪk",
+      "sentences": [
+        {
+          "id": "10000082-0082-0082-0082-000000008201",
+          "english": "Please be more specific.",
+          "japanese": "もっと具体的にしてください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008202",
+          "english": "Do you have specific requirements?",
+          "japanese": "具体的な要件はありますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008203",
+          "english": "The instructions are very specific.",
+          "japanese": "指示は非常に具体的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008204",
+          "english": "I need specific examples.",
+          "japanese": "具体例が必要です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008205",
+          "english": "This tool is for specific tasks.",
+          "japanese": "このツールは特定の作業用です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008206",
+          "english": "Can you be more specific about time?",
+          "japanese": "時間についてもっと具体的にできますか？",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008207",
+          "english": "The design has specific features.",
+          "japanese": "デザインには特定の機能があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008208",
+          "english": "Each role has specific duties.",
+          "japanese": "各役割には特定の義務があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008209",
+          "english": "We target specific demographics.",
+          "japanese": "特定の人口層を対象としています。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008210",
+          "english": "The medication is for specific conditions.",
+          "japanese": "その薬は特定の症状用です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008211",
+          "english": "Give me specific details.",
+          "japanese": "具体的な詳細を教えてください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008212",
+          "english": "The course covers specific topics.",
+          "japanese": "コースは特定のトピックをカバーします。",
+          "category": "教育"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008213",
+          "english": "We have specific goals.",
+          "japanese": "具体的な目標があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008214",
+          "english": "Follow the specific instructions.",
+          "japanese": "具体的な指示に従ってください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008215",
+          "english": "This applies to specific cases.",
+          "japanese": "これは特定のケースに適用されます。",
+          "category": "法律"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008216",
+          "english": "The problem requires specific skills.",
+          "japanese": "問題には特定のスキルが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008217",
+          "english": "We need specific measurements.",
+          "japanese": "具体的な測定が必要です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008218",
+          "english": "The policy covers specific items.",
+          "japanese": "方針は特定の項目をカバーします。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008219",
+          "english": "Each product has specific uses.",
+          "japanese": "各製品には特定の用途があります。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000082-0082-0082-0082-000000008220",
+          "english": "The contract includes specific terms.",
+          "japanese": "契約には具体的な条件が含まれます。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793314000.000000
+    },
+    {
+      "id": "10000083-0083-0083-0083-000000000083",
+      "word": "global",
+      "meaning": "世界的な",
+      "phonetic": "ˈɡloʊ.bəl",
+      "sentences": [
+        {
+          "id": "10000083-0083-0083-0083-000000008301",
+          "english": "Climate change is a global issue.",
+          "japanese": "気候変動は世界的な問題です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008302",
+          "english": "We operate on a global scale.",
+          "japanese": "世界規模で事業を展開しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008303",
+          "english": "The company has a global presence.",
+          "japanese": "会社は世界的な存在感があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008304",
+          "english": "Global markets are interconnected.",
+          "japanese": "世界市場は相互に関連しています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008305",
+          "english": "The pandemic had global effects.",
+          "japanese": "パンデミックは世界的な影響を及ぼしました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008306",
+          "english": "We need global cooperation.",
+          "japanese": "世界的な協力が必要です。",
+          "category": "政治"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008307",
+          "english": "Global trade is increasing.",
+          "japanese": "世界貿易が増加しています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008308",
+          "english": "The brand is recognized globally.",
+          "japanese": "ブランドは世界的に認知されています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008309",
+          "english": "Global warming concerns everyone.",
+          "japanese": "地球温暖化は誰もが懸念しています。",
+          "category": "環境"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008310",
+          "english": "We have a global network.",
+          "japanese": "世界的なネットワークがあります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008311",
+          "english": "The internet enables global communication.",
+          "japanese": "インターネットは世界的なコミュニケーションを可能にします。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008312",
+          "english": "Global demand is rising.",
+          "japanese": "世界的な需要が高まっています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008313",
+          "english": "The event had global coverage.",
+          "japanese": "イベントは世界的に報道されました。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008314",
+          "english": "We face global challenges.",
+          "japanese": "世界的な課題に直面しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008315",
+          "english": "Global shipping is available.",
+          "japanese": "世界配送が利用できます。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008316",
+          "english": "The economy is globally connected.",
+          "japanese": "経済は世界的につながっています。",
+          "category": "経済"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008317",
+          "english": "Global health is improving.",
+          "japanese": "世界の健康状態が改善しています。",
+          "category": "医療"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008318",
+          "english": "The company went global last year.",
+          "japanese": "会社は昨年グローバル化しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008319",
+          "english": "We promote global understanding.",
+          "japanese": "世界的な理解を促進しています。",
+          "category": "教育"
+        },
+        {
+          "id": "10000083-0083-0083-0083-000000008320",
+          "english": "Global competition is intense.",
+          "japanese": "世界的な競争は激しいです。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793317600.000000
+    },
+    {
+      "id": "10000084-0084-0084-0084-000000000084",
+      "word": "primary",
+      "meaning": "主要な、第一の",
+      "phonetic": "ˈpraɪ.mer.i",
+      "sentences": [
+        {
+          "id": "10000084-0084-0084-0084-000000008401",
+          "english": "Safety is our primary concern.",
+          "japanese": "安全が第一の関心事です。",
+          "category": "安全"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008402",
+          "english": "What's the primary reason?",
+          "japanese": "主な理由は何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008403",
+          "english": "Children attend primary school.",
+          "japanese": "子供たちは小学校に通います。",
+          "category": "教育"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008404",
+          "english": "The primary goal is growth.",
+          "japanese": "主な目標は成長です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008405",
+          "english": "Red is a primary color.",
+          "japanese": "赤は原色です。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008406",
+          "english": "This is our primary focus.",
+          "japanese": "これが主要な焦点です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008407",
+          "english": "The primary issue is cost.",
+          "japanese": "主要な問題はコストです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008408",
+          "english": "We use primary sources.",
+          "japanese": "一次資料を使用します。",
+          "category": "教育"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008409",
+          "english": "Health is the primary benefit.",
+          "japanese": "健康が主な利点です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008410",
+          "english": "This is the primary entrance.",
+          "japanese": "これが正面玄関です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008411",
+          "english": "The primary function is storage.",
+          "japanese": "主な機能は保存です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008412",
+          "english": "Quality is our primary objective.",
+          "japanese": "品質が主要な目標です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008413",
+          "english": "She's the primary contact.",
+          "japanese": "彼女が主要な連絡先です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008414",
+          "english": "The primary market is Asia.",
+          "japanese": "主要市場はアジアです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008415",
+          "english": "This is primary data.",
+          "japanese": "これは一次データです。",
+          "category": "科学"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008416",
+          "english": "The primary cause was identified.",
+          "japanese": "主要な原因が特定されました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008417",
+          "english": "Education is the primary solution.",
+          "japanese": "教育が主要な解決策です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008418",
+          "english": "Our primary duty is service.",
+          "japanese": "主な義務はサービスです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008419",
+          "english": "The primary purpose is clear.",
+          "japanese": "主な目的は明確です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000084-0084-0084-0084-000000008420",
+          "english": "Water is a primary need.",
+          "japanese": "水は主要なニーズです。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793321200.000000
+    },
+    {
+      "id": "10000085-0085-0085-0085-000000000085",
+      "word": "maximum",
+      "meaning": "最大の",
+      "phonetic": "ˈmæk.sɪ.məm",
+      "sentences": [
+        {
+          "id": "10000085-0085-0085-0085-000000008501",
+          "english": "The maximum capacity is 100 people.",
+          "japanese": "最大収容人数は100人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008502",
+          "english": "What's the maximum speed?",
+          "japanese": "最高速度は何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008503",
+          "english": "We achieved maximum efficiency.",
+          "japanese": "最高の効率を達成しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008504",
+          "english": "The maximum temperature is 35°C.",
+          "japanese": "最高気温は35度です。",
+          "category": "天気"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008505",
+          "english": "There's a maximum weight limit.",
+          "japanese": "最大重量制限があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008506",
+          "english": "Give it maximum effort.",
+          "japanese": "最大限の努力をしてください。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008507",
+          "english": "The maximum fee is $100.",
+          "japanese": "最高手数料は100ドルです。",
+          "category": "金融"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008508",
+          "english": "We operate at maximum capacity.",
+          "japanese": "最大容量で稼働しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008509",
+          "english": "The maximum duration is two hours.",
+          "japanese": "最長時間は2時間です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008510",
+          "english": "Maximum security is in place.",
+          "japanese": "最高度のセキュリティが設定されています。",
+          "category": "安全"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008511",
+          "english": "The maximum age is 65.",
+          "japanese": "最高年齢は65歳です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008512",
+          "english": "We need maximum participation.",
+          "japanese": "最大限の参加が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008513",
+          "english": "The loan has a maximum term.",
+          "japanese": "ローンには最長期間があります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008514",
+          "english": "Ensure maximum safety.",
+          "japanese": "最大限の安全を確保してください。",
+          "category": "安全"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008515",
+          "english": "The maximum penalty is serious.",
+          "japanese": "最大の罰則は深刻です。",
+          "category": "法律"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008516",
+          "english": "We allow a maximum of three attempts.",
+          "japanese": "最大3回まで許可します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008517",
+          "english": "The car reaches maximum speed quickly.",
+          "japanese": "車はすぐに最高速度に達します。",
+          "category": "自動車"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008518",
+          "english": "Maximum benefits are available.",
+          "japanese": "最大の特典が利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008519",
+          "english": "The maximum discount is 50%.",
+          "japanese": "最大割引は50%です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000085-0085-0085-0085-000000008520",
+          "english": "Focus on maximum impact.",
+          "japanese": "最大の影響に焦点を当ててください。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793324800.000000
+    },
+    {
+      "id": "10000086-0086-0086-0086-000000000086",
+      "word": "minimum",
+      "meaning": "最小の",
+      "phonetic": "ˈmɪn.ə.məm",
+      "sentences": [
+        {
+          "id": "10000086-0086-0086-0086-000000008601",
+          "english": "The minimum age is 18.",
+          "japanese": "最低年齢は18歳です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008602",
+          "english": "There's a minimum purchase requirement.",
+          "japanese": "最低購入要件があります。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008603",
+          "english": "The minimum wage increased.",
+          "japanese": "最低賃金が上がりました。",
+          "category": "経済"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008604",
+          "english": "We require minimum effort.",
+          "japanese": "最小限の努力が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008605",
+          "english": "The minimum temperature is -5°C.",
+          "japanese": "最低気温はマイナス5度です。",
+          "category": "天気"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008606",
+          "english": "A minimum of five years experience.",
+          "japanese": "最低5年の経験が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008607",
+          "english": "Keep costs to a minimum.",
+          "japanese": "コストを最小限に抑えてください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008608",
+          "english": "The minimum order is 10 units.",
+          "japanese": "最小注文数は10個です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008609",
+          "english": "Minimum qualifications are required.",
+          "japanese": "最低限の資格が必要です。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008610",
+          "english": "The account has a minimum balance.",
+          "japanese": "口座には最低残高があります。",
+          "category": "金融"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008611",
+          "english": "We need minimum disruption.",
+          "japanese": "最小限の混乱が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008612",
+          "english": "The minimum payment is due.",
+          "japanese": "最低支払額が必要です。",
+          "category": "金融"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008613",
+          "english": "Reduce waste to a minimum.",
+          "japanese": "無駄を最小限にしてください。",
+          "category": "環境"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008614",
+          "english": "The minimum stay is two nights.",
+          "japanese": "最低滞在日数は2泊です。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008615",
+          "english": "Minimum risk is guaranteed.",
+          "japanese": "最小限のリスクが保証されています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008616",
+          "english": "The minimum size is 10 square meters.",
+          "japanese": "最小サイズは10平方メートルです。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008617",
+          "english": "Minimum standards must be met.",
+          "japanese": "最低基準を満たす必要があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008618",
+          "english": "The minimum duration is one month.",
+          "japanese": "最短期間は1か月です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008619",
+          "english": "We accept minimum enrollment.",
+          "japanese": "最小限の登録を受け付けます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000086-0086-0086-0086-000000008620",
+          "english": "Maintain minimum inventory levels.",
+          "japanese": "最低在庫レベルを維持してください。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793328400.000000
+    },
+    {
+      "id": "10000087-0087-0087-0087-000000000087",
+      "word": "positive",
+      "meaning": "肯定的な、前向きな",
+      "phonetic": "ˈpɑː.zə.tɪv",
+      "sentences": [
+        {
+          "id": "10000087-0087-0087-0087-000000008701",
+          "english": "Stay positive about the future.",
+          "japanese": "未来について前向きでいてください。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008702",
+          "english": "The results were positive.",
+          "japanese": "結果は良好でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008703",
+          "english": "She has a positive attitude.",
+          "japanese": "彼女は前向きな態度を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008704",
+          "english": "The test came back positive.",
+          "japanese": "検査結果は陽性でした。",
+          "category": "医療"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008705",
+          "english": "We received positive feedback.",
+          "japanese": "肯定的なフィードバックを受け取りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008706",
+          "english": "Think positive thoughts.",
+          "japanese": "前向きに考えてください。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008707",
+          "english": "The impact was positive.",
+          "japanese": "影響は良好でした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008708",
+          "english": "He's always positive and cheerful.",
+          "japanese": "彼はいつも前向きで陽気です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008709",
+          "english": "The outlook is positive.",
+          "japanese": "見通しは良好です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008710",
+          "english": "We made positive changes.",
+          "japanese": "前向きな変化を行いました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008711",
+          "english": "Positive thinking helps.",
+          "japanese": "前向きな思考が役立ちます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008712",
+          "english": "The review was mostly positive.",
+          "japanese": "レビューはおおむね好評でした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008713",
+          "english": "Maintain a positive environment.",
+          "japanese": "前向きな環境を維持してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008714",
+          "english": "The data shows positive trends.",
+          "japanese": "データは良好な傾向を示しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008715",
+          "english": "She responded positively.",
+          "japanese": "彼女は肯定的に応答しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008716",
+          "english": "The experience was positive.",
+          "japanese": "経験は良いものでした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008717",
+          "english": "I'm positive it will work.",
+          "japanese": "うまくいくと確信しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008718",
+          "english": "Positive reinforcement is effective.",
+          "japanese": "肯定的な強化は効果的です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008719",
+          "english": "The outcome was positive.",
+          "japanese": "結果は良好でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000087-0087-0087-0087-000000008720",
+          "english": "Positive energy motivates people.",
+          "japanese": "ポジティブなエネルギーが人々を動機づけます。",
+          "category": "励まし"
+        }
+      ],
+      "createdAt": 793332000.000000
+    },
+    {
+      "id": "10000088-0088-0088-0088-000000000088",
+      "word": "negative",
+      "meaning": "否定的な、消極的な",
+      "phonetic": "ˈneɡ.ə.tɪv",
+      "sentences": [
+        {
+          "id": "10000088-0088-0088-0088-000000008801",
+          "english": "Don't be so negative.",
+          "japanese": "そんなに否定的にならないでください。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008802",
+          "english": "The test result was negative.",
+          "japanese": "検査結果は陰性でした。",
+          "category": "医療"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008803",
+          "english": "We received negative feedback.",
+          "japanese": "否定的なフィードバックを受け取りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008804",
+          "english": "The impact was negative.",
+          "japanese": "影響は否定的でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008805",
+          "english": "He has a negative attitude.",
+          "japanese": "彼は否定的な態度を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008806",
+          "english": "Avoid negative thinking.",
+          "japanese": "否定的な思考を避けてください。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008807",
+          "english": "The review was mostly negative.",
+          "japanese": "レビューはおおむね否定的でした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008808",
+          "english": "Negative numbers are below zero.",
+          "japanese": "負の数はゼロより下です。",
+          "category": "数学"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008809",
+          "english": "The response was negative.",
+          "japanese": "返答は否定的でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008810",
+          "english": "Negative comments hurt morale.",
+          "japanese": "否定的なコメントは士気を傷つけます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008811",
+          "english": "The outcome was negative.",
+          "japanese": "結果は否定的でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008812",
+          "english": "She answered in the negative.",
+          "japanese": "彼女は否定的に答えました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008813",
+          "english": "Negative pressure affects performance.",
+          "japanese": "否定的な圧力はパフォーマンスに影響します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008814",
+          "english": "The film shows the negative side.",
+          "japanese": "映画は否定的な面を示しています。",
+          "category": "エンターテイメント"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008815",
+          "english": "Negative emotions are natural.",
+          "japanese": "否定的な感情は自然です。",
+          "category": "心理"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008816",
+          "english": "The trend turned negative.",
+          "japanese": "傾向が否定的になりました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008817",
+          "english": "Negative effects were minimal.",
+          "japanese": "否定的な影響は最小限でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008818",
+          "english": "The experience left a negative impression.",
+          "japanese": "経験は否定的な印象を残しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008819",
+          "english": "Negative growth concerns investors.",
+          "japanese": "マイナス成長は投資家を懸念させます。",
+          "category": "経済"
+        },
+        {
+          "id": "10000088-0088-0088-0088-000000008820",
+          "english": "Turn negative situations into opportunities.",
+          "japanese": "否定的な状況を機会に変えてください。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793335600.000000
+    },
+    {
+      "id": "10000089-0089-0089-0089-000000000089",
+      "word": "confident",
+      "meaning": "自信のある",
+      "phonetic": "ˈkɑːn.fɪ.dənt",
+      "sentences": [
+        {
+          "id": "10000089-0089-0089-0089-000000008901",
+          "english": "She's very confident in her abilities.",
+          "japanese": "彼女は自分の能力に非常に自信があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008902",
+          "english": "I'm confident we'll succeed.",
+          "japanese": "成功すると確信しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008903",
+          "english": "He spoke with confident voice.",
+          "japanese": "彼は自信に満ちた声で話しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008904",
+          "english": "Be more confident in yourself.",
+          "japanese": "もっと自信を持ってください。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008905",
+          "english": "The team is confident about winning.",
+          "japanese": "チームは勝利に自信を持っています。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008906",
+          "english": "She gave a confident presentation.",
+          "japanese": "彼女は自信に満ちたプレゼンをしました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008907",
+          "english": "We're confident in the product.",
+          "japanese": "製品に自信があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008908",
+          "english": "His confident manner impressed everyone.",
+          "japanese": "彼の自信に満ちた態度が皆を感心させました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008909",
+          "english": "I'm confident this will work.",
+          "japanese": "これがうまくいくと確信しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008910",
+          "english": "The CEO appeared confident.",
+          "japanese": "CEOは自信があるように見えました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008911",
+          "english": "Confidence comes with practice.",
+          "japanese": "自信は練習から生まれます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008912",
+          "english": "She's quietly confident.",
+          "japanese": "彼女は静かに自信を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008913",
+          "english": "We remain confident despite challenges.",
+          "japanese": "課題にもかかわらず自信を保っています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008914",
+          "english": "His confident smile reassured us.",
+          "japanese": "彼の自信に満ちた笑顔が私たちを安心させました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008915",
+          "english": "Investors are confident in growth.",
+          "japanese": "投資家は成長に自信を持っています。",
+          "category": "金融"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008916",
+          "english": "She walked with confident steps.",
+          "japanese": "彼女は自信に満ちた足取りで歩きました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008917",
+          "english": "The doctor seemed confident.",
+          "japanese": "医師は自信があるように見えました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008918",
+          "english": "We're confident about the future.",
+          "japanese": "未来について自信があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008919",
+          "english": "He answered with confident certainty.",
+          "japanese": "彼は確信に満ちた自信で答えました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000089-0089-0089-0089-000000008920",
+          "english": "Build your confident through experience.",
+          "japanese": "経験を通じて自信をつけてください。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793339200.000000
+    },
+    {
+      "id": "10000090-0090-0090-0090-000000000090",
+      "word": "independent",
+      "meaning": "独立した",
+      "phonetic": "ˌɪn.dɪˈpen.dənt",
+      "sentences": [
+        {
+          "id": "10000090-0090-0090-0090-000000009001",
+          "english": "She's financially independent.",
+          "japanese": "彼女は経済的に独立しています。",
+          "category": "金融"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009002",
+          "english": "The country became independent in 1776.",
+          "japanese": "その国は1776年に独立しました。",
+          "category": "歴史"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009003",
+          "english": "We need an independent review.",
+          "japanese": "独立したレビューが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009004",
+          "english": "He's an independent thinker.",
+          "japanese": "彼は独立した思想家です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009005",
+          "english": "The report is from independent sources.",
+          "japanese": "レポートは独立した情報源からのものです。",
+          "category": "メディア"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009006",
+          "english": "She wants to be independent.",
+          "japanese": "彼女は独立したいと思っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009007",
+          "english": "The company operates independently.",
+          "japanese": "会社は独立して運営されています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009008",
+          "english": "We value independent opinions.",
+          "japanese": "独立した意見を大切にしています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009009",
+          "english": "He runs an independent business.",
+          "japanese": "彼は独立したビジネスを運営しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009010",
+          "english": "Children become more independent.",
+          "japanese": "子供たちはより独立していきます。",
+          "category": "家族"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009011",
+          "english": "The study was independently verified.",
+          "japanese": "研究は独立して検証されました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009012",
+          "english": "She's an independent contractor.",
+          "japanese": "彼女は独立した請負業者です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009013",
+          "english": "The regions operate independently.",
+          "japanese": "地域は独立して運営されています。",
+          "category": "政治"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009014",
+          "english": "We need independent verification.",
+          "japanese": "独立した検証が必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009015",
+          "english": "He values his independence.",
+          "japanese": "彼は自分の独立性を大切にしています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009016",
+          "english": "The judge is independent.",
+          "japanese": "裁判官は独立しています。",
+          "category": "法律"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009017",
+          "english": "She made an independent decision.",
+          "japanese": "彼女は独立した決定をしました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009018",
+          "english": "Independent research supports this.",
+          "japanese": "独立した研究がこれを支持しています。",
+          "category": "科学"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009019",
+          "english": "The two events are independent.",
+          "japanese": "2つのイベントは独立しています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000090-0090-0090-0090-000000009020",
+          "english": "They work independently of each other.",
+          "japanese": "彼らは互いに独立して働いています。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793342800.000000
+    },
+    {
+      "id": "10000091-0091-0091-0091-000000000091",
+      "word": "creative",
+      "meaning": "創造的な",
+      "phonetic": "kriˈeɪ.tɪv",
+      "sentences": [
+        {
+          "id": "10000091-0091-0091-0091-000000009101",
+          "english": "She's a creative person.",
+          "japanese": "彼女は創造的な人です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009102",
+          "english": "We need creative solutions.",
+          "japanese": "創造的な解決策が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009103",
+          "english": "The team showed creative thinking.",
+          "japanese": "チームは創造的思考を示しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009104",
+          "english": "He works in the creative industry.",
+          "japanese": "彼は創造的な業界で働いています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009105",
+          "english": "The design is very creative.",
+          "japanese": "デザインは非常に創造的です。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009106",
+          "english": "Encourage creative expression.",
+          "japanese": "創造的な表現を奨励してください。",
+          "category": "教育"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009107",
+          "english": "She has a creative mind.",
+          "japanese": "彼女は創造的な頭脳を持っています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009108",
+          "english": "The campaign was highly creative.",
+          "japanese": "キャンペーンは非常に創造的でした。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009109",
+          "english": "Creative people see things differently.",
+          "japanese": "創造的な人は物事を違う風に見ます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009110",
+          "english": "We value creative ideas.",
+          "japanese": "創造的なアイデアを大切にしています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009111",
+          "english": "The writer is very creative.",
+          "japanese": "その作家は非常に創造的です。",
+          "category": "文学"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009112",
+          "english": "Creative freedom is important.",
+          "japanese": "創造的自由は重要です。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009113",
+          "english": "He found a creative approach.",
+          "japanese": "彼は創造的なアプローチを見つけました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009114",
+          "english": "The project requires creative talent.",
+          "japanese": "プロジェクトには創造的な才能が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009115",
+          "english": "Creative thinking solves problems.",
+          "japanese": "創造的思考が問題を解決します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009116",
+          "english": "She works in creative development.",
+          "japanese": "彼女はクリエイティブ開発で働いています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009117",
+          "english": "The advertisement was creative.",
+          "japanese": "広告は創造的でした。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009118",
+          "english": "Creative arts inspire people.",
+          "japanese": "創造的芸術は人々を刺激します。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009119",
+          "english": "They use creative techniques.",
+          "japanese": "彼らは創造的な技術を使います。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000091-0091-0091-0091-000000009120",
+          "english": "Creativity drives innovation.",
+          "japanese": "創造性が革新を推進します。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793346400.000000
+    },
+    {
+      "id": "10000092-0092-0092-0092-000000000092",
+      "word": "successful",
+      "meaning": "成功した",
+      "phonetic": "səkˈses.fəl",
+      "sentences": [
+        {
+          "id": "10000092-0092-0092-0092-000000009201",
+          "english": "The project was successful.",
+          "japanese": "プロジェクトは成功しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009202",
+          "english": "She's a successful entrepreneur.",
+          "japanese": "彼女は成功した起業家です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009203",
+          "english": "The event was very successful.",
+          "japanese": "イベントは大成功でした。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009204",
+          "english": "He's successful in business.",
+          "japanese": "彼はビジネスで成功しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009205",
+          "english": "The campaign was successful.",
+          "japanese": "キャンペーンは成功しました。",
+          "category": "マーケティング"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009206",
+          "english": "We had a successful meeting.",
+          "japanese": "成功した会議を持ちました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009207",
+          "english": "The surgery was successful.",
+          "japanese": "手術は成功しました。",
+          "category": "医療"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009208",
+          "english": "She's a successful author.",
+          "japanese": "彼女は成功した作家です。",
+          "category": "文学"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009209",
+          "english": "The launch was successful.",
+          "japanese": "ローンチは成功しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009210",
+          "english": "Successful people work hard.",
+          "japanese": "成功者は懸命に働きます。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009211",
+          "english": "The business is very successful.",
+          "japanese": "ビジネスは非常に成功しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009212",
+          "english": "They built a successful company.",
+          "japanese": "彼らは成功した会社を築きました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009213",
+          "english": "The negotiation was successful.",
+          "japanese": "交渉は成功しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009214",
+          "english": "He has a successful career.",
+          "japanese": "彼は成功したキャリアを持っています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009215",
+          "english": "The product was highly successful.",
+          "japanese": "製品は大成功しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009216",
+          "english": "She's successful and humble.",
+          "japanese": "彼女は成功していて謙虚です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009217",
+          "english": "The trial was successful.",
+          "japanese": "試験は成功しました。",
+          "category": "科学"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009218",
+          "english": "Success requires dedication.",
+          "japanese": "成功には献身が必要です。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009219",
+          "english": "They're a successful team.",
+          "japanese": "彼らは成功したチームです。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000092-0092-0092-0092-000000009220",
+          "english": "The strategy proved successful.",
+          "japanese": "戦略は成功であることが証明されました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793350000.000000
+    },
+    {
+      "id": "10000093-0093-0093-0093-000000000093",
+      "word": "capable",
+      "meaning": "能力がある",
+      "phonetic": "ˈkeɪ.pə.bəl",
+      "sentences": [
+        {
+          "id": "10000093-0093-0093-0093-000000009301",
+          "english": "She's very capable.",
+          "japanese": "彼女は非常に有能です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009302",
+          "english": "Are you capable of handling this?",
+          "japanese": "これを処理できますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009303",
+          "english": "He's a capable leader.",
+          "japanese": "彼は有能なリーダーです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009304",
+          "english": "The team is capable of winning.",
+          "japanese": "チームは勝つことができます。",
+          "category": "スポーツ"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009305",
+          "english": "She proved herself capable.",
+          "japanese": "彼女は自分が有能であることを証明しました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009306",
+          "english": "We need capable employees.",
+          "japanese": "有能な従業員が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009307",
+          "english": "The system is capable of processing millions.",
+          "japanese": "システムは数百万を処理できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009308",
+          "english": "He's capable of great things.",
+          "japanese": "彼は素晴らしいことができます。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009309",
+          "english": "She's a capable manager.",
+          "japanese": "彼女は有能なマネージャーです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009310",
+          "english": "The machine is capable of high speeds.",
+          "japanese": "機械は高速で動作できます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009311",
+          "english": "Are you capable of more?",
+          "japanese": "もっとできますか？",
+          "category": "励まし"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009312",
+          "english": "They're highly capable professionals.",
+          "japanese": "彼らは非常に有能な専門家です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009313",
+          "english": "The device is capable of many functions.",
+          "japanese": "デバイスは多くの機能が可能です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009314",
+          "english": "Everyone is capable of learning.",
+          "japanese": "誰でも学ぶことができます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009315",
+          "english": "She's capable of handling pressure.",
+          "japanese": "彼女はプレッシャーに対処できます。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009316",
+          "english": "The car is capable of 200 km/h.",
+          "japanese": "車は時速200キロが可能です。",
+          "category": "自動車"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009317",
+          "english": "He's more capable than you think.",
+          "japanese": "彼はあなたが思うより有能です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009318",
+          "english": "The technology is capable of improvement.",
+          "japanese": "技術は改善が可能です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009319",
+          "english": "They're capable workers.",
+          "japanese": "彼らは有能な労働者です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000093-0093-0093-0093-000000009320",
+          "english": "You're capable of achieving your goals.",
+          "japanese": "あなたは目標を達成できます。",
+          "category": "励まし"
+        }
+      ],
+      "createdAt": 793353600.000000
+    },
+    {
+      "id": "10000094-0094-0094-0094-000000000094",
+      "word": "sufficient",
+      "meaning": "十分な",
+      "phonetic": "səˈfɪʃ.ənt",
+      "sentences": [
+        {
+          "id": "10000094-0094-0094-0094-000000009401",
+          "english": "Do we have sufficient time?",
+          "japanese": "十分な時間がありますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009402",
+          "english": "The evidence is sufficient.",
+          "japanese": "証拠は十分です。",
+          "category": "法律"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009403",
+          "english": "Is this amount sufficient?",
+          "japanese": "この量で十分ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009404",
+          "english": "We have sufficient resources.",
+          "japanese": "十分なリソースがあります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009405",
+          "english": "The budget is sufficient.",
+          "japanese": "予算は十分です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009406",
+          "english": "Sufficient preparation is essential.",
+          "japanese": "十分な準備が不可欠です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009407",
+          "english": "The information is sufficient.",
+          "japanese": "情報は十分です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009408",
+          "english": "We lack sufficient staff.",
+          "japanese": "十分なスタッフがいません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009409",
+          "english": "Sufficient funding is required.",
+          "japanese": "十分な資金が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009410",
+          "english": "The space is not sufficient.",
+          "japanese": "スペースが十分ではありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009411",
+          "english": "Is the quality sufficient?",
+          "japanese": "品質は十分ですか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009412",
+          "english": "We have sufficient supplies.",
+          "japanese": "十分な供給があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009413",
+          "english": "Sufficient rest is important.",
+          "japanese": "十分な休息が重要です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009414",
+          "english": "The proof is sufficient.",
+          "japanese": "証明は十分です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009415",
+          "english": "We need sufficient training.",
+          "japanese": "十分なトレーニングが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009416",
+          "english": "The explanation was sufficient.",
+          "japanese": "説明は十分でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009417",
+          "english": "Sufficient notice was given.",
+          "japanese": "十分な通知がありました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009418",
+          "english": "The data is sufficient for analysis.",
+          "japanese": "データは分析に十分です。",
+          "category": "科学"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009419",
+          "english": "We have sufficient capacity.",
+          "japanese": "十分な容量があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000094-0094-0094-0094-000000009420",
+          "english": "Sufficient food is available.",
+          "japanese": "十分な食料が利用できます。",
+          "category": "一般的な使い方"
+        }
+      ],
+      "createdAt": 793357200.000000
+    },
+    {
+      "id": "10000095-0095-0095-0095-000000000095",
+      "word": "alternative",
+      "meaning": "代わりの、選択肢",
+      "phonetic": "ɔːlˈtɜː.nə.tɪv",
+      "sentences": [
+        {
+          "id": "10000095-0095-0095-0095-000000009501",
+          "english": "Do you have an alternative plan?",
+          "japanese": "代替案はありますか？",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009502",
+          "english": "We need alternative solutions.",
+          "japanese": "代替解決策が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009503",
+          "english": "There's no alternative.",
+          "japanese": "代わりがありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009504",
+          "english": "Alternative energy is important.",
+          "japanese": "代替エネルギーは重要です。",
+          "category": "環境"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009505",
+          "english": "What's the alternative?",
+          "japanese": "代わりは何ですか？",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009506",
+          "english": "We explored alternative options.",
+          "japanese": "代替オプションを検討しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009507",
+          "english": "Alternative medicine is popular.",
+          "japanese": "代替医療は人気があります。",
+          "category": "医療"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009508",
+          "english": "She took an alternative route.",
+          "japanese": "彼女は別のルートを取りました。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009509",
+          "english": "We have alternative suppliers.",
+          "japanese": "代替供給業者がいます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009510",
+          "english": "Alternative methods exist.",
+          "japanese": "代替方法が存在します。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009511",
+          "english": "The alternative is expensive.",
+          "japanese": "代替案は高価です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009512",
+          "english": "Consider alternative approaches.",
+          "japanese": "代替アプローチを検討してください。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009513",
+          "english": "Alternative perspectives are valuable.",
+          "japanese": "代替の視点は価値があります。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009514",
+          "english": "We offer alternative services.",
+          "japanese": "代替サービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009515",
+          "english": "The alternative seemed better.",
+          "japanese": "代替案の方が良さそうでした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009516",
+          "english": "Alternative dates are available.",
+          "japanese": "代替日が利用できます。",
+          "category": "イベント"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009517",
+          "english": "They chose an alternative path.",
+          "japanese": "彼らは別の道を選びました。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009518",
+          "english": "Alternative products are listed.",
+          "japanese": "代替製品がリストされています。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009519",
+          "english": "We need an alternative strategy.",
+          "japanese": "代替戦略が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000095-0095-0095-0095-000000009520",
+          "english": "The alternative proved successful.",
+          "japanese": "代替案は成功しました。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793360800.000000
+    },
+    {
+      "id": "10000096-0096-0096-0096-000000000096",
+      "word": "temporary",
+      "meaning": "一時的な",
+      "phonetic": "ˈtem.pə.rer.i",
+      "sentences": [
+        {
+          "id": "10000096-0096-0096-0096-000000009601",
+          "english": "This is a temporary solution.",
+          "japanese": "これは一時的な解決策です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009602",
+          "english": "The closure is temporary.",
+          "japanese": "閉鎖は一時的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009603",
+          "english": "We hired temporary staff.",
+          "japanese": "臨時スタッフを雇いました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009604",
+          "english": "The problem is temporary.",
+          "japanese": "問題は一時的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009605",
+          "english": "She has a temporary position.",
+          "japanese": "彼女は臨時の職に就いています。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009606",
+          "english": "This is temporary housing.",
+          "japanese": "これは仮設住宅です。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009607",
+          "english": "The delay is temporary.",
+          "japanese": "遅延は一時的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009608",
+          "english": "We're using temporary measures.",
+          "japanese": "一時的な措置を使用しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009609",
+          "english": "The fix is only temporary.",
+          "japanese": "修正は一時的なものです。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009610",
+          "english": "Temporary workers are needed.",
+          "japanese": "臨時労働者が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009611",
+          "english": "The pain is temporary.",
+          "japanese": "痛みは一時的です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009612",
+          "english": "We established temporary offices.",
+          "japanese": "仮設オフィスを設置しました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009613",
+          "english": "The change is temporary.",
+          "japanese": "変更は一時的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009614",
+          "english": "He took a temporary leave.",
+          "japanese": "彼は一時的な休暇を取りました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009615",
+          "english": "Temporary storage is available.",
+          "japanese": "一時保管が利用できます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009616",
+          "english": "The arrangement is temporary.",
+          "japanese": "取り決めは一時的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009617",
+          "english": "Temporary setbacks happen.",
+          "japanese": "一時的な挫折は起こります。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009618",
+          "english": "We need temporary funding.",
+          "japanese": "一時的な資金が必要です。",
+          "category": "金融"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009619",
+          "english": "The effect is temporary.",
+          "japanese": "効果は一時的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000096-0096-0096-0096-000000009620",
+          "english": "Temporary access was granted.",
+          "japanese": "一時的なアクセスが許可されました。",
+          "category": "テクノロジー"
+        }
+      ],
+      "createdAt": 793364400.000000
+    },
+    {
+      "id": "10000097-0097-0097-0097-000000000097",
+      "word": "permanent",
+      "meaning": "永久的な",
+      "phonetic": "ˈpɜː.mə.nənt",
+      "sentences": [
+        {
+          "id": "10000097-0097-0097-0097-000000009701",
+          "english": "This is a permanent position.",
+          "japanese": "これは正社員のポジションです。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009702",
+          "english": "The damage may be permanent.",
+          "japanese": "損傷は永久的かもしれません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009703",
+          "english": "We need a permanent solution.",
+          "japanese": "恒久的な解決策が必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009704",
+          "english": "She has permanent residency.",
+          "japanese": "彼女は永住権を持っています。",
+          "category": "法律"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009705",
+          "english": "The change is permanent.",
+          "japanese": "変更は恒久的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009706",
+          "english": "Permanent employees get benefits.",
+          "japanese": "正社員は福利厚生を受けられます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009707",
+          "english": "The closure is permanent.",
+          "japanese": "閉鎖は永久的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009708",
+          "english": "We're looking for permanent staff.",
+          "japanese": "正社員を探しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009709",
+          "english": "The scar is permanent.",
+          "japanese": "傷跡は永久的です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009710",
+          "english": "Permanent records are kept.",
+          "japanese": "永久記録が保管されています。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009711",
+          "english": "The move is permanent.",
+          "japanese": "移動は恒久的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009712",
+          "english": "He got a permanent job.",
+          "japanese": "彼は正社員の仕事を得ました。",
+          "category": "キャリア"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009713",
+          "english": "Permanent changes were made.",
+          "japanese": "恒久的な変更が行われました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009714",
+          "english": "The address is permanent.",
+          "japanese": "住所は恒久的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009715",
+          "english": "Nothing is truly permanent.",
+          "japanese": "本当に恒久的なものはありません。",
+          "category": "人生の教訓"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009716",
+          "english": "The exhibit is now permanent.",
+          "japanese": "展示は現在恒久的です。",
+          "category": "芸術"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009717",
+          "english": "Permanent markers don't erase.",
+          "japanese": "油性マーカーは消えません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009718",
+          "english": "The effect is permanent.",
+          "japanese": "効果は恒久的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009719",
+          "english": "We made a permanent fix.",
+          "japanese": "恒久的な修正を行いました。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000097-0097-0097-0097-000000009720",
+          "english": "Permanent disability was confirmed.",
+          "japanese": "永久障害が確認されました。",
+          "category": "医療"
+        }
+      ],
+      "createdAt": 793368000.000000
+    },
+    {
+      "id": "10000098-0098-0098-0098-000000000098",
+      "word": "regular",
+      "meaning": "定期的な、通常の",
+      "phonetic": "ˈreɡ.jə.lɚ",
+      "sentences": [
+        {
+          "id": "10000098-0098-0098-0098-000000009801",
+          "english": "We have regular meetings.",
+          "japanese": "定例会議があります。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009802",
+          "english": "Exercise regularly for health.",
+          "japanese": "健康のために定期的に運動してください。",
+          "category": "健康"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009803",
+          "english": "He's a regular customer.",
+          "japanese": "彼は常連客です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009804",
+          "english": "The regular price is $50.",
+          "japanese": "通常価格は50ドルです。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009805",
+          "english": "Maintain a regular schedule.",
+          "japanese": "規則正しいスケジュールを保ってください。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009806",
+          "english": "Regular checkups are important.",
+          "japanese": "定期検診は重要です。",
+          "category": "医療"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009807",
+          "english": "She's a regular visitor.",
+          "japanese": "彼女は常連訪問者です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009808",
+          "english": "The bus runs on regular schedule.",
+          "japanese": "バスは定刻運行します。",
+          "category": "旅行"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009809",
+          "english": "Regular updates are provided.",
+          "japanese": "定期的な更新が提供されます。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009810",
+          "english": "He works regular hours.",
+          "japanese": "彼は通常の勤務時間で働きます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009811",
+          "english": "Regular practice improves skills.",
+          "japanese": "定期的な練習がスキルを向上させます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009812",
+          "english": "The store has regular sales.",
+          "japanese": "店は定期的にセールをします。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009813",
+          "english": "Regular maintenance is required.",
+          "japanese": "定期的なメンテナンスが必要です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009814",
+          "english": "She drinks regular coffee.",
+          "japanese": "彼女は普通のコーヒーを飲みます。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009815",
+          "english": "Regular attendance is expected.",
+          "japanese": "定期的な出席が求められます。",
+          "category": "教育"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009816",
+          "english": "The program has regular features.",
+          "japanese": "プログラムには定期的な機能があります。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009817",
+          "english": "Regular sleep is essential.",
+          "japanese": "規則正しい睡眠は不可欠です。",
+          "category": "健康"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009818",
+          "english": "We offer regular service.",
+          "japanese": "定期的なサービスを提供します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009819",
+          "english": "He's a regular guy.",
+          "japanese": "彼は普通の人です。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000098-0098-0098-0098-000000009820",
+          "english": "Regular communication is key.",
+          "japanese": "定期的なコミュニケーションが鍵です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793371600.000000
+    },
+    {
+      "id": "10000099-0099-0099-0099-000000000099",
+      "word": "ordinary",
+      "meaning": "普通の",
+      "phonetic": "ˈɔːr.dən.er.i",
+      "sentences": [
+        {
+          "id": "10000099-0099-0099-0099-000000009901",
+          "english": "It was just an ordinary day.",
+          "japanese": "ただの普通の日でした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009902",
+          "english": "She's no ordinary person.",
+          "japanese": "彼女は普通の人ではありません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009903",
+          "english": "This is an ordinary problem.",
+          "japanese": "これは普通の問題です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009904",
+          "english": "He leads an ordinary life.",
+          "japanese": "彼は普通の生活を送っています。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009905",
+          "english": "The food is quite ordinary.",
+          "japanese": "食べ物はかなり普通です。",
+          "category": "レストラン"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009906",
+          "english": "It's an ordinary occurrence.",
+          "japanese": "よくある出来事です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009907",
+          "english": "Ordinary people can achieve greatness.",
+          "japanese": "普通の人々が偉大なことを成し遂げられます。",
+          "category": "励まし"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009908",
+          "english": "The meeting was ordinary.",
+          "japanese": "会議は普通でした。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009909",
+          "english": "Nothing out of the ordinary happened.",
+          "japanese": "特別なことは何も起こりませんでした。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009910",
+          "english": "The house looks ordinary.",
+          "japanese": "家は普通に見えます。",
+          "category": "不動産"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009911",
+          "english": "She's an ordinary student.",
+          "japanese": "彼女は普通の学生です。",
+          "category": "教育"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009912",
+          "english": "Ordinary circumstances don't apply.",
+          "japanese": "通常の状況は当てはまりません。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009913",
+          "english": "The price is ordinary.",
+          "japanese": "価格は普通です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009914",
+          "english": "He's an ordinary worker.",
+          "japanese": "彼は普通の労働者です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009915",
+          "english": "The results were ordinary.",
+          "japanese": "結果は普通でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009916",
+          "english": "Ordinary methods won't work.",
+          "japanese": "通常の方法はうまくいきません。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009917",
+          "english": "It's an ordinary product.",
+          "japanese": "普通の製品です。",
+          "category": "買い物"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009918",
+          "english": "The experience was ordinary.",
+          "japanese": "経験は普通でした。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009919",
+          "english": "She wore ordinary clothes.",
+          "japanese": "彼女は普通の服を着ていました。",
+          "category": "日常会話"
+        },
+        {
+          "id": "10000099-0099-0099-0099-000000009920",
+          "english": "Extraordinary comes from ordinary efforts.",
+          "japanese": "非凡は普通の努力から生まれます。",
+          "category": "人生の教訓"
+        }
+      ],
+      "createdAt": 793375200.000000
+    },
+    {
+      "id": "10000100-0100-0100-0100-000000000100",
+      "word": "efficient",
+      "meaning": "効率的な",
+      "phonetic": "ɪˈfɪʃ.ənt",
+      "sentences": [
+        {
+          "id": "10000100-0100-0100-0100-000000010001",
+          "english": "This is an efficient method.",
+          "japanese": "これは効率的な方法です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010002",
+          "english": "The system is highly efficient.",
+          "japanese": "システムは非常に効率的です。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010003",
+          "english": "She works very efficiently.",
+          "japanese": "彼女は非常に効率的に働きます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010004",
+          "english": "We need more efficient processes.",
+          "japanese": "より効率的なプロセスが必要です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010005",
+          "english": "The car is fuel efficient.",
+          "japanese": "その車は燃費が良いです。",
+          "category": "自動車"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010006",
+          "english": "Efficient planning saves time.",
+          "japanese": "効率的な計画は時間を節約します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010007",
+          "english": "The team is very efficient.",
+          "japanese": "チームは非常に効率的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010008",
+          "english": "We use efficient technology.",
+          "japanese": "効率的な技術を使用しています。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010009",
+          "english": "Efficient communication is essential.",
+          "japanese": "効率的なコミュニケーションは不可欠です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010010",
+          "english": "The operation is cost efficient.",
+          "japanese": "運営は費用効率が良いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010011",
+          "english": "He's an efficient manager.",
+          "japanese": "彼は効率的なマネージャーです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010012",
+          "english": "The design is simple and efficient.",
+          "japanese": "デザインはシンプルで効率的です。",
+          "category": "一般的な使い方"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010013",
+          "english": "Energy efficient appliances save money.",
+          "japanese": "省エネ家電はお金を節約します。",
+          "category": "環境"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010014",
+          "english": "We strive for efficient service.",
+          "japanese": "効率的なサービスを目指しています。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010015",
+          "english": "The workflow is efficient.",
+          "japanese": "ワークフローは効率的です。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010016",
+          "english": "Efficiency improves productivity.",
+          "japanese": "効率性は生産性を向上させます。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010017",
+          "english": "The solution is time efficient.",
+          "japanese": "解決策は時間効率が良いです。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010018",
+          "english": "They use efficient strategies.",
+          "japanese": "彼らは効率的な戦略を使用します。",
+          "category": "ビジネス"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010019",
+          "english": "The machine operates efficiently.",
+          "japanese": "機械は効率的に動作します。",
+          "category": "テクノロジー"
+        },
+        {
+          "id": "10000100-0100-0100-0100-000000010020",
+          "english": "Efficient use of resources is key.",
+          "japanese": "資源の効率的な使用が鍵です。",
+          "category": "ビジネス"
+        }
+      ],
+      "createdAt": 793378800.000000
+    }
+  ]
+}


### PR DESCRIPTION
- Created word_set.json with 100 common English words
- Each word includes 20 diverse example sentences
- Covers various contexts: business, daily conversation, health, travel, education, etc.
- Total of 2,000 bilingual example sentences
- File size: 408KB, 2,904 lines
- All entries include: word, meaning, phonetic (IPA), and categorized sentences

## Summary
<!-- Describe what this PR changes -->

## Related Issue
Closes #34

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactoring
- [ ] Docs
- [ ] Infrastructure (AWS CDK)
- [x] Other

## Changes
<!-- List the main changes in bullet points -->
- add data set word

## Testing
- [ ] iOS build verified (`xcodebuild build`)
- [ ] Manually tested

