### PR TITLE
Fix VOICEVOX background playback

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -175,6 +175,13 @@ class SpeechService: NSObject, ObservableObject {
                 do {
                     audioPlayer = try AVAudioPlayer(data: audioData)
                     audioPlayer?.delegate = self
+
+                    // Enable background playback and ensure audio session is active
+                    // This is critical for VOICEVOX playback to continue in background
+                    let audioSession = AVAudioSession.sharedInstance()
+                    try audioSession.setCategory(.playback, mode: .default)
+                    try audioSession.setActive(true)
+
                     audioPlayer?.play()
                 } catch {
                     print("AVAudioPlayer error: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary

Fixed VOICEVOX audio playback stopping when the app enters background mode. The issue was caused by audio session activation happening too early in the async flow, before AVAudioPlayer was created and started playing.

**Changes:**
- Activate audio session immediately before AVAudioPlayer playback starts in the VOICEVOX code path
- Ensure iOS recognizes VOICEVOX audio as background-capable by setting audio session category and activating it in the same execution context as playback

**Technical details:**
- Previous: `activateAudioSession()` called at line 104, before async VOICEVOX API calls
- New: Audio session explicitly configured and activated right before `audioPlayer?.play()` (lines 179-183)

Native iOS TTS (`AVSpeechSynthesizer`) continues to work correctly in background, as it already had proper audio session handling.

## Test plan

- [x] Build and run the app on a physical iOS device
- [x] Navigate to Settings and select VOICEVOX (zundamon) voice
- [x] Go to a sentence and start playback
- [x] Press home button or lock the screen while audio is playing
- [x] Verify VOICEVOX audio continues playing in background
- [ ] Test native iOS TTS (female/male) to ensure no regression

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled continuous background audio playback for VOICEVOX, preventing interruptions when the app is in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->