### PR TITLE
Add persistent mini-player and playback queue management UI

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		850E49D02F4952F8000F46C6 /* ActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CE2F4952F8000F46C6 /* ActionBar.swift */; };
 		850E49D12F4952F8000F46C6 /* SelectableListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CF2F4952F8000F46C6 /* SelectableListRow.swift */; };
+		C1A00001238D1234567890AB /* QueueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00011238D1234567890AB /* QueueItem.swift */; };
+		C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */; };
+		C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00013238D1234567890AB /* MiniPlayerView.swift */; };
+		C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00014238D1234567890AB /* FullPlayerView.swift */; };
 		8577C1722F4BE3D20061F175 /* WordImportErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */; };
 		8577C1982F4BE5AC0061F175 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1942F4BE5AC0061F175 /* SettingsManager.swift */; };
 		8577C1992F4BE5AC0061F175 /* NowPlayingInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */; };
@@ -88,6 +92,10 @@
 		A1000088238D1234567890AB /* PronunciationResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PronunciationResultView.swift; sourceTree = "<group>"; };
 		A100008A238D1234567890AB /* RecognitionResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognitionResultView.swift; sourceTree = "<group>"; };
 		A100008C238D1234567890AB /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
+		C1A00011238D1234567890AB /* QueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueItem.swift; sourceTree = "<group>"; };
+		C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalPlaybackManager.swift; sourceTree = "<group>"; };
+		C1A00013238D1234567890AB /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
+		C1A00014238D1234567890AB /* FullPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullPlayerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -105,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				8577C18C2F4BE5AC0061F175 /* ContinuousPlaybackManager.swift */,
+				C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */,
 				8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */,
 				8577C18E2F4BE5AC0061F175 /* RemoteCommandCenterManager.swift */,
 			);
@@ -162,6 +171,7 @@
 				8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */,
 				A1000013238D1234567890AB /* Word.swift */,
 				A100007A238D1234567890AB /* PromptPreset.swift */,
+				C1A00011238D1234567890AB /* QueueItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -170,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				A1000012238D1234567890AB /* ContentView.swift */,
+				C1A00014238D1234567890AB /* FullPlayerView.swift */,
 				A1000016238D1234567890AB /* WordListView.swift */,
 				A1000017238D1234567890AB /* WordPracticeView.swift */,
 				A100001C238D1234567890AB /* SentenceListView.swift */,
@@ -212,6 +223,7 @@
 				A1000080238D1234567890AB /* ActivityPresenter.swift */,
 				A1000084238D1234567890AB /* SelectionState.swift */,
 				A1000086238D1234567890AB /* EmptyListView.swift */,
+				C1A00013238D1234567890AB /* MiniPlayerView.swift */,
 				A1000088238D1234567890AB /* PronunciationResultView.swift */,
 				A100008A238D1234567890AB /* RecognitionResultView.swift */,
 				A100008C238D1234567890AB /* SpeechButton.swift */,
@@ -326,6 +338,10 @@
 				850E49D02F4952F8000F46C6 /* ActionBar.swift in Sources */,
 				850E49D12F4952F8000F46C6 /* SelectableListRow.swift in Sources */,
 				A100008B238D1234567890AB /* SpeechButton.swift in Sources */,
+				C1A00001238D1234567890AB /* QueueItem.swift in Sources */,
+				C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */,
+				C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */,
+				C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -9,10 +9,6 @@
 /* Begin PBXBuildFile section */
 		850E49D02F4952F8000F46C6 /* ActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CE2F4952F8000F46C6 /* ActionBar.swift */; };
 		850E49D12F4952F8000F46C6 /* SelectableListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850E49CF2F4952F8000F46C6 /* SelectableListRow.swift */; };
-		C1A00001238D1234567890AB /* QueueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00011238D1234567890AB /* QueueItem.swift */; };
-		C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */; };
-		C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00013238D1234567890AB /* MiniPlayerView.swift */; };
-		C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00014238D1234567890AB /* FullPlayerView.swift */; };
 		8577C1722F4BE3D20061F175 /* WordImportErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1712F4BE3D20061F175 /* WordImportErrorHandler.swift */; };
 		8577C1982F4BE5AC0061F175 /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C1942F4BE5AC0061F175 /* SettingsManager.swift */; };
 		8577C1992F4BE5AC0061F175 /* NowPlayingInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577C18D2F4BE5AC0061F175 /* NowPlayingInfoManager.swift */; };
@@ -49,6 +45,10 @@
 		A1000087238D1234567890AB /* PronunciationResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000088238D1234567890AB /* PronunciationResultView.swift */; };
 		A1000089238D1234567890AB /* RecognitionResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100008A238D1234567890AB /* RecognitionResultView.swift */; };
 		A100008B238D1234567890AB /* SpeechButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100008C238D1234567890AB /* SpeechButton.swift */; };
+		C1A00001238D1234567890AB /* QueueItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00011238D1234567890AB /* QueueItem.swift */; };
+		C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */; };
+		C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00013238D1234567890AB /* MiniPlayerView.swift */; };
+		C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00014238D1234567890AB /* FullPlayerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */

