### PR TITLE
refactor: Separate evaluation criteria from review-fix skill

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -17,48 +17,46 @@ Review PR feedback from reviewers or bots, apply fixes, and push updates.
 
 ## Workflow
 
-1. **Get PR details and comments**
-   ```bash
-   gh pr view $ARGUMENTS --comments
-   ```
+### Phase 1: Fetch Feedback
 
-2. **Check for review comments on specific files**
-   ```bash
-   gh pr view $ARGUMENTS --json reviews,comments
-   gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments
-   ```
+```bash
+gh pr view $ARGUMENTS --comments
+gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments
+```
 
-3. **Analyze feedback**
-   - Read all review comments
-   - Identify actionable items
-   - Prioritize by severity (blocking vs suggestions)
+**完了条件:** 全てのレビューコメントを取得できた
 
-4. **Apply fixes**
-   - Make the necessary code changes
-   - Address each comment systematically
+### Phase 2: Classify & Prioritize
 
-5. **Commit and push**
-   ```bash
-   git add <changed-files>
-   git commit -m "fix: Address PR review feedback"
-   git push
-   ```
+`references/review-criteria.md` の基準に従い、各コメントを分類：
 
-6. **Verify PR status**
-   ```bash
-   gh pr view $ARGUMENTS
-   gh pr checks $ARGUMENTS
-   ```
+1. 全コメントを P0 / P1 / P2 に分類
+2. P0 があれば最優先で対応リストに追加
+3. P1 は原則対応（工数大なら確認）
+4. P2 は時間があれば対応
 
-## Common Review Feedback Types
+**完了条件:** 対応すべきコメントのリストが確定
 
-| Type | Action |
-|------|--------|
-| Code style | Fix formatting, add language specifiers to code blocks |
-| Logic issues | Review and fix the implementation |
-| Missing tests | Add or update test cases |
-| Documentation | Update comments or README |
-| Security | Address vulnerabilities immediately |
+### Phase 3: Apply Fixes
+
+優先度順に修正を適用：
+
+1. P0 を全て解消
+2. P1 を順次対応
+3. P2 は可能な範囲で対応
+
+**完了条件:** 対応リストの項目が全て解消
+
+### Phase 4: Commit & Verify
+
+```bash
+git add <changed-files>
+git commit -m "fix: Address PR review feedback"
+git push
+gh pr checks $ARGUMENTS
+```
+
+**完了条件:** push 成功、CI が green（または確認中）
 
 ## Prerequisites
 
@@ -66,9 +64,6 @@ Review PR feedback from reviewers or bots, apply fixes, and push updates.
 - You are on the PR branch
 - Have write access to the repository
 
-## Notes
+## References
 
-- Always read the full context of review comments
-- If unsure about a comment, ask the user for clarification
-- Run tests after making changes if applicable
-- Respond to reviewers if needed using `gh pr comment`
+- [Review Criteria](references/review-criteria.md) - 優先度分類と対応判断基準

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -21,8 +21,8 @@ Review PR feedback from reviewers or bots, apply fixes, and push updates.
 
 ```bash
 gh pr view $ARGUMENTS --comments
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews
+gh api --paginate repos/{owner}/{repo}/pulls/$ARGUMENTS/comments
+gh api --paginate repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews
 ```
 
 **完了条件:** 全てのレビューコメントとレビュー状態を取得できた

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -22,9 +22,10 @@ Review PR feedback from reviewers or bots, apply fixes, and push updates.
 ```bash
 gh pr view $ARGUMENTS --comments
 gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments
+gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews
 ```
 
-**完了条件:** 全てのレビューコメントを取得できた
+**完了条件:** 全てのレビューコメントとレビュー状態を取得できた
 
 ### Phase 2: Classify & Prioritize
 

