### PR TITLE
Refactor: Extract continuous playback logic into shared services (#70)

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -9,12 +9,17 @@
 /* Begin PBXBuildFile section */
 		850E49D02F4952F8000F46C6 /* ActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CE2F4952F8000F46C6 /* ActionBar.swift */; };
 		850E49D12F4952F8000F46C6 /* SelectableListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CF2F4952F8000F46C6 /* SelectableListRow.swift */; };
-		85F6833D2F4AA9AC00389866 /* WordImportErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F6833C2F4AA9AC00389866 /* WordImportErrorHandler.swift */; };
+		8577C1722F4BE3D20061F175 /* WordImportErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */; };
+		8577C1982F4BE5AC0061F175 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1942F4BE5AC0061F175 /* SettingsManager.swift */; };
+		8577C1992F4BE5AC0061F175 /* NowPlayingInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */; };
+		8577C19A2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18C2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift */; };
+		8577C19B2F4BE5AC0061F175 /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1962F4BE5AC0061F175 /* SpeechService.swift */; };
+		8577C19C2F4BE5AC0061F175 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1922F4BE5AC0061F175 /* OpenAIService.swift */; };
+		8577C19D2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18E2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift */; };
+		8577C19F2F4BE5AC0061F175 /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1952F4BE5AC0061F175 /* SpeechRecognizer.swift */; };
 		A1000001238D1234567890AB /* EnglishLearnAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000011238D1234567890AB /* EnglishLearnAppApp.swift */; };
 		A1000002238D1234567890AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000012238D1234567890AB /* ContentView.swift */; };
 		A1000003238D1234567890AB /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000013238D1234567890AB /* Word.swift */; };
-		A1000004238D1234567890AB /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000014238D1234567890AB /* SpeechService.swift */; };
-		A1000005238D1234567890AB /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000015238D1234567890AB /* SpeechRecognizer.swift */; };
 		A1000006238D1234567890AB /* WordListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000016238D1234567890AB /* WordListView.swift */; };
 		A1000007238D1234567890AB /* WordPracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000017238D1234567890AB /* WordPracticeView.swift */; };
 		A1000008238D1234567890AB /* words.json in Resources */ = {isa = PBXBuildFile; fileRef = A1000018238D1234567890AB /* words.json */; };
@@ -23,8 +28,6 @@
 		A100000B238D1234567890AB /* SentenceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001C238D1234567890AB /* SentenceListView.swift */; };
 		A100000C238D1234567890AB /* SentencePracticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001D238D1234567890AB /* SentencePracticeView.swift */; };
 		A100000D238D1234567890AB /* AddWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001E238D1234567890AB /* AddWordView.swift */; };
-		A100000E238D1234567890AB /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100001F238D1234567890AB /* OpenAIService.swift */; };
-		A100000F238D1234567890AB /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000020238D1234567890AB /* SettingsManager.swift */; };
 		A1000010238D1234567890AB /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000022238D1234567890AB /* SettingsView.swift */; };
 		A1000025238D1234567890AB /* TrashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000023238D1234567890AB /* TrashView.swift */; };
 		A1000026238D1234567890AB /* EditWordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000024238D1234567890AB /* EditWordView.swift */; };
