### PR TITLE
feat: Store OpenAI API key securely in iOS Keychain

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		8577C19C2F4BE5AC0061F175 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1922F4BE5AC0061F175 /* OpenAIService.swift */; };
 		8577C19D2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18E2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift */; };
 		8577C19F2F4BE5AC0061F175 /* SpeechRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1952F4BE5AC0061F175 /* SpeechRecognizer.swift */; };
+		85DE1EC12F52867000A4CA59 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85DE1EC02F52867000A4CA59 /* KeychainService.swift */; };
 		A1000001238D1234567890AB /* EnglishLearnAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000011238D1234567890AB /* EnglishLearnAppApp.swift */; };
 		A1000002238D1234567890AB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000012238D1234567890AB /* ContentView.swift */; };
 		A1000003238D1234567890AB /* Word.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000013238D1234567890AB /* Word.swift */; };
@@ -57,6 +58,7 @@
 		8577C1942F4BE5AC0061F175 /* SettingsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		8577C1952F4BE5AC0061F175 /* SpeechRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognizer.swift; sourceTree = "<group>"; };
 		8577C1962F4BE5AC0061F175 /* SpeechService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechService.swift; sourceTree = "<group>"; };
+		85DE1EC02F52867000A4CA59 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		A1000011238D1234567890AB /* EnglishLearnAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnglishLearnAppApp.swift; sourceTree = "<group>"; };
 		A1000012238D1234567890AB /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A1000013238D1234567890AB /* Word.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Word.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 		8577C1972F4BE5AC0061F175 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				85DE1EC02F52867000A4CA59 /* KeychainService.swift */,
 				8577C18F2F4BE5AC0061F175 /* Playback */,
 				8577C1922F4BE5AC0061F175 /* OpenAIService.swift */,
 				8577C1942F4BE5AC0061F175 /* SettingsManager.swift */,
@@ -306,6 +309,7 @@
 				A1000010238D1234567890AB /* SettingsView.swift in Sources */,
 				A1000025238D1234567890AB /* TrashView.swift in Sources */,
 				A1000026238D1234567890AB /* EditWordView.swift in Sources */,
+				85DE1EC12F52867000A4CA59 /* KeychainService.swift in Sources */,
 				A1000075238D1234567890AB /* ArchiveView.swift in Sources */,
 				A1000077238D1234567890AB /* PrivacyPolicyView.swift in Sources */,
 				A1000079238D1234567890AB /* TermsOfServiceView.swift in Sources */,

--- a/EnglishLearnApp/EnglishLearnApp/AppConfig.swift.example
+++ b/EnglishLearnApp/EnglishLearnApp/AppConfig.swift.example
@@ -3,34 +3,27 @@
 /// ## Security Note
 /// This file is gitignored and should NEVER be committed with real values.
 ///
-/// ## API Key Configuration (Recommended)
-/// API keys should be configured via the app's Settings screen, where they are
-/// securely stored in the iOS Keychain. This approach:
-/// - Encrypts keys at rest using device security
-/// - Prevents keys from being embedded in the binary
-/// - Allows keys to be updated without rebuilding the app
-///
-/// ## Fallback Configuration (Development Only)
-/// For development convenience, you can optionally set a fallback API key here.
-/// This is NOT recommended for production use as keys will be embedded in the binary.
+/// ## API Key Configuration
+/// - **OpenAI API Key**: Configured via Settings screen, stored in iOS Keychain
+/// - **VOICEVOX API Key**: Set in this file (developer-managed, not user-configurable)
 ///
 /// ## Setup:
 ///   1. Copy AppConfig.swift.example to AppConfig.swift
 ///   2. Deploy the CDK stack: cd aws && npm run deploy:poc
 ///   3. Get API endpoint from deployment output (VoicevoxApiEndpoint)
 ///   4. Set voicevoxBaseURL below
-///   5. Configure API key via Settings screen (preferred) OR set voicevoxApiKey here (dev only)
+///   5. Set voicevoxApiKey (from CDK deployment output or environment variable)
 enum AppConfig {
     /// Base URL for the VOICEVOX engine API (no trailing slash).
     /// Example: https://abc123xyz.execute-api.ap-northeast-1.amazonaws.com
     static let voicevoxBaseURL = "https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com"
 
-    /// Fallback API key for authenticating with the VOICEVOX backend.
+    /// API key for authenticating with the VOICEVOX backend.
     ///
-    /// ⚠️ RECOMMENDED: Leave this empty and configure via Settings > VOICEVOX設定
-    /// The Settings screen stores the key securely in iOS Keychain.
+    /// This key is managed by the developer (not user-configurable).
+    /// Get the value from CDK deployment output or environment variable:
+    ///   echo $VOICEVOX_API_KEY_POC
     ///
-    /// This fallback is only used when no key is configured in Settings.
-    /// If you must set a value here for development, it will be embedded in the binary.
+    /// ⚠️ WARNING: This key will be embedded in the app binary.
     static let voicevoxApiKey = ""
 }

