### PR TITLE
Add console log to test Worker 1 parallel development

### DIFF
--- a/aws/bin/app.ts
+++ b/aws/bin/app.ts
@@ -11,6 +11,8 @@ if (!validEnvs.includes(env)) {
   throw new Error(`Invalid env: "${env}". Must be one of: ${validEnvs.join(' | ')}`);
 }
 
+console.log('Worker 1 is working on Issue #79 - Testing parallel development');
+
 new VoicevoxStack(app, `VoicevoxStack-${env}`, {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -25,6 +25,9 @@ export class VoicevoxStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: VoicevoxStackProps) {
     super(scope, id, props);
 
+    // Worker 1: Test parallel development
+    console.log('Worker 1 is working on Issue #79');
+
     const { stackEnv } = props;
     const cfg = envConfig[stackEnv];
 


### PR DESCRIPTION
## Summary
- Added a console.log statement in `VoicevoxStack` constructor to verify Worker 1 is working independently
- Tests the parallel development workflow with worktree isolation

## Test plan
- [x] Added console.log in `aws/lib/voicevox-stack.ts:29`
- [x] Verified the change is isolated to the Worker 1 worktree
- [ ] PR created to close test issue

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runtime diagnostic logging to the application startup and worker initialization to aid development and debugging.
  * No functional or user-facing behavior changes; existing features and error handling remain unchanged.

**Note:** This release contains no user-facing changes or feature updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->