### PR TITLE
Fix continuous background playback for bilingual mode with mixed TTS engines

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -112,9 +112,16 @@ class SpeechService: NSObject, ObservableObject {
 
         currentUtterance = utterance
         isSpeaking = true
-        // Activate audio session right before starting local TTS to avoid
-        // preempting other audio until necessary.
-        _ = activateAudioSession()
+        // Ensure audio session is configured and activated right before starting TTS.
+        // This is critical for continuous playback in background mode, especially when
+        // switching between native TTS and VOICEVOX during bilingual playback.
+        let audioSession = AVAudioSession.sharedInstance()
+        do {
+            try audioSession.setCategory(.playback, mode: .default)
+            try audioSession.setActive(true)
+        } catch {
+            print("Failed to activate audio session for native TTS: \(error.localizedDescription)")
+        }
         synthesizer.speak(utterance)
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -112,15 +112,17 @@ class SpeechService: NSObject, ObservableObject {
 
         currentUtterance = utterance
         isSpeaking = true
-        // Ensure audio session is configured and activated right before starting TTS.
-        // This is critical for continuous playback in background mode, especially when
-        // switching between native TTS and VOICEVOX during bilingual playback.
+        // Ensure audio session is active for background playback.
+        // During continuous playback, avoid reconfiguring category to prevent interruption.
         let audioSession = AVAudioSession.sharedInstance()
         do {
-            try audioSession.setCategory(.playback, mode: .default)
+            // Only set category if we're starting fresh (not during continuous playback)
+            if !isContinuousPlayback || audioSession.category != .playback {
+                try audioSession.setCategory(.playback, mode: .default)
+            }
             try audioSession.setActive(true)
         } catch {
-            print("Failed to activate audio session for native TTS: \(error.localizedDescription)")
+            print("Failed to configure audio session for native TTS: \(error.localizedDescription)")
         }
         synthesizer.speak(utterance)
     }


### PR DESCRIPTION
## Summary

Fixed continuous background playback failure when using bilingual mode with mixed TTS engines (native iOS TTS + VOICEVOX). The issue occurred when the audio session context was lost during transitions between different TTS engines in background mode.

**Changes:**
- Apply consistent audio session management for native iOS TTS (AVSpeechSynthesizer)
- Explicitly set category to `.playback` and activate session right before each speech call
- Mirror the audio session pattern already working for VOICEVOX (SpeechService.swift:181-183)

**Technical details:**
- Previous: Native TTS used simple `activateAudioSession()` helper that only called `setActive(true)`
- New: Native TTS explicitly configures session category and activates in same execution context as `synthesizer.speak()`
- This ensures iOS recognizes each TTS call as background-capable, maintaining seamless playback when switching engines

## Test plan

- [ ] Build and run the app on a physical iOS device (background playback requires physical device)
- [ ] Navigate to Settings and configure bilingual playback mode
- [ ] Set English voice to native TTS (female/male/default)
- [ ] Set Japanese voice to VOICEVOX (zundamon)
- [ ] Go to a word with multiple sentences
- [ ] Start continuous playback
- [ ] Press home button or lock screen while playing
- [ ] Verify playback continues through all sentences (EN→JA→EN pattern) without stopping
- [ ] Verify the same test works when:
  - English = VOICEVOX, Japanese = native TTS
  - Both languages use native TTS
  - Both languages use VOICEVOX

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech playback reliability: activation is now tied to actual speech, reducing interruptions to ongoing playback and preserving background audio.
  * Added conditional handling to avoid switching audio modes unnecessarily during language or playback changes.
  * Enhanced error reporting for audio configuration failures to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->