--- a/.claude/skills/review-fix/references/review-criteria.md
+++ b/.claude/skills/review-fix/references/review-criteria.md
@@ -1,0 +1,69 @@
+# Review Feedback Evaluation Criteria
+
+## Priority Classification
+
+レビューコメントを以下の基準で分類し、優先度順に対応する。
+
+### P0: Blocking (必須対応)
+
+即座に対応が必要。これが未解決だとマージ不可。
+
+| パターン | 例 |
+|---------|-----|
+| セキュリティ脆弱性 | ハードコードされた秘密鍵、SQLインジェクション、XSS |
+| ビルド/テスト失敗 | CI が red、コンパイルエラー |
+| 明示的なブロック | `Request changes` ステータス、"must fix" コメント |
+| データ損失リスク | 誤った削除ロジック、上書き処理の欠陥 |
+
+### P1: Should Fix (強く推奨)
+
+マージ前に対応すべき。技術的負債になりやすい。
+
+| パターン | 例 |
+|---------|-----|
+| ロジックバグ | エッジケース未考慮、off-by-one エラー |
+| パフォーマンス問題 | O(n²) で改善可能、不要なループ |
+| API 設計の問題 | 破壊的変更、不適切な公開範囲 |
+| テスト不足 | 重要パスのテストがない |
+
+### P2: Nice to Have (推奨)
+
+時間があれば対応。次のPRで対応してもよい。
+
+| パターン | 例 |
+|---------|-----|
+| コードスタイル | フォーマット、命名規則 |
+| ドキュメント改善 | コメント追加、README 更新 |
+| リファクタリング提案 | より良い書き方の提案 |
+| nit / minor | "nit:" で始まるコメント |
+
+## Response Strategy
+
+### 即対応すべきケース
+
+- P0 は全て対応
+- P1 は原則対応（工数が大きい場合はユーザーに確認）
+
+### 確認が必要なケース
+
+- 要件の解釈が分かれるコメント
+- 大規模な設計変更の提案
+- 「〜した方がいいかも」という曖昧な提案
+
+### 対応を見送ってよいケース
+
+- 明示的に "optional" と書かれている
+- 本PRのスコープ外の改善提案（→ 別Issue化を提案）
+
+## Comment Type Detection
+
+コメント内のキーワードで自動分類：
+
+| キーワード | 分類 |
+|-----------|------|
+| `security`, `vulnerability`, `injection`, `exposed` | P0 Security |
+| `breaking`, `must`, `required`, `blocker` | P0 Blocking |
+| `bug`, `incorrect`, `wrong`, `fails` | P1 Logic |
+| `performance`, `slow`, `optimize` | P1 Performance |
+| `nit`, `minor`, `optional`, `suggestion` | P2 Style |
+| `typo`, `spelling`, `grammar` | P2 Documentation |


### PR DESCRIPTION
## Summary

- Restructure `/review-fix` skill to separate workflow from evaluation criteria
- Add `references/review-criteria.md` with P0/P1/P2 priority classification
- Reorganize SKILL.md into 4 clear phases with completion criteria

This follows the pattern from [Zenn article on Claude Code skills](https://zenn.dev/s4kura/articles/claude-code-indie-idea-scout-skill), which recommends keeping SKILL.md focused on workflow while extracting judgment criteria into separate reference files.

## Changes

### SKILL.md
- 4-phase workflow: Fetch → Classify → Fix → Verify
- Each phase has explicit completion criteria
- References external criteria file instead of inline tables

### references/review-criteria.md (new)
- P0/P1/P2 priority classification with examples
- Response strategy (when to fix immediately vs. ask for clarification)
- Keyword-based automatic comment classification

## Benefits

- Prevents SKILL.md from becoming too long (which can cause Claude to ignore later instructions)
- Makes it easy to swap evaluation criteria for different review modes
- Clearer separation of concerns

## Test plan

- [ ] Run `/review-fix <pr-number>` and verify it correctly classifies comments by priority
- [ ] Confirm phases execute in order with completion checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked code-review guidance into a unified phased workflow (Phase 1–Phase 4) with explicit completion criteria for each phase and reordered sections for clarity.
  * Added a review-feedback classification framework (P0–P2) with example patterns, response strategies, and comment-type detection.
  * Introduced a References section and bilingual-style headings for phases 2–4; minor formatting and phrasing adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->