### PR TITLE
Add language-based automatic voice selection

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -17,12 +17,12 @@ class SettingsManager: ObservableObject {
     /// The shared singleton instance.
     static let shared = SettingsManager()
 
-    /// The selected voice gender for text-to-speech.
+    /// The selected voice gender for English text-to-speech.
     ///
     /// Changes are automatically persisted to UserDefaults.
-    @Published var voiceGender: VoiceGender {
+    @Published var englishVoiceGender: EnglishVoiceGender {
         didSet {
-            saveVoiceGender()
+            saveEnglishVoiceGender()
         }
     }
 
@@ -110,16 +110,14 @@ class SettingsManager: ObservableObject {
 
     // MARK: - Nested Types
 
-    /// Voice gender options for text-to-speech.
-    enum VoiceGender: String, CaseIterable {
+    /// Voice gender options for English text-to-speech.
+    enum EnglishVoiceGender: String, CaseIterable {
         /// Use the system default voice.
         case default_ = "default"
         /// Use a female voice.
         case female = "female"
         /// Use a male voice.
         case male = "male"
-        /// Use VOICEVOX ずんだもん.
-        case zundamon = "zundamon"
 
         /// The localized display label for this option.
         var label: String {
@@ -130,8 +128,6 @@ class SettingsManager: ObservableObject {
                 return "女性"
             case .male:
                 return "男性"
-            case .zundamon:
-                return "ずんだもん"
             }
         }
     }
@@ -227,11 +223,11 @@ class SettingsManager: ObservableObject {
 
     /// Initializes the settings manager and loads saved preferences.
     init() {
-        if let saved = UserDefaults.standard.string(forKey: "voiceGender"),
-           let gender = VoiceGender(rawValue: saved) {
-            self.voiceGender = gender
+        if let saved = UserDefaults.standard.string(forKey: "englishVoiceGender"),
+           let gender = EnglishVoiceGender(rawValue: saved) {
+            self.englishVoiceGender = gender
         } else {
-            self.voiceGender = .default_
+            self.englishVoiceGender = .default_
         }
 
         // Load API key from Keychain
@@ -302,6 +298,9 @@ class SettingsManager: ObservableObject {
         // Migrate OpenAI key from UserDefaults to Keychain (one-time)
         // This must be called after all stored properties are initialized
         migrateOpenAIKeyToKeychain()
+
+        // Migrate voiceGender to englishVoiceGender (one-time)
+        migrateVoiceGenderSetting()
     }
 
     // MARK: - Preset Management
@@ -374,9 +373,9 @@ class SettingsManager: ObservableObject {
 
     // MARK: - Private Methods
 
-    /// Persists the voice gender setting to UserDefaults.
-    private func saveVoiceGender() {
-        UserDefaults.standard.set(voiceGender.rawValue, forKey: "voiceGender")
+    /// Persists the English voice gender setting to UserDefaults.
+    private func saveEnglishVoiceGender() {
+        UserDefaults.standard.set(englishVoiceGender.rawValue, forKey: "englishVoiceGender")
     }
 
     /// Persists built-in overrides to UserDefaults.
@@ -423,5 +422,50 @@ class SettingsManager: ObservableObject {
 
         // Mark migration as complete
         UserDefaults.standard.set(true, forKey: keychainMigrationKey)
+    }
+
+    /// Migrates the old voiceGender setting to the new englishVoiceGender setting.
+    ///
+    /// This handles the transition from the unified voiceGender (which included zundamon)
+    /// to the language-specific settings where English has its own voice gender and
+    /// Japanese always uses VOICEVOX.
+    private func migrateVoiceGenderSetting() {
+        let legacyKey = "voiceGender"
+        let migrationKey = "voiceGenderMigrationCompleted"
+
+        // Skip if already migrated
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
+
+        // Only migrate if the new key doesn't exist yet
+        guard UserDefaults.standard.string(forKey: "englishVoiceGender") == nil else {
+            UserDefaults.standard.set(true, forKey: migrationKey)
+            return
+        }
+
+        // Check if there's a legacy voiceGender to migrate
+        if let legacyValue = UserDefaults.standard.string(forKey: legacyKey) {
+            // Map old values to new English voice gender
+            // "zundamon" users get "default" for English (they can change it if needed)
+            let newValue: String
+            switch legacyValue {
+            case "default", "zundamon":
+                newValue = "default"
+            case "female":
+                newValue = "female"
+            case "male":
+                newValue = "male"
+            default:
+                newValue = "default"
+            }
+
+            UserDefaults.standard.set(newValue, forKey: "englishVoiceGender")
+            self.englishVoiceGender = EnglishVoiceGender(rawValue: newValue) ?? .default_
+
+            // Remove the old key
+            UserDefaults.standard.removeObject(forKey: legacyKey)
+        }
+
+        // Mark migration as complete
+        UserDefaults.standard.set(true, forKey: migrationKey)
     }
 }

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -21,7 +21,6 @@ class SpeechService: NSObject, ObservableObject {
         static let pitchMultiplier: Float = 1.0
         static let volume: Float = 1.0
         static let utteranceDelay: TimeInterval = 0.0
-        static let voiceGenderKey = "voiceGender"
     }
 
     // MARK: - Properties
@@ -32,7 +31,6 @@ class SpeechService: NSObject, ObservableObject {
 
     @Published var isSpeaking = false
     @Published var speakingLanguage: String? = nil
-    @Published var voiceGender: SettingsManager.VoiceGender = .default_
 
     /// Publisher that emits when speech finishes naturally (not cancelled).
     /// Use this instead of onChange(of: isSpeaking) for reliable completion detection.
@@ -41,7 +39,6 @@ class SpeechService: NSObject, ObservableObject {
     override init() {
         super.init()
         synthesizer.delegate = self
-        observeSettingsChanges()
         configureAudioSession()
     }
 
@@ -74,26 +71,12 @@ class SpeechService: NSObject, ObservableObject {
         }
     }
 
-    private func observeSettingsChanges() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateVoiceGender),
-            name: UserDefaults.didChangeNotification,
-            object: nil
-        )
-    }
 
-    @objc private func updateVoiceGender() {
-        guard let saved = UserDefaults.standard.string(forKey: Constants.voiceGenderKey),
-              let gender = SettingsManager.VoiceGender(rawValue: saved) else { return }
-
-        // Defer update to avoid "Publishing changes from within view updates" warning
-        Task { @MainActor in
-            self.voiceGender = gender
-        }
-    }
-
-    /// Speaks the given text using the specified language and voice gender.
+    /// Speaks the given text using automatic voice selection based on language.
+    ///
+    /// This method automatically selects the appropriate voice:
+    /// - English (en-US): Uses the user-selected English voice gender from settings
+    /// - Japanese (ja-JP): Always uses VOICEVOX with the selected style
     ///
     /// This method stops any ongoing speech before starting new playback. It tracks
     /// the current utterance to prevent race conditions from stale delegate callbacks.
@@ -101,9 +84,8 @@ class SpeechService: NSObject, ObservableObject {
     /// - Parameters:
     ///   - text: The text to be spoken
     ///   - language: The language code (default: "en-US")
-    ///   - voiceGender: The voice gender preference (default: .default_)
     ///   - isContinuousPlayback: Set to true when called from continuous playback to prevent stopping the session (default: false)
-    func speak(_ text: String, language: String = "en-US", voiceGender: SettingsManager.VoiceGender = .default_, isContinuousPlayback: Bool = false) {
+    func speak(_ text: String, language: String = "en-US", isContinuousPlayback: Bool = false) {
         stop()
 
         // Only notify when starting individual playback (not continuous playback)
@@ -114,7 +96,8 @@ class SpeechService: NSObject, ObservableObject {
 
         speakingLanguage = language
 
-        if voiceGender == .zundamon {
+        // Japanese always uses VOICEVOX
+        if language == "ja-JP" {
             isSpeaking = true
             _ = activateAudioSession()
             Task { [weak self] in
@@ -123,7 +106,9 @@ class SpeechService: NSObject, ObservableObject {
             return
         }
 
-        let utterance = createUtterance(text: text, voiceGender: voiceGender, language: language)
+        // English uses iOS native TTS with user-selected voice gender
+        let settings = SettingsManager.shared
+        let utterance = createUtterance(text: text, voiceGender: settings.englishVoiceGender, language: language)
 
         currentUtterance = utterance
         isSpeaking = true
@@ -214,7 +199,7 @@ class SpeechService: NSObject, ObservableObject {
     // MARK: - Helper Methods
 
     /// Creates and configures an AVSpeechUtterance with standard settings.
-    private func createUtterance(text: String, voiceGender: SettingsManager.VoiceGender, language: String) -> AVSpeechUtterance {
+    private func createUtterance(text: String, voiceGender: SettingsManager.EnglishVoiceGender, language: String) -> AVSpeechUtterance {
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = getVoiceForGender(voiceGender, language: language)
         utterance.rate = Constants.speechRate
@@ -248,10 +233,10 @@ class SpeechService: NSObject, ObservableObject {
     /// Returns an appropriate AVSpeechSynthesisVoice for the specified gender and language.
     ///
     /// - Parameters:
-    ///   - gender: The desired voice gender
+    ///   - gender: The desired voice gender for English speech
     ///   - language: The language code for the voice
-    /// - Returns: An AVSpeechSynthesisVoice, or nil for zundamon (uses VOICEVOX instead)
-    private func getVoiceForGender(_ gender: SettingsManager.VoiceGender, language: String) -> AVSpeechSynthesisVoice? {
+    /// - Returns: An AVSpeechSynthesisVoice
+    private func getVoiceForGender(_ gender: SettingsManager.EnglishVoiceGender, language: String) -> AVSpeechSynthesisVoice? {
         let availableVoices = AVSpeechSynthesisVoice.speechVoices()
 
         switch gender {
@@ -265,8 +250,6 @@ class SpeechService: NSObject, ObservableObject {
             return availableVoices.first { voice in
                 voice.language == language && voice.gender == .male
             } ?? AVSpeechSynthesisVoice(language: language)
-        case .zundamon:
-            return nil
         }
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SpeechButton.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SpeechButton.swift
@@ -20,7 +20,6 @@ struct SpeechButton: View {
     var style: Style = .fullWidth
 
     @ObservedObject var speechService: SpeechService
-    let voiceGender: SettingsManager.VoiceGender
 
     private var isActive: Bool {
         speechService.isSpeaking &&
@@ -31,9 +30,9 @@ struct SpeechButton: View {
     var body: some View {
         Button {
             if isJapanese {
-                speechService.speak(text, language: "ja-JP", voiceGender: voiceGender)
+                speechService.speak(text, language: "ja-JP")
             } else {
-                speechService.speak(text, voiceGender: voiceGender)
+                speechService.speak(text, language: "en-US")
             }
         } label: {
             HStack {

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -63,12 +63,12 @@ struct SentenceListView: View {
                         SpeechButton(
                             text: word.word, label: "英語を聞く",
                             isJapanese: false, color: .blue, style: .pill,
-                            speechService: speechService, voiceGender: settings.voiceGender
+                            speechService: speechService
                         )
                         SpeechButton(
                             text: word.meaning, label: "日本語を聞く",
                             isJapanese: true, color: .orange, style: .pill,
-                            speechService: speechService, voiceGender: settings.voiceGender
+                            speechService: speechService
                         )
                     }
                     .padding(.top, 4)
@@ -185,14 +185,14 @@ struct SentenceListView: View {
                 case .bilingual:
                     switch step {
                     case 0, 2:
-                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                     case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
                     default:
                         break
                     }
                 case .englishOnly:
-                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                 }
 
                 // Update Now Playing info

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
@@ -47,14 +47,14 @@ struct SentencePracticeView: View {
                     SpeechButton(
                         text: sentence.english, label: "英語を聞く",
                         isJapanese: false, color: .blue,
-                        speechService: speechService, voiceGender: settings.voiceGender
+                        speechService: speechService
                     )
 
                     // 日本語訳読み上げボタン
                     SpeechButton(
                         text: sentence.japanese, label: "日本語訳を聞く",
                         isJapanese: true, color: .orange,
-                        speechService: speechService, voiceGender: settings.voiceGender
+                        speechService: speechService
                     )
 
                     // 発音チェックボタン

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -37,21 +37,21 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section(header: Text("音声設定")) {
-                    Picker("音声の性別", selection: $settings.voiceGender) {
-                        ForEach(SettingsManager.VoiceGender.allCases, id: \.self) { gender in
+                Section(header: Text("英語の音声設定")) {
+                    Picker("音声の性別", selection: $settings.englishVoiceGender) {
+                        ForEach(SettingsManager.EnglishVoiceGender.allCases, id: \.self) { gender in
                             Text(gender.label).tag(gender)
                         }
                     }
                     .pickerStyle(.segmented)
 
                     Button(action: {
-                        speechService.speak("This is a test sentence.", voiceGender: settings.voiceGender)
+                        speechService.speak("This is a test sentence.", language: "en-US")
                     }) {
                         HStack {
-                            Image(systemName: speechService.isSpeaking ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                                 .font(.title2)
-                            Text("サンプルを再生")
+                            Text("英語サンプルを再生")
                                 .font(.headline)
                         }
                         .frame(maxWidth: .infinity)
@@ -62,6 +62,41 @@ struct SettingsView: View {
                     }
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
+                }
+
+                Section(header: Text("日本語の音声設定")) {
+                    Picker("スタイル", selection: $settings.voicevoxStyle) {
+                        ForEach(SettingsManager.VoicevoxStyle.allCases, id: \.self) { style in
+                            Text(style.label).tag(style)
+                        }
+                    }
+
+                    Button(action: {
+                        speechService.speak("これはテスト文です。", language: "ja-JP")
+                    }) {
+                        HStack {
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                                .font(.title2)
+                            Text("日本語サンプルを再生")
+                                .font(.headline)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .foregroundColor(.white)
+                        .background(Color.green)
+                        .cornerRadius(10)
+                    }
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+
+                    HStack(spacing: 4) {
+                        Image(systemName: "c.circle")
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                        Text("VOICEVOX:ずんだもん")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 Section(header: Text("連続再生設定")) {
@@ -100,25 +135,6 @@ struct SettingsView: View {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundColor(.green)
                             Text("APIキーが設定されています")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                }
-
-                if settings.voiceGender == .zundamon {
-                    Section(header: Text("VOICEVOX設定")) {
-                        Picker("スタイル", selection: $settings.voicevoxStyle) {
-                            ForEach(SettingsManager.VoicevoxStyle.allCases, id: \.self) { style in
-                                Text(style.label).tag(style)
-                            }
-                        }
-
-                        HStack(spacing: 4) {
-                            Image(systemName: "c.circle")
-                                .foregroundColor(.secondary)
-                                .font(.caption)
-                            Text("VOICEVOX:ずんだもん")
-                                .font(.caption)
                                 .foregroundColor(.secondary)
                         }
                     }
@@ -190,9 +206,9 @@ struct SettingsView: View {
 
                 Section(header: Text("説明")) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("英語の学習コンテンツの音声として、女性または男性の音声を選択できます。")
+                        Text("英語の音声は、女性・男性・デフォルトから選択できます。")
                             .font(.body)
-                        Text("デフォルトを選択すると、システムの設定に従います。")
+                        Text("日本語の音声は常にVOICEVOX(ずんだもん)を使用します。スタイルを選択して声のトーンを変更できます。")
                             .font(.body)
                             .foregroundColor(.secondary)
                     }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -392,14 +392,14 @@ struct WordListView: View {
                 case .bilingual:
                     switch step {
                     case 0, 2:
-                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                     case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
                     default:
                         break
                     }
                 case .englishOnly:
-                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                 }
 
                 // Update Now Playing info
@@ -496,7 +496,7 @@ struct WordRowView: View {
 
             HStack(spacing: 12) {
                 Button(action: {
-                    speechService.speak(word.word, voiceGender: speechService.voiceGender)
+                    speechService.speak(word.word, language: "en-US")
                 }) {
                     Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                         .font(.title2)
@@ -505,7 +505,7 @@ struct WordRowView: View {
                 .buttonStyle(.borderless)
 
                 Button(action: {
-                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: speechService.voiceGender)
+                    speechService.speak(word.meaning, language: "ja-JP")
                 }) {
                     Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                         .font(.title2)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
@@ -32,7 +32,7 @@ struct WordPracticeView: View {
             // 音声読み上げボタン
             HStack(spacing: 16) {
                 Button(action: {
-                    speechService.speak(word.word, voiceGender: settings.voiceGender)
+                    speechService.speak(word.word, language: "en-US")
                 }) {
                     VStack {
                         Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
@@ -47,7 +47,7 @@ struct WordPracticeView: View {
                 .foregroundColor(.blue)
 
                 Button(action: {
-                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
+                    speechService.speak(word.meaning, language: "ja-JP")
                 }) {
                     VStack {
                         Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")


### PR DESCRIPTION
## Summary

Implements automatic voice selection based on the language being spoken, eliminating the need for users to manually switch voice settings during bilingual practice.

### Key Changes

- **English speech**: Uses iOS native TTS with user-selected voice gender (Default/Female/Male)
- **Japanese speech**: Automatically uses VOICEVOX (ずんだもん) with selectable styles
- Split the unified voice setting into separate language-specific controls in the Settings UI

### Implementation Details

1. **SettingsManager**:
   - Renamed `voiceGender` → `englishVoiceGender` 
   - Removed `zundamon` option from `VoiceGender` enum (now `EnglishVoiceGender`)
   - Added migration logic to preserve existing user preferences

2. **SpeechService**:
   - Removed `voiceGender` parameter from `speak()` method
   - Automatically selects appropriate voice based on `language` parameter
   - Japanese (ja-JP) → VOICEVOX, English (en-US) → iOS native TTS

3. **UI Updates**:
   - SettingsView now has separate sections: "英語の音声設定" and "日本語の音声設定"
   - Each section has its own sample playback button
   - VOICEVOX settings always visible (no longer conditional)

4. **View Updates**:
   - Removed `voiceGender` parameter from all view files
   - Updated SpeechButton component to use automatic selection
   - Simplified speech calls in WordListView, SentenceListView, etc.

## Test Plan

- [x] Build succeeds with no compilation errors
- [ ] Manual testing on iOS simulator/device:
  - [ ] Verify English voice respects selected gender (Default/Female/Male)
  - [ ] Verify Japanese always uses VOICEVOX
  - [ ] Test continuous playback with bilingual mode (EN→JA→EN)
  - [ ] Test continuous playback with English-only mode
  - [ ] Verify settings migration works for existing users
  - [ ] Test both settings sample playback buttons
  - [ ] Verify individual speech buttons in word/sentence lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically migrated voice settings to new format to ensure continuity

* **New Features**
  * Reorganized voice settings with separate English and Japanese voice options
  * Voice selection now automatically adapts based on language context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->