### PR TITLE
Upgrade Lambda authorizer to Node.js 22.x

### DIFF
--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -131,7 +131,7 @@ export class VoicevoxStack extends cdk.Stack {
 
     const authorizerFn = new lambda.Function(this, 'ApiKeyAuthorizer', {
       functionName: `voicevox-authorizer-${stackEnv}`,
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_22_X,
       handler: 'index.handler',
       code: lambda.Code.fromInline(`
         exports.handler = async (event) => {


### PR DESCRIPTION
## Summary

Upgrades the VOICEVOX API key authorizer Lambda function from Node.js 20.x to Node.js 22.x in response to AWS Health Event notification about Node.js 20.x end-of-life.

**Changes:**
- Updated `runtime: lambda.Runtime.NODEJS_20_X` → `lambda.Runtime.NODEJS_22_X`
- Single line change in `aws/lib/voicevox-stack.ts:134`

**Affected resources:**
- `voicevox-authorizer-poc`
- `voicevox-authorizer-dev`
- `voicevox-authorizer-pro`

**Compatibility:**
The authorizer function uses simple inline JavaScript code for API key validation (optional chaining, async/await, boolean logic). This code is fully compatible with Node.js 22.x and requires no modifications.

## Test plan

### Build verification
- [x] TypeScript compilation successful (`npm run build`)
- [x] No syntax errors or type errors

### Deployment and testing (per environment)

**POC environment:**
- [x] Deploy: `npm run deploy:poc`
- [x] Test `/audio_query` endpoint rejects requests without `x-api-key` header (401/403)
- [x] Test `/audio_query` endpoint accepts requests with valid `x-api-key` header (200)
- [x] Test `/synthesis` endpoint with valid API key (200)
- [ ] Test `/version` endpoint works without authentication (public endpoint, 200)

**DEV environment:**
- [ ] Deploy: `npm run deploy:dev`
- [ ] Verify API key authentication works correctly

**PRO environment:**
- [ ] Deploy: `npm run deploy:pro`
- [ ] Verify API key authentication works correctly

### Rollback plan
If issues occur, rollback by reverting this commit and redeploying with Node.js 20.x until EOL date.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment for the API authorization service to a newer version for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->