--- a/EnglishLearnApp/EnglishLearnApp/AppConfig.swift.example
+++ b/EnglishLearnApp/EnglishLearnApp/AppConfig.swift.example
@@ -1,29 +1,36 @@
 /// Application-level configuration constants.
 ///
-/// ⚠️ SECURITY WARNING:
-/// - This file is gitignored and should NEVER be committed with real values
-/// - API keys will be embedded in the compiled binary (acceptable for personal/development use)
-/// - For production apps distributed via App Store, consider using:
-///   - Remote configuration (e.g., Firebase Remote Config)
-///   - Secure backend API that doesn't expose keys to clients
-///   - iOS Keychain for runtime storage (requires initial secure provisioning)
+/// ## Security Note
+/// This file is gitignored and should NEVER be committed with real values.
 ///
-/// Setup:
+/// ## API Key Configuration (Recommended)
+/// API keys should be configured via the app's Settings screen, where they are
+/// securely stored in the iOS Keychain. This approach:
+/// - Encrypts keys at rest using device security
+/// - Prevents keys from being embedded in the binary
+/// - Allows keys to be updated without rebuilding the app
+///
+/// ## Fallback Configuration (Development Only)
+/// For development convenience, you can optionally set a fallback API key here.
+/// This is NOT recommended for production use as keys will be embedded in the binary.
+///
+/// ## Setup:
 ///   1. Copy AppConfig.swift.example to AppConfig.swift
 ///   2. Deploy the CDK stack: cd aws && npm run deploy:poc
 ///   3. Get API endpoint from deployment output (VoicevoxApiEndpoint)
-///   4. Get API key from environment variable: echo $VOICEVOX_API_KEY_POC
-///   5. Replace placeholder values below with actual values
-///
-/// Note: This approach is suitable for personal/internal apps not distributed publicly.
+///   4. Set voicevoxBaseURL below
+///   5. Configure API key via Settings screen (preferred) OR set voicevoxApiKey here (dev only)
 enum AppConfig {
     /// Base URL for the VOICEVOX engine API (no trailing slash).
     /// Example: https://abc123xyz.execute-api.ap-northeast-1.amazonaws.com
     static let voicevoxBaseURL = "https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com"
 
-    /// API key for authenticating with the VOICEVOX backend.
-    /// ⚠️ WARNING: This key will be embedded in the app binary.
-    /// Only use this approach for personal/development apps.
-    /// Value should match VOICEVOX_API_KEY_{ENV} used during CDK deployment.
-    static let voicevoxApiKey = "your-api-key-here-64-character-hex-string"
+    /// Fallback API key for authenticating with the VOICEVOX backend.
+    ///
+    /// ⚠️ RECOMMENDED: Leave this empty and configure via Settings > VOICEVOX設定
+    /// The Settings screen stores the key securely in iOS Keychain.
+    ///
+    /// This fallback is only used when no key is configured in Settings.
+    /// If you must set a value here for development, it will be embedded in the binary.
+    static let voicevoxApiKey = ""
 }