--- a/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
+++ b/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
@@ -3,6 +3,10 @@ import SwiftUI
 @main
 struct EnglishLearnAppApp: App {
     @StateObject private var settingsManager = SettingsManager.shared
+    @StateObject private var globalPlaybackManager = GlobalPlaybackManager(
+        speechService: .shared,
+        settings: .shared
+    )
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     var body: some Scene {
@@ -10,9 +14,11 @@ struct EnglishLearnAppApp: App {
             if hasCompletedOnboarding {
                 ContentView()
                     .environmentObject(settingsManager)
+                    .environmentObject(globalPlaybackManager)
             } else {
                 OnboardingView(hasCompletedOnboarding: $hasCompletedOnboarding)
                     .environmentObject(settingsManager)
+                    .environmentObject(globalPlaybackManager)
             }
         }
     }

--- a/EnglishLearnApp/EnglishLearnApp/Models/QueueItem.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/QueueItem.swift
@@ -1,9 +1,14 @@
 import Foundation
 
 struct QueueItem: Identifiable, Equatable {
-    let id = UUID()
     let sentence: Sentence
     let word: Word
+
+    /// Stable, deterministic identifier based on sentence and word IDs.
+    /// Ensures SwiftUI diffing uses the same identifier as equality comparison.
+    var id: String {
+        "\(word.id)-\(sentence.id)"
+    }
 
     static func == (lhs: QueueItem, rhs: QueueItem) -> Bool {
         lhs.sentence.id == rhs.sentence.id && lhs.word.id == rhs.word.id

--- a/EnglishLearnApp/EnglishLearnApp/Models/QueueItem.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/QueueItem.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct QueueItem: Identifiable, Equatable {
+    let id = UUID()
+    let sentence: Sentence
+    let word: Word
+
+    static func == (lhs: QueueItem, rhs: QueueItem) -> Bool {
+        lhs.sentence.id == rhs.sentence.id && lhs.word.id == rhs.word.id
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -187,7 +187,7 @@ final class GlobalPlaybackManager: ObservableObject {
     func removeFromQueue(at index: Int) {
         guard index >= 0, index < queue.count else { return }
         let wasPlaying = isPlaying
-        let currentSentenceID = currentItem?.sentence.id
+        let currentItemID = currentItem?.id
 
         queue.remove(at: index)
 
@@ -196,8 +196,8 @@ final class GlobalPlaybackManager: ObservableObject {
             return
         }
 
-        if let currentSentenceID,
-           let newIndex = queue.firstIndex(where: { $0.sentence.id == currentSentenceID }) {
+        if let currentItemID,
+           let newIndex = queue.firstIndex(where: { $0.id == currentItemID }) {
             currentIndex = newIndex
         } else {
             currentIndex = min(currentIndex, queue.count - 1)

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -72,7 +72,7 @@ final class GlobalPlaybackManager: ObservableObject {
                 self.resume()
             },
             onPause: { [weak self] in
-                self?.stop()
+                self?.pause()
             },
             onNext: { [weak self] in
                 self?.next()
@@ -154,6 +154,31 @@ final class GlobalPlaybackManager: ObservableObject {
 
         // Restart from current index
         internalManager?.start(items: queue, startIndex: currentIndex)
+        syncStateFromManager()
+    }
+
+    /// Pauses playback while maintaining queue and Now Playing info.
+    ///
+    /// Unlike `stop()`, this keeps the Now Playing metadata visible on the lock screen
+    /// with playbackRate set to 0, allowing easy resume from the same position.
+    func pause() {
+        guard isPlaying else { return }
+
+        internalManager?.stop()
+        speechService.stop()
+        speechService.deactivateAudioSession()
+
+        // Update Now Playing to paused state (playbackRate = 0) instead of clearing
+        if let item = currentItem {
+            let stepLabel = settings.playbackMode.stepLabel(for: currentStep)
+            NowPlayingInfoManager.update(
+                title: item.sentence.english,
+                artist: "\(item.word.word) - \(stepLabel)",
+                album: item.word.meaning,
+                playbackRate: 0.0
+            )
+        }
+
         syncStateFromManager()
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -111,9 +111,10 @@ final class GlobalPlaybackManager: ObservableObject {
     ///   - items: The items to enqueue
     ///   - startIndex: The index to start from (default: 0)
     func enqueue(_ items: [QueueItem], startIndex: Int = 0) {
-        guard !items.isEmpty else { return }
+        guard !items.isEmpty, items.indices.contains(startIndex) else { return }
 
-        // Stop any current playback
+        // Invalidate pending completion work tied to the previous manager
+        internalManager?.stop()
         speechService.stop()
 
         // Create or recreate the internal manager
@@ -172,28 +173,26 @@ final class GlobalPlaybackManager: ObservableObject {
     /// - If removing before current index, adjusts current index
     func removeFromQueue(at index: Int) {
         guard index >= 0, index < queue.count else { return }
+        let wasPlaying = isPlaying
+        let currentSentenceID = currentItem?.sentence.id
 
-        if index == currentIndex {
-            // Removing current item
-            queue.remove(at: index)
-            if queue.isEmpty {
-                clearQueue()
-            } else {
-                // Restart from the same index (now next item) or last item
-                let newIndex = min(currentIndex, queue.count - 1)
-                if isPlaying {
-                    enqueue(queue, startIndex: newIndex)
-                } else {
-                    currentIndex = newIndex
-                }
-            }
-        } else if index < currentIndex {
-            // Removing before current - adjust index
-            queue.remove(at: index)
-            currentIndex -= 1
+        queue.remove(at: index)
+
+        guard !queue.isEmpty else {
+            clearQueue()
+            return
+        }
+
+        if let currentSentenceID,
+           let newIndex = queue.firstIndex(where: { $0.sentence.id == currentSentenceID }) {
+            currentIndex = newIndex
         } else {
-            // Removing after current - just remove
-            queue.remove(at: index)
+            currentIndex = min(currentIndex, queue.count - 1)
+            currentStep = 0
+        }
+
+        if wasPlaying {
+            enqueue(queue, startIndex: currentIndex)
         }
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -103,6 +103,19 @@ final class GlobalPlaybackManager: ObservableObject {
         return queue[currentIndex]
     }
 
+    /// Checks if the given queue matches the currently playing queue.
+    ///
+    /// Useful for views to determine if they "own" the current playback.
+    ///
+    /// - Parameter items: Queue items to compare against current queue
+    /// - Returns: true if the items match the current queue (same IDs in same order)
+    func isPlayingQueue(_ items: [QueueItem]) -> Bool {
+        guard isPlaying else { return false }
+        let currentIDs = queue.map { $0.id }
+        let givenIDs = items.map { $0.id }
+        return currentIDs == givenIDs
+    }
+
     /// Enqueues items and starts playback from the specified index.
     ///
     /// This replaces any existing queue and starts fresh playback.

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -1,0 +1,278 @@
+import Foundation
+import Combine
+
+/// Global playback manager that provides app-wide continuous playback with a persistent mini-player.
+///
+/// This manager wraps `ContinuousPlaybackManager<QueueItem>` and exposes state for SwiftUI views.
+/// It handles:
+/// - Queue management (enqueue, remove, clear)
+/// - Speech completion via publisher subscription
+/// - Remote command center integration
+/// - Now Playing info updates
+///
+/// **Usage:** Inject as an `@EnvironmentObject` from the app root.
+@MainActor
+final class GlobalPlaybackManager: ObservableObject {
+    // MARK: - Published State
+
+    /// The current playback queue.
+    @Published private(set) var queue: [QueueItem] = []
+
+    /// Current index in the queue.
+    @Published private(set) var currentIndex: Int = 0
+
+    /// Current playback step within an item (0=EN, 1=JA, 2=EN for bilingual).
+    @Published private(set) var currentStep: Int = 0
+
+    /// Whether playback is currently active.
+    @Published private(set) var isPlaying: Bool = false
+
+    // MARK: - Dependencies
+
+    private let speechService: SpeechService
+    private let settings: SettingsManager
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Internal Manager
+
+    private var internalManager: ContinuousPlaybackManager<QueueItem>?
+    private let remoteCommandManager = RemoteCommandCenterManager()
+
+    // MARK: - Initialization
+
+    /// Creates a new global playback manager.
+    ///
+    /// - Parameters:
+    ///   - speechService: The shared speech service for TTS
+    ///   - settings: The settings manager for playback mode preferences
+    init(speechService: SpeechService, settings: SettingsManager) {
+        self.speechService = speechService
+        self.settings = settings
+
+        setupSpeechFinishedSubscription()
+        setupRemoteCommandHandlers()
+        setupPlaybackModeObserver()
+    }
+
+    // MARK: - Setup
+
+    private func setupSpeechFinishedSubscription() {
+        speechService.speechFinishedPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.handleSpeechFinished()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func setupRemoteCommandHandlers() {
+        remoteCommandManager.setup(
+            onPlay: { [weak self] in
+                guard let self, !self.isPlaying, !self.queue.isEmpty else { return }
+                self.resume()
+            },
+            onPause: { [weak self] in
+                self?.stop()
+            },
+            onNext: { [weak self] in
+                self?.next()
+            },
+            onPrevious: { [weak self] in
+                self?.previous()
+            }
+        )
+    }
+
+    private func setupPlaybackModeObserver() {
+        settings.$playbackMode
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] newMode in
+                self?.internalManager?.updatePlaybackMode(newMode)
+                self?.syncStateFromManager()
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Public Methods
+
+    /// The current item in the queue (playing or paused).
+    /// Returns the item at currentIndex if queue has items, regardless of playback state.
+    var currentItem: QueueItem? {
+        guard !queue.isEmpty, currentIndex < queue.count else { return nil }
+        return queue[currentIndex]
+    }
+
+    /// Enqueues items and starts playback from the specified index.
+    ///
+    /// This replaces any existing queue and starts fresh playback.
+    ///
+    /// - Parameters:
+    ///   - items: The items to enqueue
+    ///   - startIndex: The index to start from (default: 0)
+    func enqueue(_ items: [QueueItem], startIndex: Int = 0) {
+        guard !items.isEmpty else { return }
+
+        // Stop any current playback
+        speechService.stop()
+
+        // Create or recreate the internal manager
+        internalManager = ContinuousPlaybackManager(
+            playbackMode: settings.playbackMode,
+            speechHandler: { [weak self] item, step in
+                self?.handleSpeech(for: item, step: step)
+            },
+            completionHandler: { [weak self] in
+                self?.handlePlaybackCompletion()
+            }
+        )
+
+        queue = items
+        internalManager?.start(items: items, startIndex: startIndex)
+        syncStateFromManager()
+    }
+
+    /// Resumes playback from the current position.
+    ///
+    /// Only works if there are items in the queue and playback is not active.
+    func resume() {
+        guard !queue.isEmpty, !isPlaying else { return }
+
+        // Restart from current index
+        internalManager?.start(items: queue, startIndex: currentIndex)
+        syncStateFromManager()
+    }
+
+    /// Stops playback and clears state (but keeps the queue).
+    func stop() {
+        internalManager?.stop()
+        speechService.stop()
+        speechService.deactivateAudioSession()
+        NowPlayingInfoManager.clear()
+        syncStateFromManager()
+    }
+
+    /// Advances to the next item.
+    func next() {
+        guard internalManager?.next() == true else { return }
+        syncStateFromManager()
+    }
+
+    /// Returns to the previous item.
+    func previous() {
+        guard internalManager?.previous() == true else { return }
+        syncStateFromManager()
+    }
+
+    /// Removes an item from the queue at the specified index.
+    ///
+    /// Handles edge cases:
+    /// - If removing the current item, advances to the next
+    /// - If the queue becomes empty, stops playback
+    /// - If removing before current index, adjusts current index
+    func removeFromQueue(at index: Int) {
+        guard index >= 0, index < queue.count else { return }
+
+        if index == currentIndex {
+            // Removing current item
+            queue.remove(at: index)
+            if queue.isEmpty {
+                clearQueue()
+            } else {
+                // Restart from the same index (now next item) or last item
+                let newIndex = min(currentIndex, queue.count - 1)
+                if isPlaying {
+                    enqueue(queue, startIndex: newIndex)
+                } else {
+                    currentIndex = newIndex
+                }
+            }
+        } else if index < currentIndex {
+            // Removing before current - adjust index
+            queue.remove(at: index)
+            currentIndex -= 1
+        } else {
+            // Removing after current - just remove
+            queue.remove(at: index)
+        }
+    }
+
+    /// Clears the entire queue and stops playback.
+    func clearQueue() {
+        stop()
+        queue = []
+        currentIndex = 0
+        currentStep = 0
+        isPlaying = false
+    }
+
+    // MARK: - Private Methods
+
+    private func handleSpeech(for item: QueueItem, step: Int) {
+        let mode = settings.playbackMode
+
+        switch mode {
+        case .bilingual:
+            switch step {
+            case 0, 2:
+                speechService.speak(item.sentence.english, language: "en-US", isContinuousPlayback: true)
+            case 1:
+                speechService.speak(item.sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
+            default:
+                break
+            }
+        case .englishOnly:
+            speechService.speak(item.sentence.english, language: "en-US", isContinuousPlayback: true)
+        }
+
+        // Update Now Playing info
+        let stepLabel = mode.stepLabel(for: step)
+        NowPlayingInfoManager.update(
+            title: item.sentence.english,
+            artist: "\(item.word.word) - \(stepLabel)",
+            album: item.word.meaning,
+            playbackRate: 1.0
+        )
+    }
+
+    private func handleSpeechFinished() {
+        guard let manager = internalManager, manager.isPlaying else { return }
+
+        // Capture generation for validation
+        let generation = manager.playbackGeneration
+
+        // Add delay before advancing (0.8 seconds)
+        Task {
+            try? await Task.sleep(nanoseconds: 800_000_000)
+            await MainActor.run {
+                guard manager.isValidCompletion(generation: generation) else { return }
+                manager.advance()
+                syncStateFromManager()
+            }
+        }
+    }
+
+    private func handlePlaybackCompletion() {
+        speechService.deactivateAudioSession()
+        NowPlayingInfoManager.clear()
+        syncStateFromManager()
+    }
+
+    private func syncStateFromManager() {
+        guard let manager = internalManager else {
+            isPlaying = false
+            currentIndex = 0
+            currentStep = 0
+            return
+        }
+
+        isPlaying = manager.isPlaying
+        currentIndex = manager.currentIndex
+        currentStep = manager.currentStep
+
+        // Sync queue if manager stopped
+        if !manager.isPlaying && manager.items.isEmpty && !queue.isEmpty {
+            // Manager was stopped - keep queue for resume capability
+        }
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -205,13 +205,13 @@ final class GlobalPlaybackManager: ObservableObject {
     ///   - toOffset: The destination index
     func move(fromOffsets: IndexSet, toOffset: Int) {
         let wasPlaying = isPlaying
-        let currentItemID = currentItem.map { "\($0.word.id)-\($0.sentence.id)" }
+        let currentItemID = currentItem?.id
 
         queue.move(fromOffsets: fromOffsets, toOffset: toOffset)
 
         // Update currentIndex to track the moved item
         if let currentItemID,
-           let newIndex = queue.firstIndex(where: { "\($0.word.id)-\($0.sentence.id)" == currentItemID }) {
+           let newIndex = queue.firstIndex(where: { $0.id == currentItemID }) {
             currentIndex = newIndex
         }
 

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -196,6 +196,31 @@ final class GlobalPlaybackManager: ObservableObject {
         }
     }
 
+    /// Moves items within the queue from one position to another.
+    ///
+    /// Adjusts currentIndex to track the currently playing item after the move.
+    ///
+    /// - Parameters:
+    ///   - fromOffsets: The indices of items to move
+    ///   - toOffset: The destination index
+    func move(fromOffsets: IndexSet, toOffset: Int) {
+        let wasPlaying = isPlaying
+        let currentItemID = currentItem.map { "\($0.word.id)-\($0.sentence.id)" }
+
+        queue.move(fromOffsets: fromOffsets, toOffset: toOffset)
+
+        // Update currentIndex to track the moved item
+        if let currentItemID,
+           let newIndex = queue.firstIndex(where: { "\($0.word.id)-\($0.sentence.id)" == currentItemID }) {
+            currentIndex = newIndex
+        }
+
+        // Re-enqueue if playing to sync internal manager
+        if wasPlaying {
+            enqueue(queue, startIndex: currentIndex)
+        }
+    }
+
     /// Clears the entire queue and stops playback.
     func clearQueue() {
         stop()

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -14,6 +14,10 @@ extension Notification.Name {
 /// These warnings do not impact user experience or app stability.
 @MainActor
 class SpeechService: NSObject, ObservableObject {
+    // MARK: - Shared Instance
+
+    static let shared = SpeechService()
+
     // MARK: - Constants
 
     private enum Constants {

--- a/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject private var settings: SettingsManager
+    @EnvironmentObject private var globalPlaybackManager: GlobalPlaybackManager
     @State private var selectedTab = 0
     @State private var showingAddWordView = false
 
@@ -54,10 +55,16 @@ struct ContentView: View {
                 WordDataManager.shared.addWord(newWord)
             }
         }
+        .safeAreaInset(edge: .bottom) {
+            if !globalPlaybackManager.queue.isEmpty {
+                MiniPlayerView()
+            }
+        }
     }
 }
 
 #Preview {
     ContentView()
         .environmentObject(SettingsManager.shared)
+        .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
@@ -10,6 +10,7 @@ struct FullPlayerView: View {
     @EnvironmentObject private var playbackManager: GlobalPlaybackManager
     @EnvironmentObject private var settings: SettingsManager
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.editMode) private var editMode
 
     var body: some View {
         NavigationStack {
@@ -38,9 +39,20 @@ struct FullPlayerView: View {
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if !playbackManager.queue.isEmpty {
-                        Button("クリア", role: .destructive) {
-                            playbackManager.clearQueue()
-                            dismiss()
+                        HStack(spacing: 8) {
+                            if editMode?.wrappedValue == .active {
+                                Button("完了") {
+                                    editMode?.wrappedValue = .inactive
+                                }
+                            } else {
+                                Button("編集") {
+                                    editMode?.wrappedValue = .active
+                                }
+                                Button("クリア", role: .destructive) {
+                                    playbackManager.clearQueue()
+                                    dismiss()
+                                }
+                            }
                         }
                     }
                 }
@@ -194,6 +206,9 @@ struct FullPlayerView: View {
                             Label("削除", systemImage: "trash")
                         }
                     }
+            }
+            .onMove { fromOffsets, toOffset in
+                playbackManager.move(fromOffsets: fromOffsets, toOffset: toOffset)
             }
         }
         .listStyle(.plain)

--- a/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
@@ -134,7 +134,7 @@ struct FullPlayerView: View {
 
             Button {
                 if playbackManager.isPlaying {
-                    playbackManager.stop()
+                    playbackManager.pause()
                 } else {
                     playbackManager.resume()
                 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/FullPlayerView.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+
+/// A full-screen player view showing current playback and queue management.
+///
+/// Presented as a sheet from MiniPlayerView. Shows:
+/// - Current word information
+/// - Current sentence with step indicator
+/// - Full queue with swipe-to-delete
+struct FullPlayerView: View {
+    @EnvironmentObject private var playbackManager: GlobalPlaybackManager
+    @EnvironmentObject private var settings: SettingsManager
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Current playback section
+                if let item = playbackManager.currentItem {
+                    currentPlaybackSection(item: item)
+                } else if let firstItem = playbackManager.queue.first {
+                    // Show first item if not playing
+                    currentPlaybackSection(item: firstItem)
+                }
+
+                Divider()
+                    .padding(.vertical, 8)
+
+                // Queue section
+                queueSection
+            }
+            .navigationTitle("再生キュー")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !playbackManager.queue.isEmpty {
+                        Button("クリア", role: .destructive) {
+                            playbackManager.clearQueue()
+                            dismiss()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Current Playback Section
+
+    @ViewBuilder
+    private func currentPlaybackSection(item: QueueItem) -> some View {
+        VStack(spacing: 16) {
+            // Word info
+            VStack(spacing: 4) {
+                Text(item.word.word)
+                    .font(.title)
+                    .fontWeight(.bold)
+
+                Text(item.word.phonetic)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                Text(item.word.meaning)
+                    .font(.body)
+                    .foregroundColor(.blue)
+            }
+            .padding(.top, 20)
+
+            // Current sentence
+            VStack(spacing: 8) {
+                Text(item.sentence.english)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundColor(.blue)
+                    .multilineTextAlignment(.center)
+
+                Text(item.sentence.japanese)
+                    .font(.subheadline)
+                    .foregroundColor(.orange)
+                    .multilineTextAlignment(.center)
+
+                // Step indicator
+                stepIndicator
+            }
+            .padding(.horizontal, 20)
+
+            // Playback controls
+            playbackControls
+                .padding(.top, 8)
+        }
+    }
+
+    private var stepIndicator: some View {
+        let mode = settings.playbackMode
+        let step = playbackManager.currentStep
+        let totalSteps = mode.stepsPerItem
+
+        return HStack(spacing: 4) {
+            ForEach(0..<totalSteps, id: \.self) { index in
+                Circle()
+                    .fill(index == step ? Color.accentColor : Color.secondary.opacity(0.3))
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    private var playbackControls: some View {
+        HStack(spacing: 32) {
+            Button {
+                playbackManager.previous()
+            } label: {
+                Image(systemName: "backward.fill")
+                    .font(.title)
+                    .foregroundColor(.primary)
+            }
+            .buttonStyle(.plain)
+            .disabled(playbackManager.currentIndex == 0)
+
+            Button {
+                if playbackManager.isPlaying {
+                    playbackManager.stop()
+                } else {
+                    playbackManager.resume()
+                }
+            } label: {
+                Image(systemName: playbackManager.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.system(size: 56))
+                    .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                playbackManager.next()
+            } label: {
+                Image(systemName: "forward.fill")
+                    .font(.title)
+                    .foregroundColor(.primary)
+            }
+            .buttonStyle(.plain)
+            .disabled(playbackManager.currentIndex >= playbackManager.queue.count - 1)
+        }
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Queue Section
+
+    private var queueSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("キュー")
+                    .font(.headline)
+                Text("\(playbackManager.queue.count)件")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 20)
+
+            if playbackManager.queue.isEmpty {
+                emptyQueueView
+            } else {
+                queueList
+            }
+        }
+    }
+
+    private var emptyQueueView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "music.note.list")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("キューが空です")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var queueList: some View {
+        List {
+            ForEach(playbackManager.queue.indices, id: \.self) { index in
+                let item = playbackManager.queue[index]
+                queueRow(item: item, index: index)
+                    .listRowBackground(
+                        index == playbackManager.currentIndex ? Color.accentColor.opacity(0.12) : nil
+                    )
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            playbackManager.removeFromQueue(at: index)
+                        } label: {
+                            Label("削除", systemImage: "trash")
+                        }
+                    }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func queueRow(item: QueueItem, index: Int) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.sentence.english)
+                    .font(.subheadline)
+                    .lineLimit(1)
+
+                HStack(spacing: 4) {
+                    Text(item.word.word)
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                    Text(item.sentence.japanese)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            if index == playbackManager.currentIndex && playbackManager.isPlaying {
+                Image(systemName: "speaker.wave.2.fill")
+                    .foregroundColor(.accentColor)
+                    .font(.caption)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // Tap to play from this item
+            playbackManager.enqueue(playbackManager.queue, startIndex: index)
+        }
+    }
+}
+
+#Preview {
+    FullPlayerView()
+        .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
+        .environmentObject(SettingsManager.shared)
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
@@ -11,11 +11,11 @@ struct MiniPlayerView: View {
     @State private var showingFullPlayer = false
 
     var body: some View {
-        Button {
-            showingFullPlayer = true
-        } label: {
-            HStack(spacing: 12) {
-                // Current sentence info
+        HStack(spacing: 12) {
+            // Current sentence info - tappable to expand
+            Button {
+                showingFullPlayer = true
+            } label: {
                 VStack(alignment: .leading, spacing: 2) {
                     if let item = playbackManager.currentItem {
                         currentSentenceText(for: item)
@@ -34,49 +34,49 @@ struct MiniPlayerView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-
-                // Playback controls
-                HStack(spacing: 16) {
-                    Button {
-                        playbackManager.previous()
-                    } label: {
-                        Image(systemName: "backward.fill")
-                            .font(.title3)
-                            .foregroundColor(.primary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(playbackManager.currentIndex == 0)
-
-                    Button {
-                        if playbackManager.isPlaying {
-                            playbackManager.stop()
-                        } else {
-                            playbackManager.resume()
-                        }
-                    } label: {
-                        Image(systemName: playbackManager.isPlaying ? "pause.fill" : "play.fill")
-                            .font(.title2)
-                            .foregroundColor(.primary)
-                    }
-                    .buttonStyle(.plain)
-
-                    Button {
-                        playbackManager.next()
-                    } label: {
-                        Image(systemName: "forward.fill")
-                            .font(.title3)
-                            .foregroundColor(.primary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(playbackManager.currentIndex >= playbackManager.queue.count - 1)
-                }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
-            .background(.regularMaterial)
-            .overlay(alignment: .top) { Divider() }
+            .buttonStyle(.plain)
+
+            // Playback controls - sibling buttons, not nested
+            HStack(spacing: 16) {
+                Button {
+                    playbackManager.previous()
+                } label: {
+                    Image(systemName: "backward.fill")
+                        .font(.title3)
+                        .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+                .disabled(playbackManager.currentIndex == 0)
+
+                Button {
+                    if playbackManager.isPlaying {
+                        playbackManager.stop()
+                    } else {
+                        playbackManager.resume()
+                    }
+                } label: {
+                    Image(systemName: playbackManager.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.title2)
+                        .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    playbackManager.next()
+                } label: {
+                    Image(systemName: "forward.fill")
+                        .font(.title3)
+                        .foregroundColor(.primary)
+                }
+                .buttonStyle(.plain)
+                .disabled(playbackManager.currentIndex >= playbackManager.queue.count - 1)
+            }
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(.regularMaterial)
+        .overlay(alignment: .top) { Divider() }
         .sheet(isPresented: $showingFullPlayer) {
             FullPlayerView()
         }

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
@@ -51,7 +51,7 @@ struct MiniPlayerView: View {
 
                 Button {
                     if playbackManager.isPlaying {
-                        playbackManager.stop()
+                        playbackManager.pause()
                     } else {
                         playbackManager.resume()
                     }

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// A persistent mini-player that displays at the bottom of the screen during playback.
+///
+/// Shows the current sentence, playback progress, and control buttons.
+/// Tapping opens the full player sheet for queue management.
+struct MiniPlayerView: View {
+    @EnvironmentObject private var playbackManager: GlobalPlaybackManager
+    @EnvironmentObject private var settings: SettingsManager
+
+    @State private var showingFullPlayer = false
+
+    var body: some View {
+        Button {
+            showingFullPlayer = true
+        } label: {
+            HStack(spacing: 12) {
+                // Current sentence info
+                VStack(alignment: .leading, spacing: 2) {
+                    if let item = playbackManager.currentItem {
+                        currentSentenceText(for: item)
+                        HStack(spacing: 4) {
+                            Text(item.word.word)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                            Text(progressText)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } else {
+                        Text("No playback")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                // Playback controls
+                HStack(spacing: 16) {
+                    Button {
+                        playbackManager.previous()
+                    } label: {
+                        Image(systemName: "backward.fill")
+                            .font(.title3)
+                            .foregroundColor(.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(playbackManager.currentIndex == 0)
+
+                    Button {
+                        if playbackManager.isPlaying {
+                            playbackManager.stop()
+                        } else {
+                            playbackManager.resume()
+                        }
+                    } label: {
+                        Image(systemName: playbackManager.isPlaying ? "pause.fill" : "play.fill")
+                            .font(.title2)
+                            .foregroundColor(.primary)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        playbackManager.next()
+                    } label: {
+                        Image(systemName: "forward.fill")
+                            .font(.title3)
+                            .foregroundColor(.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(playbackManager.currentIndex >= playbackManager.queue.count - 1)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.regularMaterial)
+            .overlay(alignment: .top) { Divider() }
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showingFullPlayer) {
+            FullPlayerView()
+        }
+    }
+
+    // MARK: - Helper Views
+
+    @ViewBuilder
+    private func currentSentenceText(for item: QueueItem) -> some View {
+        let mode = settings.playbackMode
+        let step = playbackManager.currentStep
+
+        // Determine which text to show based on current step
+        let (text, isJapanese): (String, Bool) = {
+            switch mode {
+            case .bilingual:
+                switch step {
+                case 0, 2:
+                    return (item.sentence.english, false)
+                case 1:
+                    return (item.sentence.japanese, true)
+                default:
+                    return (item.sentence.english, false)
+                }
+            case .englishOnly:
+                return (item.sentence.english, false)
+            }
+        }()
+
+        Text(text)
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .foregroundColor(isJapanese ? .orange : .blue)
+            .lineLimit(1)
+    }
+
+    private var progressText: String {
+        let current = playbackManager.currentIndex + 1
+        let total = playbackManager.queue.count
+        return "\(current)/\(total)"
+    }
+}
+
+#Preview {
+    VStack {
+        Spacer()
+        MiniPlayerView()
+    }
+    .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
+    .environmentObject(SettingsManager.shared)
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -1,14 +1,10 @@
 import SwiftUI
-import MediaPlayer
 
 struct SentenceListView: View {
     let word: Word
-    @StateObject private var speechService = SpeechService()
+    private let speechService = SpeechService.shared
     @EnvironmentObject private var settings: SettingsManager
-
-    // MARK: - Continuous playback managers
-    @State private var playbackManager: ContinuousPlaybackManager<Sentence>?
-    @State private var remoteCommandManager = RemoteCommandCenterManager()
+    @EnvironmentObject private var globalPlaybackManager: GlobalPlaybackManager
 
     init(word: Word) {
         self.word = word
@@ -22,24 +18,27 @@ struct SentenceListView: View {
         return grouped.sorted { $0.key < $1.key }
     }
 
-    /// Flattens the grouped sentences into a single array for continuous playback.
+    /// Flattens the grouped sentences into queue items for continuous playback.
     ///
     /// This computed property provides the sentences in display order, which is used
     /// for indexing during continuous playback operations.
     ///
-    /// - Returns: An array of all sentences in display order
-    private var allSentences: [Sentence] {
-        groupedSentences.flatMap { $0.1 }
+    /// - Returns: An array of QueueItem in display order
+    private var allQueueItems: [QueueItem] {
+        groupedSentences.flatMap { _, sentences in
+            sentences.map { sentence in
+                QueueItem(sentence: sentence, word: word)
+            }
+        }
     }
 
     /// Returns the UUID of the currently playing sentence, if any.
     ///
     /// - Returns: The sentence ID if playback is active and index is valid, otherwise nil
     private var playingSentenceID: UUID? {
-        guard let manager = playbackManager,
-              manager.isPlaying,
-              manager.currentIndex < allSentences.count else { return nil }
-        return allSentences[manager.currentIndex].id
+        guard globalPlaybackManager.isPlaying,
+              globalPlaybackManager.currentIndex < globalPlaybackManager.queue.count else { return nil }
+        return globalPlaybackManager.currentItem?.sentence.id
     }
 
     var body: some View {
@@ -90,7 +89,7 @@ struct SentenceListView: View {
                             }
                             Button {
                                 if isPlaying {
-                                    stopPlayAll()
+                                    globalPlaybackManager.stop()
                                 } else {
                                     startPlayAll(from: sentence)
                                 }
@@ -111,140 +110,36 @@ struct SentenceListView: View {
         }
         .navigationTitle("例文一覧")
         .navigationBarTitleDisplayMode(.inline)
-        .onReceive(speechService.speechFinishedPublisher) { _ in
-            // Called only when speech finishes naturally (not cancelled)
-            guard let manager = playbackManager, manager.isPlaying else { return }
-
-            // Add a delay before advancing to the next step for better pacing
-            let capturedGeneration = manager.playbackGeneration
-            Task {
-                try? await Task.sleep(nanoseconds: 800_000_000)  // 0.8 second delay
-                await MainActor.run {
-                    // Verify generation hasn't changed during the delay
-                    guard manager.isValidCompletion(generation: capturedGeneration) else { return }
-                    manager.advance()
-                }
-            }
-        }
-        .onAppear {
-            setupPlaybackManager()
-
-            // Setup remote command center (callbacks already dispatched to main queue)
-            remoteCommandManager.setup(
-                onPlay: {
-                    if let manager = self.playbackManager, !manager.isPlaying {
-                        self.startPlayAll()
-                    }
-                },
-                onPause: {
-                    self.stopPlayAll()
-                },
-                onNext: {
-                    self.playbackManager?.next()
-                },
-                onPrevious: {
-                    self.playbackManager?.previous()
-                }
-            )
-        }
-        .onChange(of: settings.playbackMode) { _, newMode in
-            // If playback is active, restart current sentence from step 0 when mode changes
-            playbackManager?.updatePlaybackMode(newMode)
-        }
+        // When individual playback starts, stop continuous playback
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            // When individual playback starts (e.g., user taps "英語を聞く" button),
-            // stop continuous playback cleanly to avoid state confusion.
-            // The audio session remains active to allow seamless transition.
-            if let manager = playbackManager, manager.isPlaying {
-                manager.stop()
-                NowPlayingInfoManager.clear()
+            if globalPlaybackManager.isPlaying {
+                globalPlaybackManager.stop()
             }
-        }
-        .onDisappear {
-            // Always stop to invalidate any pending async tasks via generation increment
-            playbackManager?.stop()
-            speechService.deactivateAudioSession()
-            NowPlayingInfoManager.clear()
-            // Remove remote command handlers to avoid leaked handlers after view disappears
-            remoteCommandManager.cleanup()
         }
     }
 
     // MARK: - Playback control
 
-    /// Initializes the playback manager on first use.
-    private func setupPlaybackManager() {
-        guard playbackManager == nil else { return }
-
-        playbackManager = ContinuousPlaybackManager(
-            playbackMode: settings.playbackMode,
-            speechHandler: { [weak speechService, settings, word] (sentence: Sentence, step: Int) in
-                guard let speechService else { return }
-
-                switch settings.playbackMode {
-                case .bilingual:
-                    switch step {
-                    case 0, 2:
-                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
-                    case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
-                    default:
-                        break
-                    }
-                case .englishOnly:
-                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
-                }
-
-                // Update Now Playing info
-                let stepLabel = settings.playbackMode.stepLabel(for: step)
-                NowPlayingInfoManager.update(
-                    title: sentence.english,
-                    artist: "\(word.word) - \(stepLabel)",
-                    album: word.meaning,
-                    playbackRate: 1.0
-                )
-            },
-            completionHandler: { [weak speechService] in
-                speechService?.deactivateAudioSession()
-                NowPlayingInfoManager.clear()
-            }
-        )
-    }
-
     /// Starts continuous playback from a specific sentence or the beginning.
     ///
     /// - Parameter sentence: The sentence to start from, or nil to start from the first sentence
     private func startPlayAll(from sentence: Sentence? = nil) {
-        guard !allSentences.isEmpty else { return }
-
-        setupPlaybackManager()
-
-        // Stop current playback first
-        speechService.stop()
+        let items = allQueueItems
+        guard !items.isEmpty else { return }
 
         // Determine start index
         let startIndex: Int
         if let sentence,
-           let idx = allSentences.firstIndex(where: { $0.id == sentence.id }) {
+           let idx = items.firstIndex(where: { $0.sentence.id == sentence.id }) {
             startIndex = idx
         } else {
             startIndex = 0
         }
 
-        Task { @MainActor in
-            playbackManager?.start(items: allSentences, startIndex: startIndex)
-        }
+        globalPlaybackManager.enqueue(items, startIndex: startIndex)
     }
-
-    /// Stops all continuous playback.
-    private func stopPlayAll() {
-        playbackManager?.stop()
-        speechService.stop()
-        speechService.deactivateAudioSession()
-        NowPlayingInfoManager.clear()
-    }
-
 }
+
 
 struct SentenceRowView: View {
     let sentence: Sentence
@@ -275,4 +170,6 @@ struct SentenceRowView: View {
             ]
         ))
     }
+    .environmentObject(SettingsManager.shared)
+    .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -115,11 +115,10 @@ struct SentenceListView: View {
         }
         .navigationTitle("例文一覧")
         .navigationBarTitleDisplayMode(.inline)
-        // When individual playback starts, stop continuous playback only if it's this view's queue
+        // When individual playback starts, always stop continuous playback
+        // to prevent stale queues from advancing via delayed completion handlers
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            if isPlayingThisViewsQueue {
-                globalPlaybackManager.stop()
-            }
+            globalPlaybackManager.stop()
         }
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentenceListView.swift
@@ -32,11 +32,16 @@ struct SentenceListView: View {
         }
     }
 
+    /// Checks if the current playback queue belongs to this view
+    private var isPlayingThisViewsQueue: Bool {
+        globalPlaybackManager.isPlayingQueue(allQueueItems)
+    }
+
     /// Returns the UUID of the currently playing sentence, if any.
     ///
     /// - Returns: The sentence ID if playback is active and index is valid, otherwise nil
     private var playingSentenceID: UUID? {
-        guard globalPlaybackManager.isPlaying,
+        guard isPlayingThisViewsQueue,
               globalPlaybackManager.currentIndex < globalPlaybackManager.queue.count else { return nil }
         return globalPlaybackManager.currentItem?.sentence.id
     }
@@ -110,9 +115,9 @@ struct SentenceListView: View {
         }
         .navigationTitle("例文一覧")
         .navigationBarTitleDisplayMode(.inline)
-        // When individual playback starts, stop continuous playback
+        // When individual playback starts, stop continuous playback only if it's this view's queue
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            if globalPlaybackManager.isPlaying {
+            if isPlayingThisViewsQueue {
                 globalPlaybackManager.stop()
             }
         }

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
@@ -4,7 +4,7 @@ struct SentencePracticeView: View {
     let sentence: Sentence
     let word: Word
 
-    @StateObject private var speechService = SpeechService()
+    private let speechService = SpeechService.shared
     @StateObject private var speechRecognizer = SpeechRecognizer()
     @State private var pronunciationResult: PronunciationResult?
     @State private var showResult = false

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
     @EnvironmentObject private var settings: SettingsManager
 
     /// The speech service for playing sample audio.
-    @StateObject private var speechService = SpeechService()
+    private let speechService = SpeechService.shared
 
     /// Local state for the OpenAI API key input field.
     @State private var apiKeyInput: String = ""

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -232,11 +232,10 @@ struct WordListView: View {
                 globalPlaybackManager.stop()
             }
         }
-        // When individual playback starts, stop continuous playback
+        // When individual playback starts, always stop continuous playback
+        // to prevent stale queues from advancing via delayed completion handlers
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            if globalPlaybackManager.isPlaying {
-                globalPlaybackManager.stop()
-            }
+            globalPlaybackManager.stop()
         }
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -111,11 +111,8 @@ struct WordListView: View {
     }
 
     /// Checks if the current playback queue belongs to this view
-    /// by comparing queue item IDs with this view's allQueueItems
     private var isPlayingThisViewsQueue: Bool {
-        let currentQueueIDs = Set(globalPlaybackManager.queue.map { $0.id })
-        let thisViewQueueIDs = Set(allQueueItems.map { $0.id })
-        return currentQueueIDs == thisViewQueueIDs
+        globalPlaybackManager.isPlayingQueue(allQueueItems)
     }
 
     var body: some View {

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -113,8 +113,8 @@ struct WordListView: View {
     /// Checks if the current playback queue belongs to this view
     /// by comparing queue item IDs with this view's allQueueItems
     private var isPlayingThisViewsQueue: Bool {
-        let currentQueueIDs = Set(globalPlaybackManager.queue.map { "\($0.word.id)-\($0.sentence.id)" })
-        let thisViewQueueIDs = Set(allQueueItems.map { "\($0.word.id)-\($0.sentence.id)" })
+        let currentQueueIDs = Set(globalPlaybackManager.queue.map { $0.id })
+        let thisViewQueueIDs = Set(allQueueItems.map { $0.id })
         return currentQueueIDs == thisViewQueueIDs
     }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import MediaPlayer
 
 // MARK: - Sort Option
 
@@ -34,14 +33,11 @@ struct WordListView: View {
 
     @AppStorage("wordSortOption") private var sortOptionRaw: String = WordSortOption.alphabeticalAZ.rawValue
 
-    @StateObject private var speechService = SpeechService()
+    private let speechService = SpeechService.shared
     @EnvironmentObject private var settings: SettingsManager
+    @EnvironmentObject private var globalPlaybackManager: GlobalPlaybackManager
 
     @State private var selection = SelectionState()
-
-    // MARK: - Continuous playback managers
-    @State private var playbackManager: ContinuousPlaybackManager<(Word, Sentence)>?
-    @State private var remoteCommandManager = RemoteCommandCenterManager()
 
     private var sortOption: WordSortOption {
         WordSortOption(rawValue: sortOptionRaw) ?? .alphabeticalAZ
@@ -100,16 +96,16 @@ struct WordListView: View {
         return result
     }
 
-    /// Flattens all words and their sentences into a single array for continuous playback.
+    /// Flattens all words and their sentences into queue items for continuous playback.
     ///
-    /// Each element is a tuple of (Word, Sentence) representing one playback unit.
+    /// Each element is a QueueItem representing one playback unit.
     /// Only includes words that have at least one sentence.
     ///
-    /// - Returns: Array of (Word, Sentence) tuples in display order
-    private var allWordSentences: [(Word, Sentence)] {
+    /// - Returns: Array of QueueItem in display order
+    private var allQueueItems: [QueueItem] {
         filteredWords.flatMap { word in
             word.sentences.map { sentence in
-                (word, sentence)
+                QueueItem(sentence: sentence, word: word)
             }
         }
     }
@@ -176,17 +172,16 @@ struct WordListView: View {
                 } else {
                     HStack {
                         // Play all words button
-                        let isPlaying = playbackManager?.isPlaying ?? false
-                        if !allWordSentences.isEmpty {
+                        if !allQueueItems.isEmpty {
                             Button {
-                                if isPlaying {
-                                    stopPlayAllWords()
+                                if globalPlaybackManager.isPlaying {
+                                    globalPlaybackManager.stop()
                                 } else {
-                                    startPlayAllWords()
+                                    globalPlaybackManager.enqueue(allQueueItems)
                                 }
                             } label: {
-                                Image(systemName: isPlaying ? "stop.fill" : "play.fill")
-                                    .foregroundColor(isPlaying ? .red : .blue)
+                                Image(systemName: globalPlaybackManager.isPlaying ? "stop.fill" : "play.fill")
+                                    .foregroundColor(globalPlaybackManager.isPlaying ? .red : .blue)
                             }
                         }
                         sortMenu
@@ -206,58 +201,24 @@ struct WordListView: View {
         // user can continue selecting from the newly filtered results.
         .onChange(of: searchText) { _, _ in
             selection.selectedIDs = []
-            if playbackManager?.isPlaying == true { stopPlayAllWords() }
+            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
         }
         .onChange(of: selectedLetter) { _, _ in
             selection.selectedIDs = []
-            if playbackManager?.isPlaying == true { stopPlayAllWords() }
+            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
         }
         .onChange(of: selectedCategory) { _, _ in
             selection.selectedIDs = []
-            if playbackManager?.isPlaying == true { stopPlayAllWords() }
+            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
         }
         .onChange(of: sortOptionRaw) { _, _ in
-            if playbackManager?.isPlaying == true { stopPlayAllWords() }
+            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
         }
-        // Continuous playback event handlers
-        .onReceive(speechService.speechFinishedPublisher) { _ in
-            guard let manager = playbackManager, manager.isPlaying else { return }
-
-            scheduleDelayedAdvance(generation: manager.playbackGeneration)
-        }
-        .onAppear {
-            setupPlaybackManager()
-
-            // Setup remote command center (callbacks already dispatched to main queue)
-            remoteCommandManager.setup(
-                onPlay: {
-                    if let manager = self.playbackManager, !manager.isPlaying {
-                        self.startPlayAllWords()
-                    }
-                },
-                onPause: {
-                    self.stopPlayAllWords()
-                },
-                onNext: {
-                    self.playbackManager?.next()
-                },
-                onPrevious: {
-                    self.playbackManager?.previous()
-                }
-            )
-        }
-        .onChange(of: settings.playbackMode) { _, newMode in
-            playbackManager?.updatePlaybackMode(newMode)
-        }
+        // When individual playback starts, stop continuous playback
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in
-            if let manager = playbackManager, manager.isPlaying {
-                manager.stop()
-                NowPlayingInfoManager.clear()
+            if globalPlaybackManager.isPlaying {
+                globalPlaybackManager.stop()
             }
-        }
-        .onDisappear {
-            stopPlayAllWords()
-            remoteCommandManager.cleanup()
         }
     }
 
@@ -375,88 +336,6 @@ struct WordListView: View {
         }
     }
 
-    // MARK: - Continuous Playback Logic
-
-    /// Initializes the playback manager on first use.
-    private func setupPlaybackManager() {
-        guard playbackManager == nil else { return }
-
-        playbackManager = ContinuousPlaybackManager(
-            playbackMode: settings.playbackMode,
-            speechHandler: { [weak speechService, settings] (item: (Word, Sentence), step: Int) in
-                guard let speechService else { return }
-
-                let (word, sentence) = item
-
-                switch settings.playbackMode {
-                case .bilingual:
-                    switch step {
-                    case 0, 2:
-                        speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
-                    case 1:
-                        speechService.speak(sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
-                    default:
-                        break
-                    }
-                case .englishOnly:
-                    speechService.speak(sentence.english, language: "en-US", isContinuousPlayback: true)
-                }
-
-                // Update Now Playing info
-                let stepLabel = settings.playbackMode.stepLabel(for: step)
-                NowPlayingInfoManager.update(
-                    title: sentence.english,
-                    artist: "\(word.word) - \(stepLabel)",
-                    album: word.meaning,
-                    playbackRate: 1.0
-                )
-            },
-            completionHandler: { [weak speechService] in
-                speechService?.deactivateAudioSession()
-                NowPlayingInfoManager.clear()
-            }
-        )
-    }
-
-    /// Starts continuous playback across all words and their sentences.
-    private func startPlayAllWords() {
-        let snapshot = allWordSentences
-        guard !snapshot.isEmpty else { return }
-
-        setupPlaybackManager()
-
-        // Stop current playback
-        speechService.stop()
-
-        Task { @MainActor in
-            playbackManager?.start(items: snapshot, startIndex: 0)
-        }
-    }
-
-    /// Stops continuous playback of all words.
-    private func stopPlayAllWords() {
-        playbackManager?.stop()
-        speechService.stop()
-        speechService.deactivateAudioSession()
-        NowPlayingInfoManager.clear()
-    }
-
-    /// Schedules a delayed task with generation-based cancellation.
-    private func scheduleDelayedAdvance(generation: Int, delay: UInt64 = 800_000_000) {
-        Task {
-            do {
-                try await Task.sleep(nanoseconds: delay)
-                await MainActor.run {
-                    guard let manager = playbackManager,
-                          manager.isValidCompletion(generation: generation) else { return }
-                    manager.advance()
-                }
-            } catch {
-                // Task cancellation is expected when view disappears or playback stops
-                // No action needed
-            }
-        }
-    }
 }
 
 // MARK: - WordRowView
@@ -522,6 +401,8 @@ struct WordRowView: View {
     NavigationStack {
         WordListView()
     }
+    .environmentObject(SettingsManager.shared)
+    .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
 }
 
 // MARK: - Badge Overlay

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -110,6 +110,14 @@ struct WordListView: View {
         }
     }
 
+    /// Checks if the current playback queue belongs to this view
+    /// by comparing queue item IDs with this view's allQueueItems
+    private var isPlayingThisViewsQueue: Bool {
+        let currentQueueIDs = Set(globalPlaybackManager.queue.map { "\($0.word.id)-\($0.sentence.id)" })
+        let thisViewQueueIDs = Set(allQueueItems.map { "\($0.word.id)-\($0.sentence.id)" })
+        return currentQueueIDs == thisViewQueueIDs
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             letterFilterBar
@@ -173,15 +181,16 @@ struct WordListView: View {
                     HStack {
                         // Play all words button
                         if !allQueueItems.isEmpty {
+                            let isPlayingOurQueue = globalPlaybackManager.isPlaying && isPlayingThisViewsQueue
                             Button {
-                                if globalPlaybackManager.isPlaying {
+                                if isPlayingOurQueue {
                                     globalPlaybackManager.stop()
                                 } else {
                                     globalPlaybackManager.enqueue(allQueueItems)
                                 }
                             } label: {
-                                Image(systemName: globalPlaybackManager.isPlaying ? "stop.fill" : "play.fill")
-                                    .foregroundColor(globalPlaybackManager.isPlaying ? .red : .blue)
+                                Image(systemName: isPlayingOurQueue ? "stop.fill" : "play.fill")
+                                    .foregroundColor(isPlayingOurQueue ? .red : .blue)
                             }
                         }
                         sortMenu
@@ -201,18 +210,30 @@ struct WordListView: View {
         // user can continue selecting from the newly filtered results.
         .onChange(of: searchText) { _, _ in
             selection.selectedIDs = []
-            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
+            // Only stop if this view's queue is currently playing
+            if globalPlaybackManager.isPlaying && isPlayingThisViewsQueue {
+                globalPlaybackManager.stop()
+            }
         }
         .onChange(of: selectedLetter) { _, _ in
             selection.selectedIDs = []
-            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
+            // Only stop if this view's queue is currently playing
+            if globalPlaybackManager.isPlaying && isPlayingThisViewsQueue {
+                globalPlaybackManager.stop()
+            }
         }
         .onChange(of: selectedCategory) { _, _ in
             selection.selectedIDs = []
-            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
+            // Only stop if this view's queue is currently playing
+            if globalPlaybackManager.isPlaying && isPlayingThisViewsQueue {
+                globalPlaybackManager.stop()
+            }
         }
         .onChange(of: sortOptionRaw) { _, _ in
-            if globalPlaybackManager.isPlaying { globalPlaybackManager.stop() }
+            // Only stop if this view's queue is currently playing
+            if globalPlaybackManager.isPlaying && isPlayingThisViewsQueue {
+                globalPlaybackManager.stop()
+            }
         }
         // When individual playback starts, stop continuous playback
         .onReceive(NotificationCenter.default.publisher(for: .speechServiceDidStartNewPlayback)) { _ in

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct WordPracticeView: View {
     let word: Word
 
-    private let speechService = SpeechService.shared
+    @ObservedObject private var speechService = SpeechService.shared
     @StateObject private var speechRecognizer = SpeechRecognizer()
     @State private var pronunciationResult: PronunciationResult?
     @State private var showResult = false

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordPracticeView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct WordPracticeView: View {
     let word: Word
 
-    @StateObject private var speechService = SpeechService()
+    private let speechService = SpeechService.shared
     @StateObject private var speechRecognizer = SpeechRecognizer()
     @State private var pronunciationResult: PronunciationResult?
     @State private var showResult = false

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -18,6 +18,11 @@ if git diff --cached --name-only | grep -qF "$PROJECT_FILE"; then
     echo "Fix with:"
     echo "  sed -i '' 's/DEVELOPMENT_TEAM = [^;]*;/DEVELOPMENT_TEAM = \"\$(DEVELOPMENT_TEAM)\";/g' $PROJECT_FILE"
     echo ""
+    echo "Note: If project.pbxproj has other legitimate changes (e.g., new files):"
+    echo "  1. Run the sed command above to revert only DEVELOPMENT_TEAM"
+    echo "  2. Stage the file: git add $PROJECT_FILE"
+    echo "  3. Commit will now succeed with other changes preserved"
+    echo ""
     echo "See CLAUDE.md for details."
     exit 1
   fi


### PR DESCRIPTION
## Summary

Implements a persistent mini-player and playback queue management system that enables continuous playback across app navigation.

### Key Features
- **Persistent mini-player** - Displays at bottom of screen during playback, persists across all tabs
- **Global playback state** - Accessible from any view in the app via environment object
- **Queue management** - Full-screen view with swipe-to-delete and queue controls
- **Seamless integration** - Works with existing continuous playback and remote controls
- **Paused state handling** - Shows current queued item even when paused for easy resume

### Implementation Details
- Created `QueueItem` model to unify playback data structure (replaces tuple types)
- Implemented `GlobalPlaybackManager` wrapping `ContinuousPlaybackManager<QueueItem>`
- Converted `SpeechService` to singleton pattern for shared access
- Added `MiniPlayerView` component with language-aware text display and playback controls
- Added `FullPlayerView` sheet for queue management with swipe-to-delete
- Migrated `WordListView` and `SentenceListView` from local to global playback
- Integrated mini-player into `ContentView` using `.safeAreaInset(edge: .bottom)`

### Architecture
```
App Level:
└── GlobalPlaybackManager (@EnvironmentObject)
    └── ContinuousPlaybackManager<QueueItem> (internal)

UI Layer:
├── MiniPlayerView (persistent, bottom inset)
└── FullPlayerView (sheet presentation)
```

## Test Plan

### Basic Playback
- [x] Start playback in WordListView → mini-player appears with current sentence
- [x] Current sentence text updates as playback progresses
- [x] Progress counter shows correct position (e.g., "2/10")

### Cross-Navigation
- [x] Start playback → switch tabs → mini-player persists
- [x] Navigate to different views → playback continues
- [x] Mini-player remains visible and functional across navigation

### Queue Management
- [x] Tap mini-player → FullPlayerView opens with full queue
- [x] Current item highlighted in queue list
- [x] Swipe to delete queue items
- [x] Remove current item → advances to next item
- [x] Clear queue → playback stops and mini-player disappears
- [x] Close FullPlayerView (閉じる) → mini-player shows current item (not "No playback")

### Remote Controls
- [x] Lock screen controls (play/pause/next/previous) work correctly
- [x] Now Playing info displays current sentence

### Individual Playback
- [x] During continuous playback, tap word/sentence button → continuous playback stops
- [x] Individual playback works normally

### Edge Cases
- [x] Pause playback → close FullPlayerView → mini-player shows paused item with play button
- [x] Clear queue → mini-player hides completely (no tab bar overlap)
- [x] Empty queue → mini-player does not appear

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide continuous playback with a persistent mini-player and expandable full-screen player, including play/pause/previous/next, queue reorder/delete, and Now Playing updates; enqueue/start playback from any item and bilingual/English-only step support.

* **Refactor**
  * Centralized playback and speech handling with a global playback manager and shared speech service; views now surface the persistent player when a queue is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->