### PR TITLE
Add language-specific voice selection

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -17,12 +17,21 @@ class SettingsManager: ObservableObject {
     /// The shared singleton instance.
     static let shared = SettingsManager()
 
-    /// The selected voice gender for text-to-speech.
+    /// The selected voice gender for English text-to-speech.
     ///
     /// Changes are automatically persisted to UserDefaults.
-    @Published var voiceGender: VoiceGender {
+    @Published var englishVoiceGender: VoiceGender {
         didSet {
-            saveVoiceGender()
+            saveEnglishVoiceGender()
+        }
+    }
+
+    /// The selected voice gender for Japanese text-to-speech.
+    ///
+    /// Changes are automatically persisted to UserDefaults.
+    @Published var japaneseVoiceGender: VoiceGender {
+        didSet {
+            saveJapaneseVoiceGender()
         }
     }
 
@@ -227,11 +236,18 @@ class SettingsManager: ObservableObject {
 
     /// Initializes the settings manager and loads saved preferences.
     init() {
-        if let saved = UserDefaults.standard.string(forKey: "voiceGender"),
+        if let saved = UserDefaults.standard.string(forKey: "englishVoiceGender"),
            let gender = VoiceGender(rawValue: saved) {
-            self.voiceGender = gender
+            self.englishVoiceGender = gender
         } else {
-            self.voiceGender = .default_
+            self.englishVoiceGender = .default_
+        }
+
+        if let saved = UserDefaults.standard.string(forKey: "japaneseVoiceGender"),
+           let gender = VoiceGender(rawValue: saved) {
+            self.japaneseVoiceGender = gender
+        } else {
+            self.japaneseVoiceGender = .zundamon
         }
 
         // Load API key from Keychain
@@ -302,6 +318,9 @@ class SettingsManager: ObservableObject {
         // Migrate OpenAI key from UserDefaults to Keychain (one-time)
         // This must be called after all stored properties are initialized
         migrateOpenAIKeyToKeychain()
+
+        // Migrate voiceGender to language-specific settings (one-time)
+        migrateVoiceGenderSettings()
     }
 
     // MARK: - Preset Management
@@ -374,9 +393,14 @@ class SettingsManager: ObservableObject {
 
     // MARK: - Private Methods
 
-    /// Persists the voice gender setting to UserDefaults.
-    private func saveVoiceGender() {
-        UserDefaults.standard.set(voiceGender.rawValue, forKey: "voiceGender")
+    /// Persists the English voice gender setting to UserDefaults.
+    private func saveEnglishVoiceGender() {
+        UserDefaults.standard.set(englishVoiceGender.rawValue, forKey: "englishVoiceGender")
+    }
+
+    /// Persists the Japanese voice gender setting to UserDefaults.
+    private func saveJapaneseVoiceGender() {
+        UserDefaults.standard.set(japaneseVoiceGender.rawValue, forKey: "japaneseVoiceGender")
     }
 
     /// Persists built-in overrides to UserDefaults.
@@ -423,5 +447,42 @@ class SettingsManager: ObservableObject {
 
         // Mark migration as complete
         UserDefaults.standard.set(true, forKey: keychainMigrationKey)
+    }
+
+    /// Migrates the old voiceGender setting to language-specific settings.
+    ///
+    /// This handles the transition from a single voiceGender setting to separate
+    /// englishVoiceGender and japaneseVoiceGender settings.
+    private func migrateVoiceGenderSettings() {
+        let legacyKey = "voiceGender"
+        let migrationKey = "voiceGenderLanguageMigrationCompleted"
+
+        // Skip if already migrated
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
+
+        // Only migrate if the new keys don't exist yet
+        let hasEnglish = UserDefaults.standard.string(forKey: "englishVoiceGender") != nil
+        let hasJapanese = UserDefaults.standard.string(forKey: "japaneseVoiceGender") != nil
+
+        if !hasEnglish || !hasJapanese {
+            // Check if there's a legacy voiceGender to migrate
+            if let legacyValue = UserDefaults.standard.string(forKey: legacyKey) {
+                // Migrate to both language settings
+                if !hasEnglish {
+                    UserDefaults.standard.set(legacyValue, forKey: "englishVoiceGender")
+                    self.englishVoiceGender = VoiceGender(rawValue: legacyValue) ?? .default_
+                }
+                if !hasJapanese {
+                    UserDefaults.standard.set(legacyValue, forKey: "japaneseVoiceGender")
+                    self.japaneseVoiceGender = VoiceGender(rawValue: legacyValue) ?? .zundamon
+                }
+
+                // Remove the old key
+                UserDefaults.standard.removeObject(forKey: legacyKey)
+            }
+        }
+
+        // Mark migration as complete
+        UserDefaults.standard.set(true, forKey: migrationKey)
     }
 }

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -7,8 +7,9 @@ import Foundation
 ///
 /// ## Usage
 /// ```swift
-/// // Access voice gender setting
-/// let gender = SettingsManager.shared.voiceGender
+/// // Access language-specific voice settings
+/// let englishVoice = SettingsManager.shared.englishVoiceGender
+/// let japaneseVoice = SettingsManager.shared.japaneseVoiceGender
 ///
 /// // Set OpenAI API key
 /// SettingsManager.shared.openAIAPIKey = "sk-..."

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -21,7 +21,6 @@ class SpeechService: NSObject, ObservableObject {
         static let pitchMultiplier: Float = 1.0
         static let volume: Float = 1.0
         static let utteranceDelay: TimeInterval = 0.0
-        static let voiceGenderKey = "voiceGender"
     }
 
     // MARK: - Properties
@@ -32,7 +31,6 @@ class SpeechService: NSObject, ObservableObject {
 
     @Published var isSpeaking = false
     @Published var speakingLanguage: String? = nil
-    @Published var voiceGender: SettingsManager.VoiceGender = .default_
 
     /// Publisher that emits when speech finishes naturally (not cancelled).
     /// Use this instead of onChange(of: isSpeaking) for reliable completion detection.
@@ -41,7 +39,6 @@ class SpeechService: NSObject, ObservableObject {
     override init() {
         super.init()
         synthesizer.delegate = self
-        observeSettingsChanges()
         configureAudioSession()
     }
 
@@ -74,26 +71,11 @@ class SpeechService: NSObject, ObservableObject {
         }
     }
 
-    private func observeSettingsChanges() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(updateVoiceGender),
-            name: UserDefaults.didChangeNotification,
-            object: nil
-        )
-    }
-
-    @objc private func updateVoiceGender() {
-        guard let saved = UserDefaults.standard.string(forKey: Constants.voiceGenderKey),
-              let gender = SettingsManager.VoiceGender(rawValue: saved) else { return }
-
-        // Defer update to avoid "Publishing changes from within view updates" warning
-        Task { @MainActor in
-            self.voiceGender = gender
-        }
-    }
-
-    /// Speaks the given text using the specified language and voice gender.
+    /// Speaks the given text using language-specific voice settings from SettingsManager.
+    ///
+    /// This method automatically selects the appropriate voice based on the language:
+    /// - For English ("en-US"): Uses englishVoiceGender setting
+    /// - For Japanese ("ja-JP"): Uses japaneseVoiceGender setting
     ///
     /// This method stops any ongoing speech before starting new playback. It tracks
     /// the current utterance to prevent race conditions from stale delegate callbacks.
@@ -101,9 +83,8 @@ class SpeechService: NSObject, ObservableObject {
     /// - Parameters:
     ///   - text: The text to be spoken
     ///   - language: The language code (default: "en-US")
-    ///   - voiceGender: The voice gender preference (default: .default_)
     ///   - isContinuousPlayback: Set to true when called from continuous playback to prevent stopping the session (default: false)
-    func speak(_ text: String, language: String = "en-US", voiceGender: SettingsManager.VoiceGender = .default_, isContinuousPlayback: Bool = false) {
+    func speak(_ text: String, language: String = "en-US", isContinuousPlayback: Bool = false) {
         stop()
 
         // Only notify when starting individual playback (not continuous playback)
@@ -113,6 +94,10 @@ class SpeechService: NSObject, ObservableObject {
         }
 
         speakingLanguage = language
+
+        // Get the appropriate voice gender based on language
+        let settings = SettingsManager.shared
+        let voiceGender = language == "ja-JP" ? settings.japaneseVoiceGender : settings.englishVoiceGender
 
         if voiceGender == .zundamon {
             isSpeaking = true

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SpeechButton.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/SpeechButton.swift
@@ -20,7 +20,6 @@ struct SpeechButton: View {
     var style: Style = .fullWidth
 
     @ObservedObject var speechService: SpeechService
-    let voiceGender: SettingsManager.VoiceGender
 
     private var isActive: Bool {
         speechService.isSpeaking &&
@@ -31,9 +30,9 @@ struct SpeechButton: View {
     var body: some View {
         Button {
             if isJapanese {
-                speechService.speak(text, language: "ja-JP", voiceGender: voiceGender)
+                speechService.speak(text, language: "ja-JP")
             } else {
-                speechService.speak(text, voiceGender: voiceGender)
+                speechService.speak(text, language: "en-US")
             }
         } label: {
             HStack {

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -63,12 +63,12 @@ struct SentenceListView: View {
                         SpeechButton(
                             text: word.word, label: "英語を聞く",
                             isJapanese: false, color: .blue, style: .pill,
-                            speechService: speechService, voiceGender: settings.voiceGender
+                            speechService: speechService
                         )
                         SpeechButton(
                             text: word.meaning, label: "日本語を聞く",
                             isJapanese: true, color: .orange, style: .pill,
-                            speechService: speechService, voiceGender: settings.voiceGender
+                            speechService: speechService
                         )
                     }
                     .padding(.top, 4)
@@ -185,14 +185,14 @@ struct SentenceListView: View {
                 case .bilingual:
                     switch step {
                     case 0, 2:
-                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                     case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
                     default:
                         break
                     }
                 case .englishOnly:
-                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                 }
 
                 // Update Now Playing info

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
@@ -47,14 +47,14 @@ struct SentencePracticeView: View {
                     SpeechButton(
                         text: sentence.english, label: "英語を聞く",
                         isJapanese: false, color: .blue,
-                        speechService: speechService, voiceGender: settings.voiceGender
+                        speechService: speechService
                     )
 
                     // 日本語訳読み上げボタン
                     SpeechButton(
                         text: sentence.japanese, label: "日本語訳を聞く",
                         isJapanese: true, color: .orange,
-                        speechService: speechService, voiceGender: settings.voiceGender
+                        speechService: speechService
                     )
 
                     // 発音チェックボタン

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -45,23 +45,13 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
 
-                    Button(action: {
-                        speechService.speak("This is a test sentence.", language: "en-US")
-                    }) {
-                        HStack {
-                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
-                                .font(.title2)
-                            Text("英語サンプルを再生")
-                                .font(.headline)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .foregroundColor(.white)
-                        .background(Color.blue)
-                        .cornerRadius(10)
-                    }
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
+                    VoiceSampleButton(
+                        text: "This is a test sentence.",
+                        language: "en-US",
+                        label: "英語サンプルを再生",
+                        color: .blue,
+                        speechService: speechService
+                    )
                 }
 
                 Section(header: Text("日本語の音声設定")) {
@@ -71,23 +61,13 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
 
-                    Button(action: {
-                        speechService.speak("これはテスト文です。", language: "ja-JP")
-                    }) {
-                        HStack {
-                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
-                                .font(.title2)
-                            Text("日本語サンプルを再生")
-                                .font(.headline)
-                        }
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 50)
-                        .foregroundColor(.white)
-                        .background(Color.green)
-                        .cornerRadius(10)
-                    }
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
+                    VoiceSampleButton(
+                        text: "これはテスト文です。",
+                        language: "ja-JP",
+                        label: "日本語サンプルを再生",
+                        color: .green,
+                        speechService: speechService
+                    )
                 }
 
                 Section(header: Text("連続再生設定")) {
@@ -319,6 +299,42 @@ struct SettingsView: View {
         }
     }
 
+}
+
+/// A reusable button for playing voice sample in settings.
+private struct VoiceSampleButton: View {
+    let text: String
+    let language: String
+    let label: String
+    let color: Color
+    @ObservedObject var speechService: SpeechService
+
+    private var isActive: Bool {
+        speechService.isSpeaking &&
+        (language == "ja-JP"
+            ? speechService.speakingLanguage == "ja-JP"
+            : speechService.speakingLanguage != "ja-JP")
+    }
+
+    var body: some View {
+        Button(action: {
+            speechService.speak(text, language: language)
+        }) {
+            HStack {
+                Image(systemName: isActive ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                    .font(.title2)
+                Text(label)
+                    .font(.headline)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .foregroundColor(.white)
+            .background(color)
+            .cornerRadius(10)
+        }
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+    }
 }
 
 #Preview {

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -310,10 +310,7 @@ private struct VoiceSampleButton: View {
     @ObservedObject var speechService: SpeechService
 
     private var isActive: Bool {
-        speechService.isSpeaking &&
-        (language == "ja-JP"
-            ? speechService.speakingLanguage == "ja-JP"
-            : speechService.speakingLanguage != "ja-JP")
+        speechService.isSpeaking && speechService.speakingLanguage == language
     }
 
     var body: some View {

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -37,8 +37,8 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section(header: Text("音声設定")) {
-                    Picker("音声の性別", selection: $settings.voiceGender) {
+                Section(header: Text("英語の音声設定")) {
+                    Picker("音声", selection: $settings.englishVoiceGender) {
                         ForEach(SettingsManager.VoiceGender.allCases, id: \.self) { gender in
                             Text(gender.label).tag(gender)
                         }
@@ -46,18 +46,44 @@ struct SettingsView: View {
                     .pickerStyle(.segmented)
 
                     Button(action: {
-                        speechService.speak("This is a test sentence.", voiceGender: settings.voiceGender)
+                        speechService.speak("This is a test sentence.", language: "en-US")
                     }) {
                         HStack {
-                            Image(systemName: speechService.isSpeaking ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                                 .font(.title2)
-                            Text("サンプルを再生")
+                            Text("英語サンプルを再生")
                                 .font(.headline)
                         }
                         .frame(maxWidth: .infinity)
                         .frame(height: 50)
                         .foregroundColor(.white)
                         .background(Color.blue)
+                        .cornerRadius(10)
+                    }
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                }
+
+                Section(header: Text("日本語の音声設定")) {
+                    Picker("音声", selection: $settings.japaneseVoiceGender) {
+                        Text("ずんだもん").tag(SettingsManager.VoiceGender.zundamon)
+                        Text("デフォルト").tag(SettingsManager.VoiceGender.default_)
+                    }
+                    .pickerStyle(.segmented)
+
+                    Button(action: {
+                        speechService.speak("これはテスト文です。", language: "ja-JP")
+                    }) {
+                        HStack {
+                            Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
+                                .font(.title2)
+                            Text("日本語サンプルを再生")
+                                .font(.headline)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 50)
+                        .foregroundColor(.white)
+                        .background(Color.green)
                         .cornerRadius(10)
                     }
                     .listRowInsets(EdgeInsets())
@@ -105,7 +131,7 @@ struct SettingsView: View {
                     }
                 }
 
-                if settings.voiceGender == .zundamon {
+                if settings.englishVoiceGender == .zundamon || settings.japaneseVoiceGender == .zundamon {
                     Section(header: Text("VOICEVOX設定")) {
                         Picker("スタイル", selection: $settings.voicevoxStyle) {
                             ForEach(SettingsManager.VoicevoxStyle.allCases, id: \.self) { style in
@@ -190,10 +216,13 @@ struct SettingsView: View {
 
                 Section(header: Text("説明")) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("英語の学習コンテンツの音声として、女性または男性の音声を選択できます。")
+                        Text("英語・日本語それぞれの音声を個別に設定できます。")
                             .font(.body)
-                        Text("デフォルトを選択すると、システムの設定に従います。")
-                            .font(.body)
+                        Text("英語音声: デフォルト/女性/男性/ずんだもん から選択")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("日本語音声: ずんだもん/デフォルト から選択")
+                            .font(.caption)
                             .foregroundColor(.secondary)
                     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -392,14 +392,14 @@ struct WordListView: View {
                 case .bilingual:
                     switch step {
                     case 0, 2:
-                        speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                     case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
                     default:
                         break
                     }
                 case .englishOnly:
-                    speechService.speak(sentence.english, voiceGender: settings.voiceGender, isContinuousPlayback: true)
+                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
                 }
 
                 // Update Now Playing info
@@ -496,7 +496,7 @@ struct WordRowView: View {
 
             HStack(spacing: 12) {
                 Button(action: {
-                    speechService.speak(word.word, voiceGender: speechService.voiceGender)
+                    speechService.speak(word.word, language: "en-US")
                 }) {
                     Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                         .font(.title2)
@@ -505,7 +505,7 @@ struct WordRowView: View {
                 .buttonStyle(.borderless)
 
                 Button(action: {
-                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: speechService.voiceGender)
+                    speechService.speak(word.meaning, language: "ja-JP")
                 }) {
                     Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
                         .font(.title2)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
@@ -32,7 +32,7 @@ struct WordPracticeView: View {
             // 音声読み上げボタン
             HStack(spacing: 16) {
                 Button(action: {
-                    speechService.speak(word.word, voiceGender: settings.voiceGender)
+                    speechService.speak(word.word, language: "en-US")
                 }) {
                     VStack {
                         Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage != "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")
@@ -47,7 +47,7 @@ struct WordPracticeView: View {
                 .foregroundColor(.blue)
 
                 Button(action: {
-                    speechService.speak(word.meaning, language: "ja-JP", voiceGender: settings.voiceGender)
+                    speechService.speak(word.meaning, language: "ja-JP")
                 }) {
                     VStack {
                         Image(systemName: (speechService.isSpeaking && speechService.speakingLanguage == "ja-JP") ? "speaker.wave.3.fill" : "speaker.wave.2.fill")


### PR DESCRIPTION
## Summary

Implements language-specific voice selection to provide maximum flexibility for bilingual learning. Users can now independently configure voice settings for English and Japanese speech.

### Voice Options

- **English**: Default / Female / Male / ずんだもん (VOICEVOX)
- **Japanese**: ずんだもん (VOICEVOX) / デフォルト (iOS Native TTS)

### Key Changes

1. **SettingsManager**:
   - Split unified `voiceGender` into `englishVoiceGender` and `japaneseVoiceGender`
   - Both properties use the same `VoiceGender` enum (Default/Female/Male/ずんだもん)
   - Added migration logic to preserve existing user settings

2. **SpeechService**:
   - Removed `voiceGender` parameter from `speak()` method
   - Automatically selects appropriate voice based on `language` parameter:
     - `language == "en-US"` → uses `settings.englishVoiceGender`
     - `language == "ja-JP"` → uses `settings.japaneseVoiceGender`
   - Both languages can use VOICEVOX when ずんだもん is selected

3. **UI Updates**:
   - SettingsView now has separate sections: "英語の音声設定" and "日本語の音声設定"
   - English picker shows all 4 options (Default/Female/Male/ずんだもん)
   - Japanese picker shows 2 options (ずんだもん/デフォルト)
   - Each section has its own sample playback button
   - VOICEVOX style picker appears when either language uses ずんだもん

4. **View Updates**:
   - Removed `voiceGender` parameter from all view files
   - Updated SpeechButton component for automatic voice selection
   - Simplified speech calls in WordListView, SentenceListView, etc.

## Test Plan

- [x] Build succeeds with no compilation errors
- [ ] Manual testing on iOS simulator/device:
  - [x] Verify English can use all 4 voice options
  - [x] Verify Japanese can use ずんだもん or iOS Native
  - [x] Test continuous playback with bilingual mode (EN→JA→EN)
  - [x] Test continuous playback with English-only mode
  - [ ] Verify settings migration works for existing users
  - [x] Test both settings sample playback buttons
  - [x] Verify individual speech buttons in word/sentence lists
  - [x] Test mix-and-match scenarios (e.g., Male English + ずんだもん Japanese)

## Benefits

- Maximum flexibility for bilingual learning
- Users can mix and match voices per language
- Supports use cases where users want ずんだもん for both languages
- No manual voice switching needed during practice
- More intuitive UX with language-specific controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-language voice gender settings: configure English and Japanese voices independently.
  * Settings screen updated with separate English/Japanese voice sections and per-language sample buttons.
  * Speech now auto-selects voice based on content language (affects single and continuous playback).

* **Changes**
  * Samples and playback use explicit language selection for more consistent pronunciation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->