--- a/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
@@ -47,9 +47,6 @@ final class KeychainService {
     func save(key: String, for keyType: KeyType) -> Bool {
         guard let data = key.data(using: .utf8) else { return false }
 
-        // First, try to delete any existing item
-        delete(for: keyType)
-
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: keyType.rawValue,
@@ -57,7 +54,22 @@ final class KeychainService {
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
 
-        let status = SecItemAdd(query as CFDictionary, nil)
+        // Try to add the item first
+        var status = SecItemAdd(query as CFDictionary, nil)
+
+        // If item already exists, update it instead
+        if status == errSecDuplicateItem {
+            let searchQuery: [String: Any] = [
+                kSecClass as String: kSecClassGenericPassword,
+                kSecAttrAccount as String: keyType.rawValue
+            ]
+            let attributesToUpdate: [String: Any] = [
+                kSecValueData as String: data,
+                kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            ]
+            status = SecItemUpdate(searchQuery as CFDictionary, attributesToUpdate as CFDictionary)
+        }
+
         return status == errSecSuccess
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
@@ -20,7 +20,7 @@ import Security
 /// }
 ///
 /// // Delete an API key
-/// KeychainService.shared.delete(for: .voicevox)
+/// KeychainService.shared.delete(for: .openAI)
 /// ```
 final class KeychainService {
     /// The shared singleton instance.

--- a/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/KeychainService.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Security
+
+/// Service for securely storing and retrieving API keys from the iOS Keychain.
+///
+/// The Keychain provides encrypted storage that persists across app launches and
+/// is protected by the device's security features. Keys stored here are:
+/// - Encrypted at rest
+/// - Accessible only when the device is unlocked
+/// - Not included in unencrypted backups
+///
+/// ## Usage
+/// ```swift
+/// // Save an API key
+/// KeychainService.shared.save(key: "sk-...", for: .openAI)
+///
+/// // Retrieve an API key
+/// if let key = KeychainService.shared.retrieve(for: .openAI) {
+///     // Use the key
+/// }
+///
+/// // Delete an API key
+/// KeychainService.shared.delete(for: .voicevox)
+/// ```
+final class KeychainService {
+    /// The shared singleton instance.
+    static let shared = KeychainService()
+
+    /// Keychain item identifiers for API keys.
+    enum KeyType: String {
+        case openAI = "com.englishlearnapp.openai-api-key"
+    }
+
+    private init() {}
+
+    // MARK: - Public Methods
+
+    /// Saves an API key to the Keychain.
+    ///
+    /// If a key already exists for the specified type, it will be updated.
+    ///
+    /// - Parameters:
+    ///   - key: The API key string to store
+    ///   - keyType: The type of key being stored
+    /// - Returns: `true` if the save was successful, `false` otherwise
+    @discardableResult
+    func save(key: String, for keyType: KeyType) -> Bool {
+        guard let data = key.data(using: .utf8) else { return false }
+
+        // First, try to delete any existing item
+        delete(for: keyType)
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keyType.rawValue,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    /// Retrieves an API key from the Keychain.
+    ///
+    /// - Parameter keyType: The type of key to retrieve
+    /// - Returns: The API key string if found, `nil` otherwise
+    func retrieve(for keyType: KeyType) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keyType.rawValue,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let key = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        return key
+    }
+
+    /// Deletes an API key from the Keychain.
+    ///
+    /// - Parameter keyType: The type of key to delete
+    /// - Returns: `true` if the deletion was successful or the item didn't exist, `false` on error
+    @discardableResult
+    func delete(for keyType: KeyType) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keyType.rawValue
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    /// Checks if an API key exists in the Keychain.
+    ///
+    /// - Parameter keyType: The type of key to check
+    /// - Returns: `true` if a key exists, `false` otherwise
+    func exists(for keyType: KeyType) -> Bool {
+        retrieve(for: keyType) != nil
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -29,7 +29,7 @@ class SettingsManager: ObservableObject {
     /// The OpenAI API key for sentence generation.
     ///
     /// Set this value before using `OpenAIService`.
-    /// Changes are automatically persisted to UserDefaults.
+    /// Changes are automatically persisted to the iOS Keychain.
     @Published var openAIAPIKey: String? {
         didSet {
             saveOpenAIAPIKey()
@@ -217,8 +217,11 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    /// The UserDefaults key for the OpenAI API key.
+    /// The UserDefaults key for the OpenAI API key (legacy, used for migration).
     private let openAIAPIKeyKey = "openAIAPIKey"
+
+    /// Flag to track if Keychain migration has been completed.
+    private let keychainMigrationKey = "keychainMigrationCompleted"
 
     // MARK: - Initializer
 
@@ -231,7 +234,8 @@ class SettingsManager: ObservableObject {
             self.voiceGender = .default_
         }
 
-        self.openAIAPIKey = UserDefaults.standard.string(forKey: openAIAPIKeyKey)
+        // Load API key from Keychain
+        self.openAIAPIKey = KeychainService.shared.retrieve(for: .openAI)
 
         if let saved = UserDefaults.standard.string(forKey: "openAIModel"),
            let model = OpenAIModel(rawValue: saved) {
@@ -294,6 +298,10 @@ class SettingsManager: ObservableObject {
             }
             UserDefaults.standard.removeObject(forKey: legacyKey)
         }
+
+        // Migrate OpenAI key from UserDefaults to Keychain (one-time)
+        // This must be called after all stored properties are initialized
+        migrateOpenAIKeyToKeychain()
     }
 
     // MARK: - Preset Management
@@ -378,14 +386,42 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    /// Persists the OpenAI API key to UserDefaults.
+    /// Persists the OpenAI API key to the Keychain.
     ///
-    /// If the key is nil, removes the stored value.
+    /// If the key is nil or empty, removes the stored value.
     private func saveOpenAIAPIKey() {
-        if let key = openAIAPIKey {
-            UserDefaults.standard.set(key, forKey: openAIAPIKeyKey)
+        if let key = openAIAPIKey, !key.isEmpty {
+            KeychainService.shared.save(key: key, for: .openAI)
         } else {
+            KeychainService.shared.delete(for: .openAI)
+        }
+    }
+
+    /// Migrates the OpenAI API key from UserDefaults to Keychain.
+    ///
+    /// This method runs once on app upgrade. It:
+    /// 1. Checks if migration has already been completed
+    /// 2. Reads the key from UserDefaults (if present)
+    /// 3. Saves it to Keychain
+    /// 4. Removes the key from UserDefaults
+    /// 5. Marks migration as complete
+    private func migrateOpenAIKeyToKeychain() {
+        // Skip if already migrated
+        guard !UserDefaults.standard.bool(forKey: keychainMigrationKey) else { return }
+
+        // Check if there's a key in UserDefaults to migrate
+        if let legacyKey = UserDefaults.standard.string(forKey: openAIAPIKeyKey),
+           !legacyKey.isEmpty {
+            // Only migrate if we don't already have a key in Keychain
+            if openAIAPIKey == nil {
+                KeychainService.shared.save(key: legacyKey, for: .openAI)
+                self.openAIAPIKey = legacyKey
+            }
+            // Remove from UserDefaults regardless (don't leave plaintext key lying around)
             UserDefaults.standard.removeObject(forKey: openAIAPIKeyKey)
         }
+
+        // Mark migration as complete
+        UserDefaults.standard.set(true, forKey: keychainMigrationKey)
     }
 }

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -147,6 +147,14 @@ class SpeechService: NSObject, ObservableObject {
             return
         }
 
+        // Ensure API key is configured
+        let apiKey = AppConfig.voicevoxApiKey
+        guard !apiKey.isEmpty else {
+            print("VOICEVOX API key not configured in AppConfig")
+            handleVoicevoxFailure()
+            return
+        }
+
         let speakerID = SettingsManager.shared.voicevoxStyle.rawValue
 
         guard let encodedText = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
     /// The speech service for playing sample audio.
     @StateObject private var speechService = SpeechService()
 
-    /// Local state for the API key input field.
+    /// Local state for the OpenAI API key input field.
     @State private var apiKeyInput: String = ""
 
     // MARK: - Export / Import state
@@ -209,6 +209,14 @@ struct SettingsView: View {
                         Text("AIモデルは精度やコストに応じて選択できます。GPT-4o miniは高速で低コスト、GPT-4oは高性能です。")
                             .font(.body)
                         Text("例文生成の条件は「プリセット管理」から選択・編集できます。組み込みプリセットはデフォルトに戻すことができます。")
+                            .font(.body)
+                            .foregroundColor(.secondary)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("APIキーはiOS Keychainに安全に保存されます。")
+                            .font(.body)
+                        Text("Keychainはデバイスのセキュリティ機能により暗号化され、他のアプリからアクセスできません。")
                             .font(.body)
                             .foregroundColor(.secondary)
                     }


### PR DESCRIPTION
## Summary
- Add `KeychainService` for encrypted API key storage using iOS Keychain
- Migrate existing OpenAI API keys from UserDefaults to Keychain (one-time migration)
- Remove VOICEVOX API key from user settings (developer-managed in AppConfig only)
- Update documentation in `AppConfig.swift.example`

## Changes
| File | Description |
|------|-------------|
| `KeychainService.swift` | New service for Keychain CRUD operations |
| `SettingsManager.swift` | Store/retrieve OpenAI key via Keychain, add migration logic |
| `SpeechService.swift` | Use `AppConfig.voicevoxApiKey` directly |
| `SettingsView.swift` | Add Keychain security explanation |
| `AppConfig.swift.example` | Updated security documentation |

## Test plan
- [x] Build and run the app
- [x] Set OpenAI API key in Settings → verify it persists after app restart
- [ ] Select "ずんだもん" voice → verify audio plays (using AppConfig key)
- [ ] Verify no VOICEVOX API key input field appears in Settings

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys are now stored securely in the device Keychain; a new service enables save/retrieve/delete/access checks.
  * Settings screen shows information about secure API key storage and device security.

* **Bug Fixes**
  * Validation added to stop voice service requests when required VOICEVOX/OpenAI API keys are missing.

* **Refactor**
  * Automatic one-time migration of existing API keys from legacy storage to the Keychain.

* **Documentation**
  * Updated configuration and setup notes for API key provisioning and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->