@@ -46,12 +49,17 @@
 /* Begin PBXFileReference section */
 		850E49CE2F4952F8000F46C6 /* ActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionBar.swift; sourceTree = "<group>"; };
 		850E49CF2F4952F8000F46C6 /* SelectableListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableListRow.swift; sourceTree = "<group>"; };
-		85F6833C2F4AA9AC00389866 /* WordImportErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordImportErrorHandler.swift; sourceTree = "<group>"; };
+		8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordImportErrorHandler.swift; sourceTree = "<group>"; };
+		8577C18C2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContinuousPlaybackManager.swift; sourceTree = "<group>"; };
+		8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoManager.swift; sourceTree = "<group>"; };
+		8577C18E2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCommandCenterManager.swift; sourceTree = "<group>"; };
+		8577C1922F4BE5AC0061F175 /* OpenAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIService.swift; sourceTree = "<group>"; };
+		8577C1942F4BE5AC0061F175 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
+		8577C1952F4BE5AC0061F175 /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
+		8577C1962F4BE5AC0061F175 /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
 		A1000011238D1234567890AB /* EnglishLearnAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnglishLearnAppApp.swift; sourceTree = "<group>"; };
 		A1000012238D1234567890AB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A1000013238D1234567890AB /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
-		A1000014238D1234567890AB /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
-		A1000015238D1234567890AB /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 		A1000016238D1234567890AB /* WordListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordListView.swift; sourceTree = "<group>"; };
 		A1000017238D1234567890AB /* WordPracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPracticeView.swift; sourceTree = "<group>"; };
 		A1000018238D1234567890AB /* words.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = words.json; sourceTree = "<group>"; };
@@ -61,8 +69,6 @@
 		A100001C238D1234567890AB /* SentenceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentenceListView.swift; sourceTree = "<group>"; };
 		A100001D238D1234567890AB /* SentencePracticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentencePracticeView.swift; sourceTree = "<group>"; };
 		A100001E238D1234567890AB /* AddWordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWordView.swift; sourceTree = "<group>"; };
-		A100001F238D1234567890AB /* OpenAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIService.swift; sourceTree = "<group>"; };
-		A1000020238D1234567890AB /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		A1000021238D1234567890AB /* EnglishLearnApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EnglishLearnApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1000022238D1234567890AB /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		A1000023238D1234567890AB /* TrashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrashView.swift; sourceTree = "<group>"; };
@@ -93,6 +99,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8577C18F2F4BE5AC0061F175 /* Playback */ = {
+			isa = PBXGroup;
+			children = (
+				8577C18C2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift */,
+				8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */,
+				8577C18E2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift */,
+			);
+			path = Playback;
+			sourceTree = "<group>";
+		};
+		8577C1972F4BE5AC0061F175 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				8577C18F2F4BE5AC0061F175 /* Playback */,
+				8577C1922F4BE5AC0061F175 /* OpenAIService.swift */,
+				8577C1942F4BE5AC0061F175 /* SettingsManager.swift */,
+				8577C1952F4BE5AC0061F175 /* SpeechRecognizer.swift */,
+				8577C1962F4BE5AC0061F175 /* SpeechService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		A1000030238D1234567890AB = {
 			isa = PBXGroup;
 			children = (
@@ -104,10 +132,10 @@
 		A1000031238D1234567890AB /* EnglishLearnApp */ = {
 			isa = PBXGroup;
 			children = (
+				8577C1972F4BE5AC0061F175 /* Services */,
 				A1000011238D1234567890AB /* EnglishLearnAppApp.swift */,
 				A1000028238D1234567890AB /* AppConfig.swift */,
 				A1000033238D1234567890AB /* Models */,
-				A1000034238D1234567890AB /* Services */,
 				A1000035238D1234567890AB /* Views */,
 				A1000036238D1234567890AB /* Resources */,
 				A1000019238D1234567890AB /* Assets.xcassets */,
@@ -128,22 +156,11 @@
 		A1000033238D1234567890AB /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				85F6833C2F4AA9AC00389866 /* WordImportErrorHandler.swift */,
+				8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */,
 				A1000013238D1234567890AB /* Word.swift */,
 				A100007A238D1234567890AB /* PromptPreset.swift */,
 			);
 			path = Models;
-			sourceTree = "<group>";
-		};
-		A1000034238D1234567890AB /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				A1000014238D1234567890AB /* SpeechService.swift */,
-				A1000015238D1234567890AB /* SpeechRecognizer.swift */,
-				A100001F238D1234567890AB /* OpenAIService.swift */,
-				A1000020238D1234567890AB /* SettingsManager.swift */,
-			);
-			path = Services;
 			sourceTree = "<group>";
 		};
 		A1000035238D1234567890AB /* Views */ = {
@@ -274,15 +291,18 @@
 				A1000001238D1234567890AB /* EnglishLearnAppApp.swift in Sources */,
 				A1000002238D1234567890AB /* ContentView.swift in Sources */,
 				A1000003238D1234567890AB /* Word.swift in Sources */,
-				A1000004238D1234567890AB /* SpeechService.swift in Sources */,
-				A1000005238D1234567890AB /* SpeechRecognizer.swift in Sources */,
 				A1000006238D1234567890AB /* WordListView.swift in Sources */,
 				A1000007238D1234567890AB /* WordPracticeView.swift in Sources */,
 				A100000B238D1234567890AB /* SentenceListView.swift in Sources */,
 				A100000C238D1234567890AB /* SentencePracticeView.swift in Sources */,
+				8577C1982F4BE5AC0061F175 /* SettingsManager.swift in Sources */,
+				8577C1992F4BE5AC0061F175 /* NowPlayingInfoManager.swift in Sources */,
+				8577C19A2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift in Sources */,
+				8577C19B2F4BE5AC0061F175 /* SpeechService.swift in Sources */,
+				8577C19C2F4BE5AC0061F175 /* OpenAIService.swift in Sources */,
+				8577C19D2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift in Sources */,
+				8577C19F2F4BE5AC0061F175 /* SpeechRecognizer.swift in Sources */,
 				A100000D238D1234567890AB /* AddWordView.swift in Sources */,
-				A100000E238D1234567890AB /* OpenAIService.swift in Sources */,
-				A100000F238D1234567890AB /* SettingsManager.swift in Sources */,
 				A1000010238D1234567890AB /* SettingsView.swift in Sources */,
 				A1000025238D1234567890AB /* TrashView.swift in Sources */,
 				A1000026238D1234567890AB /* EditWordView.swift in Sources */,
@@ -292,10 +312,10 @@
 				A100007F238D1234567890AB /* OnboardingView.swift in Sources */,
 				A1000027238D1234567890AB /* AppConfig.swift in Sources */,
 				A100007B238D1234567890AB /* PromptPreset.swift in Sources */,
+				8577C1722F4BE3D20061F175 /* WordImportErrorHandler.swift in Sources */,
 				A100007D238D1234567890AB /* PromptPresetsView.swift in Sources */,
 				A1000081238D1234567890AB /* ActivityPresenter.swift in Sources */,
 				A1000083238D1234567890AB /* SelectionState.swift in Sources */,
-				85F6833D2F4AA9AC00389866 /* WordImportErrorHandler.swift in Sources */,
 				A1000085238D1234567890AB /* EmptyListView.swift in Sources */,
 				A1000087238D1234567890AB /* PronunciationResultView.swift in Sources */,
 				A1000089238D1234567890AB /* RecognitionResultView.swift in Sources */,

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/ContinuousPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/ContinuousPlaybackManager.swift
@@ -8,7 +8,8 @@ import Observation
 /// - Playback state (playing/stopped, current index, current step)
 /// - Generation-based cancellation to prevent race conditions
 /// - Playback advancement through steps and items
-/// - Thread-safe state updates
+///
+/// **Thread Safety:** All methods must be called from the main thread.
 ///
 /// Generic parameter T represents the item type being played (e.g., Sentence or (Word, Sentence)).
 @Observable

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/ContinuousPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/ContinuousPlaybackManager.swift
@@ -1,0 +1,201 @@
+import Foundation
+import Observation
+
+/// Generic continuous playback manager that handles state and logic for playing through a sequence of items.
+///
+/// This manager consolidates the duplicated playback logic previously spread across
+/// WordListView and SentenceListView. It handles:
+/// - Playback state (playing/stopped, current index, current step)
+/// - Generation-based cancellation to prevent race conditions
+/// - Playback advancement through steps and items
+/// - Thread-safe state updates
+///
+/// Generic parameter T represents the item type being played (e.g., Sentence or (Word, Sentence)).
+@Observable
+final class ContinuousPlaybackManager<Item> {
+    // MARK: - State
+
+    /// Whether continuous playback is currently active.
+    private(set) var isPlaying: Bool = false
+
+    /// Current index in the items array.
+    private(set) var currentIndex: Int = 0
+
+    /// Current playback step within an item (0-based).
+    /// For bilingual mode: 0=EN, 1=JA, 2=EN (3 steps)
+    /// For English-only mode: 0=EN, 1=EN (2 steps)
+    private(set) var currentStep: Int = 0
+
+    /// Playback generation counter for invalidating stale async tasks.
+    /// Incremented when starting/stopping playback to ensure old completion
+    /// callbacks don't affect the new session.
+    private(set) var playbackGeneration: Int = 0
+
+    /// Expected generation value when speech started.
+    /// Checked on speech completion to validate this is still the active session.
+    private(set) var expectedGeneration: Int = 0
+
+    // MARK: - Configuration
+
+    /// Current playback mode determining step sequence.
+    var playbackMode: SettingsManager.PlaybackMode
+
+    /// Items to play through.
+    private(set) var items: [Item] = []
+
+    /// Callback invoked when speech should be performed for an item at a specific step.
+    /// Parameters: (item, step)
+    private let speechHandler: (Item, Int) -> Void
+
+    /// Callback invoked when playback completes all items.
+    private let completionHandler: () -> Void
+
+    // MARK: - Initialization
+
+    /// Creates a new continuous playback manager.
+    ///
+    /// - Parameters:
+    ///   - playbackMode: The initial playback mode (bilingual or English-only)
+    ///   - speechHandler: Closure called when speech should be performed for an item at a step
+    ///   - completionHandler: Closure called when all items have been played
+    init(
+        playbackMode: SettingsManager.PlaybackMode,
+        speechHandler: @escaping (Item, Int) -> Void,
+        completionHandler: @escaping () -> Void = {}
+    ) {
+        self.playbackMode = playbackMode
+        self.speechHandler = speechHandler
+        self.completionHandler = completionHandler
+    }
+
+    // MARK: - Public Methods
+
+    /// Starts continuous playback from the beginning or a specific index.
+    ///
+    /// This method increments the playback generation to invalidate any pending
+    /// async tasks from previous sessions, preventing race conditions.
+    ///
+    /// - Parameters:
+    ///   - items: Array of items to play
+    ///   - startIndex: Index to start from (default: 0)
+    func start(items: [Item], startIndex: Int = 0) {
+        guard !items.isEmpty, startIndex >= 0, startIndex < items.count else { return }
+
+        // Increment generation to invalidate pending tasks
+        playbackGeneration += 1
+
+        self.items = items
+        currentIndex = startIndex
+        currentStep = 0
+        isPlaying = true
+        expectedGeneration = playbackGeneration
+
+        speechHandler(items[currentIndex], currentStep)
+    }
+
+    /// Stops continuous playback and clears state.
+    ///
+    /// Increments the generation counter to ensure any in-flight completion
+    /// callbacks from the previous session are ignored.
+    func stop() {
+        playbackGeneration += 1
+        isPlaying = false
+        currentIndex = 0
+        currentStep = 0
+        items = []
+    }
+
+    /// Advances to the next playback step or item.
+    ///
+    /// Called after speech completion. Progresses through the playback cycle:
+    /// - Bilingual: EN→JA→EN (3 steps per item)
+    /// - English-only: EN→EN (2 steps per item)
+    ///
+    /// When all steps for an item complete, moves to the next item.
+    /// When all items complete, stops playback and calls completion handler.
+    func advance() {
+        guard isPlaying else { return }
+
+        let maxSteps = playbackMode.stepsPerItem
+        let nextStep = currentStep + 1
+
+        if nextStep < maxSteps {
+            // More steps remain within the current item
+            currentStep = nextStep
+            expectedGeneration = playbackGeneration
+            speechHandler(items[currentIndex], currentStep)
+        } else {
+            // Move to the next item
+            let nextIndex = currentIndex + 1
+            if nextIndex < items.count {
+                currentIndex = nextIndex
+                currentStep = 0
+                expectedGeneration = playbackGeneration
+                speechHandler(items[currentIndex], currentStep)
+            } else {
+                // All items done
+                stop()
+                completionHandler()
+            }
+        }
+    }
+
+    /// Skips to the next item, restarting from step 0.
+    ///
+    /// Increments the generation counter to invalidate any pending completion handlers.
+    /// Returns false if already at the last item.
+    @discardableResult
+    func next() -> Bool {
+        guard isPlaying, currentIndex + 1 < items.count else { return false }
+
+        playbackGeneration += 1
+        currentIndex += 1
+        currentStep = 0
+        expectedGeneration = playbackGeneration
+        speechHandler(items[currentIndex], currentStep)
+
+        return true
+    }
+
+    /// Skips to the previous item, restarting from step 0.
+    ///
+    /// Increments the generation counter to invalidate any pending completion handlers.
+    /// Returns false if already at the first item.
+    @discardableResult
+    func previous() -> Bool {
+        guard isPlaying, currentIndex > 0 else { return false }
+
+        playbackGeneration += 1
+        currentIndex -= 1
+        currentStep = 0
+        expectedGeneration = playbackGeneration
+        speechHandler(items[currentIndex], currentStep)
+
+        return true
+    }
+
+    /// Validates if a speech completion event is for the current playback session.
+    ///
+    /// This should be called when speech finishes to check if the completion
+    /// is still valid (generation hasn't changed during speech).
+    ///
+    /// - Parameter generation: The generation value captured when speech started
+    /// - Returns: true if the generation matches and playback is still active
+    func isValidCompletion(generation: Int) -> Bool {
+        return isPlaying && generation == playbackGeneration
+    }
+
+    /// Updates playback mode and restarts current item from step 0 if playing.
+    ///
+    /// - Parameter mode: The new playback mode
+    func updatePlaybackMode(_ mode: SettingsManager.PlaybackMode) {
+        self.playbackMode = mode
+
+        if isPlaying {
+            playbackGeneration += 1
+            currentStep = 0
+            expectedGeneration = playbackGeneration
+            speechHandler(items[currentIndex], currentStep)
+        }
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/NowPlayingInfoManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/NowPlayingInfoManager.swift
@@ -1,0 +1,49 @@
+import MediaPlayer
+
+/// Manages Now Playing info displayed on lock screen and Control Center.
+///
+/// This manager provides a centralized, thread-safe interface for updating
+/// the media metadata shown to users on the lock screen, Control Center,
+/// and external devices like CarPlay.
+enum NowPlayingInfoManager {
+    /// Updates Now Playing info with the provided metadata.
+    ///
+    /// Sets the metadata displayed on lock screen and Control Center:
+    /// - Title: Main text (usually the sentence being played)
+    /// - Artist: Secondary text (word + step label)
+    /// - Album: Additional context (word meaning)
+    /// - Playback rate: 1.0 for playing, 0.0 for paused
+    ///
+    /// Thread-safe: Can be called from any thread.
+    ///
+    /// - Parameters:
+    ///   - title: The main title (e.g., English sentence)
+    ///   - artist: The artist/subtitle (e.g., "word - step")
+    ///   - album: The album title (e.g., word meaning)
+    ///   - playbackRate: 1.0 for playing, 0.0 for paused
+    static func update(
+        title: String,
+        artist: String,
+        album: String,
+        playbackRate: Double = 1.0
+    ) {
+        var nowPlayingInfo = [String: Any]()
+        nowPlayingInfo[MPMediaItemPropertyTitle] = title
+        nowPlayingInfo[MPMediaItemPropertyArtist] = artist
+        nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = album
+        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
+        nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    }
+
+    /// Clears all Now Playing info.
+    ///
+    /// Should be called when playback stops to remove stale metadata
+    /// from lock screen and Control Center.
+    ///
+    /// Thread-safe: Can be called from any thread.
+    static func clear() {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/RemoteCommandCenterManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/RemoteCommandCenterManager.swift
@@ -1,0 +1,123 @@
+import MediaPlayer
+
+/// Manages remote command center handlers for lock screen and Control Center playback controls.
+///
+/// This manager centralizes the setup and teardown of remote command handlers,
+/// preventing duplicate registrations and ensuring proper cleanup.
+/// Remote commands allow users to control playback from:
+/// - Lock screen
+/// - Control Center
+/// - External devices (AirPods, CarPlay, etc.)
+final class RemoteCommandCenterManager {
+    // MARK: - Types
+
+    typealias CommandHandler = () -> Void
+
+    // MARK: - Properties
+
+    private var playCommandToken: Any?
+    private var pauseCommandToken: Any?
+    private var nextCommandToken: Any?
+    private var previousCommandToken: Any?
+
+    private let commandCenter: MPRemoteCommandCenter
+
+    // MARK: - Initialization
+
+    /// Creates a new remote command center manager.
+    ///
+    /// - Parameter commandCenter: The remote command center to manage (default: shared)
+    init(commandCenter: MPRemoteCommandCenter = .shared()) {
+        self.commandCenter = commandCenter
+    }
+
+    // MARK: - Setup
+
+    /// Sets up remote command handlers with the provided closures.
+    ///
+    /// This method is idempotent - calling it multiple times will remove old handlers
+    /// before adding new ones, preventing duplicate registrations.
+    ///
+    /// All handlers are dispatched to the main queue automatically to ensure
+    /// thread-safe UI updates.
+    ///
+    /// - Parameters:
+    ///   - onPlay: Closure to call when play command is triggered
+    ///   - onPause: Closure to call when pause command is triggered
+    ///   - onNext: Closure to call when next track command is triggered
+    ///   - onPrevious: Closure to call when previous track command is triggered
+    func setup(
+        onPlay: @escaping CommandHandler,
+        onPause: @escaping CommandHandler,
+        onNext: @escaping CommandHandler,
+        onPrevious: @escaping CommandHandler
+    ) {
+        // Remove existing handlers first to prevent duplicates
+        cleanup()
+
+        // Play command
+        playCommandToken = commandCenter.playCommand.addTarget { [weak self] _ in
+            guard self != nil else { return .commandFailed }
+            DispatchQueue.main.async {
+                onPlay()
+            }
+            return .success
+        }
+
+        // Pause command
+        pauseCommandToken = commandCenter.pauseCommand.addTarget { [weak self] _ in
+            guard self != nil else { return .commandFailed }
+            DispatchQueue.main.async {
+                onPause()
+            }
+            return .success
+        }
+
+        // Next track command
+        nextCommandToken = commandCenter.nextTrackCommand.addTarget { [weak self] _ in
+            guard self != nil else { return .commandFailed }
+            DispatchQueue.main.async {
+                onNext()
+            }
+            return .success
+        }
+
+        // Previous track command
+        previousCommandToken = commandCenter.previousTrackCommand.addTarget { [weak self] _ in
+            guard self != nil else { return .commandFailed }
+            DispatchQueue.main.async {
+                onPrevious()
+            }
+            return .success
+        }
+    }
+
+    /// Removes all remote command handlers and clears tokens.
+    ///
+    /// Safe to call multiple times. Should be called when the view disappears
+    /// to prevent leaked handlers.
+    func cleanup() {
+        if let token = playCommandToken {
+            commandCenter.playCommand.removeTarget(token)
+            playCommandToken = nil
+        }
+        if let token = pauseCommandToken {
+            commandCenter.pauseCommand.removeTarget(token)
+            pauseCommandToken = nil
+        }
+        if let token = nextCommandToken {
+            commandCenter.nextTrackCommand.removeTarget(token)
+            nextCommandToken = nil
+        }
+        if let token = previousCommandToken {
+            commandCenter.previousTrackCommand.removeTarget(token)
+            previousCommandToken = nil
+        }
+    }
+
+    // MARK: - Deinitialization
+
+    deinit {
+        cleanup()
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -171,6 +171,29 @@ class SettingsManager: ObservableObject {
                 return "英語のみ (EN→EN)"
             }
         }
+
+        /// Number of steps per item for this mode.
+        var stepsPerItem: Int {
+            switch self {
+            case .bilingual: return 3
+            case .englishOnly: return 2
+            }
+        }
+
+        /// Returns the step label for display purposes.
+        ///
+        /// - Parameter step: The step index (0-based)
+        /// - Returns: Localized step label
+        func stepLabel(for step: Int) -> String {
+            let clampedStep = min(max(step, 0), stepsPerItem - 1)
+
+            switch self {
+            case .bilingual:
+                return ["English (1st)", "Japanese", "English (2nd)"][clampedStep]
+            case .englishOnly:
+                return ["English (1st)", "English (2nd)"][clampedStep]
+            }
+        }
     }
 
     /// OpenAI model options for sentence generation.

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -113,10 +113,7 @@ struct SentenceListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onReceive(speechService.speechFinishedPublisher) { _ in
             // Called only when speech finishes naturally (not cancelled)
-            guard let manager = playbackManager else { return }
-
-            // Check if this completion is for the current playback session
-            guard manager.isValidCompletion(generation: manager.expectedGeneration) else { return }
+            guard let manager = playbackManager, manager.isPlaying else { return }
 
             // Add a delay before advancing to the next step for better pacing
             let capturedGeneration = manager.playbackGeneration
@@ -132,29 +129,21 @@ struct SentenceListView: View {
         .onAppear {
             setupPlaybackManager()
 
-            // Setup remote command center
+            // Setup remote command center (callbacks already dispatched to main queue)
             remoteCommandManager.setup(
                 onPlay: {
-                    Task { @MainActor in
-                        if let manager = self.playbackManager, !manager.isPlaying {
-                            self.startPlayAll()
-                        }
+                    if let manager = self.playbackManager, !manager.isPlaying {
+                        self.startPlayAll()
                     }
                 },
                 onPause: {
-                    Task { @MainActor in
-                        self.stopPlayAll()
-                    }
+                    self.stopPlayAll()
                 },
                 onNext: {
-                    Task { @MainActor in
-                        self.playbackManager?.next()
-                    }
+                    self.playbackManager?.next()
                 },
                 onPrevious: {
-                    Task { @MainActor in
-                        self.playbackManager?.previous()
-                    }
+                    self.playbackManager?.previous()
                 }
             )
         }

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -6,17 +6,9 @@ struct SentenceListView: View {
     @StateObject private var speechService = SpeechService()
     @EnvironmentObject private var settings: SettingsManager
 
-    // MARK: Continuous playback
-    @State private var isPlayingAll = false
-    @State private var playingIndex: Int = 0  // flat index into allSentences
-    @State private var playingStep: Int = 0   // 0=EN, 1=JA, 2=EN, 3=JA
-    @State private var playbackGeneration = 0  // Increment to invalidate old async tasks
-    @State private var expectedGeneration = 0  // Set when starting speech, checked on completion
-    // Tokens returned by MPRemoteCommand.addTarget(handler:) so we can remove them
-    @State private var playCommandToken: Any? = nil
-    @State private var pauseCommandToken: Any? = nil
-    @State private var nextCommandToken: Any? = nil
-    @State private var previousCommandToken: Any? = nil
+    // MARK: - Continuous playback managers
+    @State private var playbackManager: ContinuousPlaybackManager<Sentence>?
+    @State private var remoteCommandManager = RemoteCommandCenterManager()
 
     init(word: Word) {
         self.word = word
@@ -44,8 +36,10 @@ struct SentenceListView: View {
     ///
     /// - Returns: The sentence ID if playback is active and index is valid, otherwise nil
     private var playingSentenceID: UUID? {
-        guard isPlayingAll, playingIndex < allSentences.count else { return nil }
-        return allSentences[playingIndex].id
+        guard let manager = playbackManager,
+              manager.isPlaying,
+              manager.currentIndex < allSentences.count else { return nil }
+        return allSentences[manager.currentIndex].id
     }
 
     var body: some View {
@@ -119,267 +113,148 @@ struct SentenceListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .onReceive(speechService.speechFinishedPublisher) { _ in
             // Called only when speech finishes naturally (not cancelled)
-            guard isPlayingAll else { return }
+            guard let manager = playbackManager else { return }
 
             // Check if this completion is for the current playback session
-            guard expectedGeneration == playbackGeneration else { return }
+            guard manager.isValidCompletion(generation: manager.expectedGeneration) else { return }
 
             // Add a delay before advancing to the next step for better pacing
-            let capturedGeneration = playbackGeneration
+            let capturedGeneration = manager.playbackGeneration
             Task {
                 try? await Task.sleep(nanoseconds: 800_000_000)  // 0.8 second delay
                 await MainActor.run {
                     // Verify generation hasn't changed during the delay
-                    guard capturedGeneration == playbackGeneration else { return }
-                    advancePlayback()
+                    guard manager.isValidCompletion(generation: capturedGeneration) else { return }
+                    manager.advance()
                 }
             }
         }
         .onAppear {
-            setupRemoteCommandCenter()
+            setupPlaybackManager()
+
+            // Setup remote command center
+            remoteCommandManager.setup(
+                onPlay: {
+                    Task { @MainActor in
+                        if let manager = self.playbackManager, !manager.isPlaying {
+                            self.startPlayAll()
+                        }
+                    }
+                },
+                onPause: {
+                    Task { @MainActor in
+                        self.stopPlayAll()
+                    }
+                },
+                onNext: {
+                    Task { @MainActor in
+                        self.playbackManager?.next()
+                    }
+                },
+                onPrevious: {
+                    Task { @MainActor in
+                        self.playbackManager?.previous()
+                    }
+                }
+            )
         }
-        .onChange(of: settings.playbackMode) { _, _ in
+        .onChange(of: settings.playbackMode) { _, newMode in
             // If playback is active, restart current sentence from step 0 when mode changes
-            if isPlayingAll {
-                playbackGeneration += 1
-                playingStep = 0
-                speakCurrentStep()
-            }
+            playbackManager?.updatePlaybackMode(newMode)
         }
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
             // When individual playback starts (e.g., user taps "英語を聞く" button),
             // stop continuous playback cleanly to avoid state confusion.
             // The audio session remains active to allow seamless transition.
-            if isPlayingAll {
-                playbackGeneration += 1
-                isPlayingAll = false
-                playingStep = 0
-                clearNowPlayingInfo()
+            if let manager = playbackManager, manager.isPlaying {
+                manager.stop()
+                NowPlayingInfoManager.clear()
             }
         }
         .onDisappear {
             // Always stop to invalidate any pending async tasks via generation increment
-            stopPlayAll()
+            playbackManager?.stop()
+            speechService.deactivateAudioSession()
+            NowPlayingInfoManager.clear()
             // Remove remote command handlers to avoid leaked handlers after view disappears
-            let commandCenter = MPRemoteCommandCenter.shared()
-            if let t = playCommandToken { commandCenter.playCommand.removeTarget(t) }
-            if let t = pauseCommandToken { commandCenter.pauseCommand.removeTarget(t) }
-            if let t = nextCommandToken { commandCenter.nextTrackCommand.removeTarget(t) }
-            if let t = previousCommandToken { commandCenter.previousTrackCommand.removeTarget(t) }
-            playCommandToken = nil
-            pauseCommandToken = nil
-            nextCommandToken = nil
-            previousCommandToken = nil
+            remoteCommandManager.cleanup()
         }
     }
 
     // MARK: - Playback control
 
-    /// Starts continuous playback with proper race condition handling.
-    ///
-    /// This method uses a generation counter to invalidate any pending async tasks
-    /// from previous playback sessions, preventing race conditions when rapidly
-    /// switching between sentences during playback.
+    /// Initializes the playback manager on first use.
+    private func setupPlaybackManager() {
+        guard playbackManager == nil else { return }
+
+        playbackManager = ContinuousPlaybackManager(
+            playbackMode: settings.playbackMode,
+            speechHandler: { [weak speechService, settings, word] (sentence: Sentence, step: Int) in
+                guard let speechService else { return }
+
+                switch settings.playbackMode {
+                case .bilingual:
+                    switch step {
+                    case 0, 2:
+                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    case 1:
+                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    default:
+                        break
+                    }
+                case .englishOnly:
+                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                }
+
+                // Update Now Playing info
+                let stepLabel = settings.playbackMode.stepLabel(for: step)
+                NowPlayingInfoManager.update(
+                    title: sentence.english,
+                    artist: "\(word.word) - \(stepLabel)",
+                    album: word.meaning,
+                    playbackRate: 1.0
+                )
+            },
+            completionHandler: { [weak speechService] in
+                speechService?.deactivateAudioSession()
+                NowPlayingInfoManager.clear()
+            }
+        )
+    }
+
+    /// Starts continuous playback from a specific sentence or the beginning.
     ///
     /// - Parameter sentence: The sentence to start from, or nil to start from the first sentence
     private func startPlayAll(from sentence: Sentence? = nil) {
         guard !allSentences.isEmpty else { return }
 
-        // Increment generation to invalidate all pending async tasks
-        playbackGeneration += 1
-        let currentGen = playbackGeneration
+        setupPlaybackManager()
 
-        // Immediately stop everything
-        isPlayingAll = false
-        playingStep = 0
+        // Stop current playback first
         speechService.stop()
+
+        // Determine start index
+        let startIndex: Int
+        if let sentence,
+           let idx = allSentences.firstIndex(where: { $0.id == sentence.id }) {
+            startIndex = idx
+        } else {
+            startIndex = 0
+        }
 
         Task { @MainActor in
-            // Check if this task is still valid (no new startPlayAll was called)
-            guard currentGen == playbackGeneration else { return }
-
-            // Set up new playback position
-            if let sentence,
-               let idx = allSentences.firstIndex(where: { $0.id == sentence.id }) {
-                playingIndex = idx
-            } else {
-                playingIndex = 0
-            }
-            isPlayingAll = true
-            playingStep = 0
-            speakCurrentStep()
+            playbackManager?.start(items: allSentences, startIndex: startIndex)
         }
     }
 
-    /// Stops all continuous playback and invalidates pending async tasks.
-    ///
-    /// Increments the playback generation counter to ensure any in-flight
-    /// completion callbacks from the previous session are ignored.
-    /// Also deactivates the audio session to allow other apps to resume audio.
+    /// Stops all continuous playback.
     private func stopPlayAll() {
-        // Increment generation to invalidate all pending tasks
-        playbackGeneration += 1
-        isPlayingAll = false
-        playingStep = 0
+        playbackManager?.stop()
         speechService.stop()
         speechService.deactivateAudioSession()
-        clearNowPlayingInfo()
+        NowPlayingInfoManager.clear()
     }
 
-    /// Speaks the text for the current sentence and playback step.
-    ///
-    /// Records the current playback generation before starting speech to enable
-    /// validation in the completion callback. This prevents stale completion events
-    /// from affecting new playback sessions.
-    ///
-    /// Playback steps (bilingual): 0=EN, 1=JA, 2=EN (3 steps per sentence)
-    /// Playback steps (English-only): 0=EN, 1=EN (2 steps per sentence)
-    private func speakCurrentStep() {
-        guard playingIndex < allSentences.count else {
-            stopPlayAll()
-            return
-        }
-        // Record the current generation before starting speech
-        expectedGeneration = playbackGeneration
-
-        let sentence = allSentences[playingIndex]
-
-        switch settings.playbackMode {
-        case .bilingual:
-            switch playingStep {
-            case 0, 2:
-                speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
-            case 1:
-                speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
-            default:
-                break
-            }
-        case .englishOnly:
-            // Both steps 0 and 1 play English
-            speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
-        }
-
-        // Update Now Playing info for lock screen/Control Center
-        updateNowPlayingInfo()
-    }
-
-    /// Advances to the next playback step or sentence after natural speech completion.
-    ///
-    /// This method is called only when speech finishes naturally (not on cancellation)
-    /// via the speechFinishedPublisher. It progresses through the playback cycle
-    /// (bilingual: EN→JA→EN, English-only: EN→EN) and moves to the next sentence when all steps complete.
-    private func advancePlayback() {
-        let maxSteps = settings.playbackMode == .bilingual ? 3 : 2
-        let nextStep = playingStep + 1
-
-        if nextStep < maxSteps {
-            // More steps remain within the current sentence
-            playingStep = nextStep
-            speakCurrentStep()
-        } else {
-            // Move to the next sentence
-            let nextIdx = playingIndex + 1
-            if nextIdx < allSentences.count {
-                playingIndex = nextIdx
-                playingStep = 0
-                speakCurrentStep()
-            } else {
-                // All sentences done
-                isPlayingAll = false
-                playingStep = 0
-                clearNowPlayingInfo()
-            }
-        }
-    }
-
-    // MARK: - Media Controls
-
-    /// Sets up remote command center handlers for lock screen/Control Center controls.
-    ///
-    /// Registers handlers for play, pause, next track, and previous track commands.
-    /// These allow users to control playback from the lock screen, Control Center,
-    /// and external devices like AirPods.
-    private func setupRemoteCommandCenter() {
-        let commandCenter = MPRemoteCommandCenter.shared()
-
-        // Play command
-        playCommandToken = commandCenter.playCommand.addTarget { _ in
-            if !self.isPlayingAll {
-                // startPlayAll() will increment playbackGeneration internally
-                self.startPlayAll()
-                return .success
-            }
-            return .commandFailed
-        }
-
-        // Pause command
-        pauseCommandToken = commandCenter.pauseCommand.addTarget { _ in
-            if self.isPlayingAll {
-                self.stopPlayAll()
-                return .success
-            }
-            return .commandFailed
-        }
-
-        // Next track command (skip to next sentence)
-        nextCommandToken = commandCenter.nextTrackCommand.addTarget { _ in
-            if self.isPlayingAll && self.playingIndex + 1 < self.allSentences.count {
-                // Invalidate any previous completion handlers to avoid races
-                self.playbackGeneration += 1
-                self.playingIndex += 1
-                self.playingStep = 0
-                self.speakCurrentStep()
-                return .success
-            }
-            return .commandFailed
-        }
-
-        // Previous track command (go back to previous sentence)
-        previousCommandToken = commandCenter.previousTrackCommand.addTarget { _ in
-            if self.isPlayingAll && self.playingIndex > 0 {
-                // Invalidate any previous completion handlers to avoid races
-                self.playbackGeneration += 1
-                self.playingIndex -= 1
-                self.playingStep = 0
-                self.speakCurrentStep()
-                return .success
-            }
-            return .commandFailed
-        }
-    }
-
-    /// Updates the Now Playing info displayed on lock screen and Control Center.
-    ///
-    /// Shows the current sentence being played along with metadata like word,
-    /// meaning, and playback position.
-    private func updateNowPlayingInfo() {
-        guard playingIndex < allSentences.count else { return }
-
-        let sentence = allSentences[playingIndex]
-        let maxSteps = settings.playbackMode == .bilingual ? 3 : 2
-        let clampedStep = min(max(playingStep, 0), maxSteps - 1)
-
-        let stepLabel: String
-        if settings.playbackMode == .bilingual {
-            stepLabel = ["English (1st)", "Japanese", "English (2nd)"][clampedStep]
-        } else {
-            stepLabel = ["English (1st)", "English (2nd)"][clampedStep]
-        }
-
-        var nowPlayingInfo = [String: Any]()
-        nowPlayingInfo[MPMediaItemPropertyTitle] = sentence.english
-        nowPlayingInfo[MPMediaItemPropertyArtist] = "\(word.word) - \(stepLabel)"
-        nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = word.meaning
-        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlayingAll ? 1.0 : 0.0
-        nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
-
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    }
-
-    /// Clears the Now Playing info when playback stops.
-    private func clearNowPlayingInfo() {
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
-    }
 }
 
 struct SentenceRowView: View {

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -39,17 +39,9 @@ struct WordListView: View {
 
     @State private var selection = SelectionState()
 
-    // MARK: - Continuous playback for all words
-    @State private var isPlayingAllWords = false
-    @State private var playingFlatIndex: Int = 0  // Index into playAllWordSentences
-    @State private var playingStep: Int = 0       // 0=EN, 1=JA, 2=EN (bilingual) or 0=EN, 1=EN (English-only)
-    @State private var playbackGeneration = 0      // Invalidate old async tasks
-    @State private var expectedGeneration = 0
-    @State private var playCommandToken: Any? = nil
-    @State private var pauseCommandToken: Any? = nil
-    @State private var nextCommandToken: Any? = nil
-    @State private var previousCommandToken: Any? = nil
-    @State private var playAllWordSentences: [(Word, Sentence)] = []  // Cached snapshot for playback
+    // MARK: - Continuous playback managers
+    @State private var playbackManager: ContinuousPlaybackManager<(Word, Sentence)>?
+    @State private var remoteCommandManager = RemoteCommandCenterManager()
 
     private var sortOption: WordSortOption {
         WordSortOption(rawValue: sortOptionRaw) ?? .alphabeticalAZ
@@ -184,16 +176,17 @@ struct WordListView: View {
                 } else {
                     HStack {
                         // Play all words button
+                        let isPlaying = playbackManager?.isPlaying ?? false
                         if !allWordSentences.isEmpty {
                             Button {
-                                if isPlayingAllWords {
+                                if isPlaying {
                                     stopPlayAllWords()
                                 } else {
                                     startPlayAllWords()
                                 }
                             } label: {
-                                Image(systemName: isPlayingAllWords ? "stop.fill" : "play.fill")
-                                    .foregroundColor(isPlayingAllWords ? .red : .blue)
+                                Image(systemName: isPlaying ? "stop.fill" : "play.fill")
+                                    .foregroundColor(isPlaying ? .red : .blue)
                             }
                         }
                         sortMenu
@@ -213,47 +206,67 @@ struct WordListView: View {
         // user can continue selecting from the newly filtered results.
         .onChange(of: searchText) { _, _ in
             selection.selectedIDs = []
-            if isPlayingAllWords { stopPlayAllWords() }
+            if playbackManager?.isPlaying == true { stopPlayAllWords() }
         }
         .onChange(of: selectedLetter) { _, _ in
             selection.selectedIDs = []
-            if isPlayingAllWords { stopPlayAllWords() }
+            if playbackManager?.isPlaying == true { stopPlayAllWords() }
         }
         .onChange(of: selectedCategory) { _, _ in
             selection.selectedIDs = []
-            if isPlayingAllWords { stopPlayAllWords() }
+            if playbackManager?.isPlaying == true { stopPlayAllWords() }
         }
         .onChange(of: sortOptionRaw) { _, _ in
-            if isPlayingAllWords { stopPlayAllWords() }
+            if playbackManager?.isPlaying == true { stopPlayAllWords() }
         }
         // Continuous playback event handlers
         .onReceive(speechService.speechFinishedPublisher) { _ in
-            guard isPlayingAllWords else { return }
-            guard expectedGeneration == playbackGeneration else { return }
+            guard let manager = playbackManager else { return }
+            guard manager.isValidCompletion(generation: manager.expectedGeneration) else { return }
 
-            scheduleDelayedAdvance(generation: playbackGeneration)
+            scheduleDelayedAdvance(generation: manager.playbackGeneration)
         }
         .onAppear {
-            setupRemoteCommandCenter()
+            setupPlaybackManager()
+
+            // Setup remote command center
+            remoteCommandManager.setup(
+                onPlay: {
+                    Task { @MainActor in
+                        if let manager = self.playbackManager, !manager.isPlaying {
+                            self.startPlayAllWords()
+                        }
+                    }
+                },
+                onPause: {
+                    Task { @MainActor in
+                        self.stopPlayAllWords()
+                    }
+                },
+                onNext: {
+                    Task { @MainActor in
+                        self.playbackManager?.next()
+                    }
+                },
+                onPrevious: {
+                    Task { @MainActor in
+                        self.playbackManager?.previous()
+                    }
+                }
+            )
         }
-        .onChange(of: settings.playbackMode) { _, _ in
-            if isPlayingAllWords {
-                playbackGeneration += 1
-                playingStep = 0
-                speakCurrentStepAllWords()
-            }
+        .onChange(of: settings.playbackMode) { _, newMode in
+            playbackManager?.updatePlaybackMode(newMode)
         }
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            if isPlayingAllWords {
-                playbackGeneration += 1
-                isPlayingAllWords = false
-                playingStep = 0
-                clearNowPlayingInfo()
+            if let manager = playbackManager, manager.isPlaying {
+                manager.stop()
+                NowPlayingInfoManager.clear()
             }
         }
         .onDisappear {
             stopPlayAllWords()
-            removeRemoteCommandHandlers()
+            remoteCommandManager.cleanup()
         }
     }
 
@@ -373,226 +386,84 @@ struct WordListView: View {
 
     // MARK: - Continuous Playback Logic
 
+    /// Initializes the playback manager on first use.
+    private func setupPlaybackManager() {
+        guard playbackManager == nil else { return }
+
+        playbackManager = ContinuousPlaybackManager(
+            playbackMode: settings.playbackMode,
+            speechHandler: { [weak speechService, settings] (item: (Word, Sentence), step: Int) in
+                guard let speechService else { return }
+
+                let (word, sentence) = item
+
+                switch settings.playbackMode {
+                case .bilingual:
+                    switch step {
+                    case 0, 2:
+                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    case 1:
+                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    default:
+                        break
+                    }
+                case .englishOnly:
+                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                }
+
+                // Update Now Playing info
+                let stepLabel = settings.playbackMode.stepLabel(for: step)
+                NowPlayingInfoManager.update(
+                    title: sentence.english,
+                    artist: "\(word.word) - \(stepLabel)",
+                    album: word.meaning,
+                    playbackRate: 1.0
+                )
+            },
+            completionHandler: { [weak speechService] in
+                speechService?.deactivateAudioSession()
+                NowPlayingInfoManager.clear()
+            }
+        )
+    }
+
     /// Starts continuous playback across all words and their sentences.
     private func startPlayAllWords() {
-        // Snapshot the current filtered word/sentence list
         let snapshot = allWordSentences
         guard !snapshot.isEmpty else { return }
 
-        // Increment generation to invalidate pending tasks
-        playbackGeneration += 1
-        let currentGen = playbackGeneration
+        setupPlaybackManager()
 
         // Stop current playback
-        isPlayingAllWords = false
-        playingStep = 0
         speechService.stop()
 
         Task { @MainActor in
-            guard currentGen == playbackGeneration else { return }
-
-            playAllWordSentences = snapshot
-            playingFlatIndex = 0
-            isPlayingAllWords = true
-            playingStep = 0
-            speakCurrentStepAllWords()
+            playbackManager?.start(items: snapshot, startIndex: 0)
         }
     }
 
     /// Stops continuous playback of all words.
     private func stopPlayAllWords() {
-        playbackGeneration += 1
-        isPlayingAllWords = false
-        playingStep = 0
-        playAllWordSentences = []
+        playbackManager?.stop()
         speechService.stop()
         speechService.deactivateAudioSession()
-        clearNowPlayingInfo()
-    }
-
-    /// Speaks the text for the current sentence and playback step.
-    private func speakCurrentStepAllWords() {
-        guard playingFlatIndex < playAllWordSentences.count else {
-            stopPlayAllWords()
-            return
-        }
-
-        expectedGeneration = playbackGeneration
-
-        let (word, sentence) = playAllWordSentences[playingFlatIndex]
-
-        switch settings.playbackMode {
-        case .bilingual:
-            switch playingStep {
-            case 0, 2:
-                speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
-            case 1:
-                speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
-            default:
-                break
-            }
-        case .englishOnly:
-            speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
-        }
-
-        updateNowPlayingInfoAllWords()
-    }
-
-    /// Advances to the next playback step or sentence.
-    private func advancePlaybackAllWords() {
-        let maxSteps = settings.playbackMode == .bilingual ? 3 : 2
-        let nextStep = playingStep + 1
-
-        if nextStep < maxSteps {
-            playingStep = nextStep
-            speakCurrentStepAllWords()
-        } else {
-            let nextIdx = playingFlatIndex + 1
-            if nextIdx < playAllWordSentences.count {
-                playingFlatIndex = nextIdx
-                playingStep = 0
-                speakCurrentStepAllWords()
-            } else {
-                // All done - clean up audio session
-                isPlayingAllWords = false
-                playingStep = 0
-                playAllWordSentences = []
-                speechService.deactivateAudioSession()
-                clearNowPlayingInfo()
-            }
-        }
-    }
-
-    /// Sets up remote command center for lock screen controls.
-    /// Idempotent: removes existing handlers before adding new ones.
-    private func setupRemoteCommandCenter() {
-        let commandCenter = MPRemoteCommandCenter.shared()
-
-        // Remove existing handlers to prevent duplicates
-        removeRemoteCommandHandlers()
-
-        playCommandToken = commandCenter.playCommand.addTarget { _ in
-            DispatchQueue.main.async {
-                if !self.isPlayingAllWords {
-                    self.startPlayAllWords()
-                }
-            }
-            return .success
-        }
-
-        pauseCommandToken = commandCenter.pauseCommand.addTarget { _ in
-            DispatchQueue.main.async {
-                if self.isPlayingAllWords {
-                    self.stopPlayAllWords()
-                }
-            }
-            return .success
-        }
-
-        nextCommandToken = commandCenter.nextTrackCommand.addTarget { _ in
-            DispatchQueue.main.async {
-                if self.isPlayingAllWords && self.playingFlatIndex + 1 < self.playAllWordSentences.count {
-                    self.playbackGeneration += 1
-                    self.playingFlatIndex += 1
-                    self.playingStep = 0
-                    self.speakCurrentStepAllWords()
-                }
-            }
-            return .success
-        }
-
-        previousCommandToken = commandCenter.previousTrackCommand.addTarget { _ in
-            DispatchQueue.main.async {
-                if self.isPlayingAllWords && self.playingFlatIndex > 0 {
-                    self.playbackGeneration += 1
-                    self.playingFlatIndex -= 1
-                    self.playingStep = 0
-                    self.speakCurrentStepAllWords()
-                }
-            }
-            return .success
-        }
-    }
-
-    /// Updates Now Playing info for lock screen/Control Center.
-    /// Thread-safe: validates index before accessing array to prevent race conditions.
-    private func updateNowPlayingInfoAllWords() {
-        // Thread-safe snapshot to prevent race condition between check and access
-        let snapshot = playAllWordSentences
-        guard playingFlatIndex >= 0 && playingFlatIndex < snapshot.count else {
-            assertionFailure("playingFlatIndex out of bounds: \(playingFlatIndex), count: \(snapshot.count)")
-            return
-        }
-
-        let (word, sentence) = snapshot[playingFlatIndex]
-
-        // Calculate step label
-        let stepLabel = getStepLabel(for: playingStep, mode: settings.playbackMode)
-
-        var nowPlayingInfo = [String: Any]()
-        nowPlayingInfo[MPMediaItemPropertyTitle] = sentence.english
-        nowPlayingInfo[MPMediaItemPropertyArtist] = "\(word.word) - \(stepLabel)"
-        nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = word.meaning
-        nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = isPlayingAllWords ? 1.0 : 0.0
-        nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
-
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-    }
-
-    /// Returns the step label for the given playback step and mode.
-    private func getStepLabel(for step: Int, mode: SettingsManager.PlaybackMode) -> String {
-        let maxSteps = mode == .bilingual ? 3 : 2
-        let clampedStep = min(max(step, 0), maxSteps - 1)
-
-        if mode == .bilingual {
-            return ["English (1st)", "Japanese", "English (2nd)"][clampedStep]
-        } else {
-            return ["English (1st)", "English (2nd)"][clampedStep]
-        }
-    }
-
-    /// Clears Now Playing info.
-    private func clearNowPlayingInfo() {
-        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        NowPlayingInfoManager.clear()
     }
 
     /// Schedules a delayed task with generation-based cancellation.
-    /// Returns early if the generation changes during the delay (playback stopped/restarted).
     private func scheduleDelayedAdvance(generation: Int, delay: UInt64 = 800_000_000) {
         Task {
             do {
                 try await Task.sleep(nanoseconds: delay)
                 await MainActor.run {
-                    guard generation == playbackGeneration else { return }
-                    advancePlaybackAllWords()
+                    guard let manager = playbackManager,
+                          manager.isValidCompletion(generation: generation) else { return }
+                    manager.advance()
                 }
             } catch {
                 // Task cancellation is expected when view disappears or playback stops
                 // No action needed
             }
-        }
-    }
-
-    /// Removes all remote command handlers and clears tokens.
-    /// Safe to call multiple times.
-    private func removeRemoteCommandHandlers() {
-        let commandCenter = MPRemoteCommandCenter.shared()
-
-        if let token = playCommandToken {
-            commandCenter.playCommand.removeTarget(token)
-            playCommandToken = nil
-        }
-        if let token = pauseCommandToken {
-            commandCenter.pauseCommand.removeTarget(token)
-            pauseCommandToken = nil
-        }
-        if let token = nextCommandToken {
-            commandCenter.nextTrackCommand.removeTarget(token)
-            nextCommandToken = nil
-        }
-        if let token = previousCommandToken {
-            commandCenter.previousTrackCommand.removeTarget(token)
-            previousCommandToken = nil
         }
     }
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -221,37 +221,28 @@ struct WordListView: View {
         }
         // Continuous playback event handlers
         .onReceive(speechService.speechFinishedPublisher) { _ in
-            guard let manager = playbackManager else { return }
-            guard manager.isValidCompletion(generation: manager.expectedGeneration) else { return }
+            guard let manager = playbackManager, manager.isPlaying else { return }
 
             scheduleDelayedAdvance(generation: manager.playbackGeneration)
         }
         .onAppear {
             setupPlaybackManager()
 
-            // Setup remote command center
+            // Setup remote command center (callbacks already dispatched to main queue)
             remoteCommandManager.setup(
                 onPlay: {
-                    Task { @MainActor in
-                        if let manager = self.playbackManager, !manager.isPlaying {
-                            self.startPlayAllWords()
-                        }
+                    if let manager = self.playbackManager, !manager.isPlaying {
+                        self.startPlayAllWords()
                     }
                 },
                 onPause: {
-                    Task { @MainActor in
-                        self.stopPlayAllWords()
-                    }
+                    self.stopPlayAllWords()
                 },
                 onNext: {
-                    Task { @MainActor in
-                        self.playbackManager?.next()
-                    }
+                    self.playbackManager?.next()
                 },
                 onPrevious: {
-                    Task { @MainActor in
-                        self.playbackManager?.previous()
-                    }
+                    self.playbackManager?.previous()
                 }
             )
         }


### PR DESCRIPTION
## Summary

Refactors duplicated continuous playback logic from `WordListView` and `SentenceListView` into reusable service classes, addressing Issue #70.

## Changes

### New Services (`Services/Playback/`)

1. **ContinuousPlaybackManager\<T\>** (201 lines)
   - Generic playback state management
   - Handles playback advancement, generation-based cancellation
   - Supports both `Sentence` and `(Word, Sentence)` item types

2. **RemoteCommandCenterManager** (123 lines)
   - Centralizes remote command setup/teardown
   - Prevents duplicate handler registration
   - Thread-safe command handling

3. **NowPlayingInfoManager** (49 lines)
   - Manages Now Playing metadata
   - Thread-safe updates and clearing

### Migrated Views

- **SentenceListView**: Reduced from complex playback logic to service calls
- **WordListView**: Reduced from complex playback logic to service calls
- **SettingsManager**: Extended `PlaybackMode` with `stepsPerItem` and `stepLabel(for:)` helpers

## Code Impact

**Reduction:**
- Views: -254 lines (net)
- Eliminated ~200 lines of duplicated logic

**Addition:**
- New services: +373 lines (reusable, testable)

**Net change:** +162 lines overall (with significant quality improvements)

## Benefits

✅ **Eliminates code duplication**
- Single source of truth for playback logic
- Bugs fixed once apply everywhere

✅ **Improves maintainability**
- Services follow single responsibility principle
- Changes isolated to specific service classes

✅ **Enables testing**
- Playback logic can be unit tested in isolation
- Service layer can be mocked for view tests

✅ **Future extensibility**
- Easy to add new playback features
- Services reusable for future views

## Test Plan

- [x] Build succeeds without errors
- [x] SentenceListView continuous playback works
- [x] WordListView all-words playback works
- [x] Lock screen controls (play/pause/next/previous) work
- [x] Playback mode switching (bilingual/English-only) works
- [x] Filter changes stop playback correctly
- [x] Now Playing info displays correctly

## Code Review

- [x] Addressed CodeRabbit feedback:
  - Fixed thread-safety documentation
  - Removed redundant double main-thread dispatch
  - Simplified isValidCompletion checks

## Related

- Closes #70
- Related to PR #69 (added continuous playback feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)