### PR TITLE
Add client-side audio caching for VOICEVOX responses (#92)

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */; };
 		C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00013238D1234567890AB /* MiniPlayerView.swift */; };
 		C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00014238D1234567890AB /* FullPlayerView.swift */; };
+		D1A00031238D1234567890AB /* AudioCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A00021238D1234567890AB /* AudioCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -96,6 +97,7 @@
 		C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalPlaybackManager.swift; sourceTree = "<group>"; };
 		C1A00013238D1234567890AB /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
 		C1A00014238D1234567890AB /* FullPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullPlayerView.swift; sourceTree = "<group>"; };
+		D1A00021238D1234567890AB /* AudioCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 		8577C1972F4BE5AC0061F175 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				D1A00021238D1234567890AB /* AudioCache.swift */,
 				85DE1EC02F52867000A4CA59 /* KeychainService.swift */,
 				8577C18F2F4BE5AC0061F175 /* Playback */,
 				8577C1922F4BE5AC0061F175 /* OpenAIService.swift */,
@@ -303,6 +306,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D1A00031238D1234567890AB /* AudioCache.swift in Sources */,
 				A1000001238D1234567890AB /* EnglishLearnAppApp.swift in Sources */,
 				A1000002238D1234567890AB /* ContentView.swift in Sources */,
 				A1000003238D1234567890AB /* Word.swift in Sources */,

--- a/EnglishLearnApp/EnglishLearnApp/Services/AudioCache.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/AudioCache.swift
@@ -84,7 +84,7 @@ actor AudioCache {
 
         // Store on disk
         let fileURL = cacheDirectory.appendingPathComponent(key)
-        try? data.write(to: fileURL)
+        try? data.write(to: fileURL, options: .atomic)
 
         // Enforce disk cache size limit
         enforceDiskCacheLimit()

--- a/EnglishLearnApp/EnglishLearnApp/Services/AudioCache.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/AudioCache.swift
@@ -1,0 +1,152 @@
+import Foundation
+import CryptoKit
+
+/// A two-tier cache (memory + disk) for VOICEVOX audio data.
+///
+/// Memory cache provides fast access for recently played audio.
+/// Disk cache persists audio across app sessions, reducing API calls.
+actor AudioCache {
+    // MARK: - Shared Instance
+
+    static let shared = AudioCache()
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let maxMemoryCacheCount = 50
+        static let maxDiskCacheSizeBytes: UInt64 = 50 * 1024 * 1024  // 50MB
+        static let cacheDirectoryName = "VoicevoxAudioCache"
+    }
+
+    // MARK: - Properties
+
+    private let memoryCache = NSCache<NSString, NSData>()
+    private let fileManager = FileManager.default
+    private let cacheDirectory: URL
+
+    // MARK: - Initialization
+
+    private init() {
+        // Configure memory cache
+        memoryCache.countLimit = Constants.maxMemoryCacheCount
+
+        // Set up disk cache directory
+        let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        cacheDirectory = cachesDirectory.appendingPathComponent(Constants.cacheDirectoryName)
+
+        // Create directory if needed
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Public Methods
+
+    /// Retrieves cached audio data for the given text and speaker.
+    /// - Parameters:
+    ///   - text: The text that was synthesized
+    ///   - speakerID: The VOICEVOX speaker ID
+    /// - Returns: Cached audio data if available, nil otherwise
+    func get(text: String, speakerID: Int) -> Data? {
+        let key = cacheKey(text: text, speakerID: speakerID)
+
+        // Check memory cache first
+        if let data = memoryCache.object(forKey: key as NSString) {
+            return data as Data
+        }
+
+        // Fall back to disk cache
+        let fileURL = cacheDirectory.appendingPathComponent(key)
+        guard let data = try? Data(contentsOf: fileURL) else {
+            return nil
+        }
+
+        // Promote to memory cache
+        memoryCache.setObject(data as NSData, forKey: key as NSString)
+
+        // Update access time for LRU
+        try? fileManager.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: fileURL.path
+        )
+
+        return data
+    }
+
+    /// Stores audio data in both memory and disk cache.
+    /// - Parameters:
+    ///   - data: The audio data to cache
+    ///   - text: The text that was synthesized
+    ///   - speakerID: The VOICEVOX speaker ID
+    func set(_ data: Data, text: String, speakerID: Int) {
+        let key = cacheKey(text: text, speakerID: speakerID)
+
+        // Store in memory cache
+        memoryCache.setObject(data as NSData, forKey: key as NSString)
+
+        // Store on disk
+        let fileURL = cacheDirectory.appendingPathComponent(key)
+        try? data.write(to: fileURL)
+
+        // Enforce disk cache size limit
+        enforceDiskCacheLimit()
+    }
+
+    /// Clears all cached audio data from both memory and disk.
+    func clearAll() {
+        memoryCache.removeAllObjects()
+        try? fileManager.removeItem(at: cacheDirectory)
+        try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+    }
+
+    /// Returns the current disk cache size in bytes.
+    func diskCacheSize() -> UInt64 {
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.fileSizeKey]
+        ) else {
+            return 0
+        }
+
+        return files.reduce(0) { total, url in
+            let size = (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            return total + UInt64(size)
+        }
+    }
+
+    // MARK: - Private Methods
+
+    /// Generates a cache key from text and speaker ID using SHA256.
+    private func cacheKey(text: String, speakerID: Int) -> String {
+        let input = "\(text)-\(speakerID)"
+        let hash = SHA256.hash(data: Data(input.utf8))
+        return hash.compactMap { String(format: "%02x", $0) }.joined() + ".wav"
+    }
+
+    /// Removes oldest files when disk cache exceeds size limit (LRU eviction).
+    private func enforceDiskCacheLimit() {
+        guard diskCacheSize() > Constants.maxDiskCacheSizeBytes else { return }
+
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
+        ) else {
+            return
+        }
+
+        // Sort by modification date (oldest first)
+        let sortedFiles = files.sorted { url1, url2 in
+            let date1 = (try? url1.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let date2 = (try? url2.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return date1 < date2
+        }
+
+        // Remove oldest files until under limit
+        var currentSize = diskCacheSize()
+        for fileURL in sortedFiles {
+            guard currentSize > Constants.maxDiskCacheSizeBytes else { break }
+
+            let fileSize = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            try? fileManager.removeItem(at: fileURL)
+            currentSize -= UInt64(fileSize)
+        }
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -133,78 +133,97 @@ class SpeechService: NSObject, ObservableObject {
 
     /// Synthesizes speech using the VOICEVOX API and plays it via AVAudioPlayer.
     ///
-    /// This method makes two HTTP requests to the VOICEVOX server:
-    /// 1. POST /audio_query to generate query parameters
-    /// 2. POST /synthesis to synthesize audio from the query
+    /// This method first checks the audio cache for previously synthesized audio.
+    /// On cache miss, it fetches from the VOICEVOX API and caches the result.
     ///
     /// - Parameter text: The Japanese text to be spoken
     private func speakWithVoicevox(_ text: String) async {
-        let baseURL = AppConfig.voicevoxBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        guard !baseURL.isEmpty else {
-            handleVoicevoxFailure()
-            return
-        }
-
-        // Ensure API key is configured
-        let apiKey = AppConfig.voicevoxApiKey
-        guard !apiKey.isEmpty else {
-            print("VOICEVOX API key not configured in AppConfig")
-            handleVoicevoxFailure()
-            return
-        }
-
         let speakerID = SettingsManager.shared.voicevoxStyle.rawValue
+
+        // Check cache first
+        if let cachedAudio = await AudioCache.shared.get(text: text, speakerID: speakerID) {
+            playAudioData(cachedAudio)
+            return
+        }
+
+        // Cache miss - fetch from API
+        guard let audioData = await fetchVoicevoxAudio(text: text, speakerID: speakerID) else {
+            handleVoicevoxFailure()
+            return
+        }
+
+        // Cache the audio data for future playback
+        await AudioCache.shared.set(audioData, text: text, speakerID: speakerID)
+
+        playAudioData(audioData)
+    }
+
+    /// Fetches audio data from VOICEVOX API.
+    ///
+    /// Makes two HTTP requests to the VOICEVOX server:
+    /// 1. POST /audio_query to generate query parameters
+    /// 2. POST /synthesis to synthesize audio from the query
+    ///
+    /// - Parameters:
+    ///   - text: The text to synthesize
+    ///   - speakerID: The VOICEVOX speaker ID
+    /// - Returns: Audio data on success, nil on failure
+    private func fetchVoicevoxAudio(text: String, speakerID: Int) async -> Data? {
+        let baseURL = AppConfig.voicevoxBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard !baseURL.isEmpty else { return nil }
+        guard !AppConfig.voicevoxApiKey.isEmpty else {
+            print("VOICEVOX API key not configured in AppConfig")
+            return nil
+        }
 
         guard let encodedText = text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let queryURL = URL(string: "\(baseURL)/audio_query?text=\(encodedText)&speaker=\(speakerID)"),
               let synthURL = URL(string: "\(baseURL)/synthesis?speaker=\(speakerID)") else {
-            handleVoicevoxFailure()
-            return
+            return nil
         }
 
         do {
             let (queryData, queryResponse) = try await performPOSTRequest(to: queryURL)
             guard isSuccessfulResponse(queryResponse) else {
                 print("VOICEVOX audio_query failed: \((queryResponse as? HTTPURLResponse)?.statusCode ?? -1)")
-                handleVoicevoxFailure()
-                return
+                return nil
             }
 
             let (audioData, synthResponse) = try await performPOSTRequest(to: synthURL, body: queryData, contentType: "application/json")
             guard isSuccessfulResponse(synthResponse) else {
                 print("VOICEVOX synthesis failed: \((synthResponse as? HTTPURLResponse)?.statusCode ?? -1)")
-                handleVoicevoxFailure()
-                return
+                return nil
             }
 
-            // Validate audio data before creating AVAudioPlayer to avoid buffer warnings
             guard !audioData.isEmpty else {
                 print("VOICEVOX returned empty audio data")
-                handleVoicevoxFailure()
-                return
+                return nil
             }
 
-            await MainActor.run {
-                do {
-                    audioPlayer = try AVAudioPlayer(data: audioData)
-                    audioPlayer?.delegate = self
-
-                    // Enable background playback and ensure audio session is active
-                    // This is critical for VOICEVOX playback to continue in background
-                    let audioSession = AVAudioSession.sharedInstance()
-                    try audioSession.setCategory(.playback, mode: .default)
-                    try audioSession.setActive(true)
-
-                    audioPlayer?.play()
-                } catch {
-                    print("AVAudioPlayer error: \(error.localizedDescription)")
-                    isSpeaking = false
-                    speechFinishedPublisher.send()
-                }
-            }
+            return audioData
         } catch {
             print("VOICEVOX error: \(error.localizedDescription)")
-            handleVoicevoxFailure()
+            return nil
+        }
+    }
+
+    /// Plays audio data using AVAudioPlayer.
+    /// - Parameter audioData: The audio data to play
+    private func playAudioData(_ audioData: Data) {
+        do {
+            audioPlayer = try AVAudioPlayer(data: audioData)
+            audioPlayer?.delegate = self
+
+            // Enable background playback and ensure audio session is active
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .default)
+            try audioSession.setActive(true)
+
+            audioPlayer?.play()
+        } catch {
+            print("AVAudioPlayer error: \(error.localizedDescription)")
+            isSpeaking = false
+            speechFinishedPublisher.send()
         }
     }
 


### PR DESCRIPTION
## Summary
- Implement two-tier caching (memory + disk) for VOICEVOX audio data
- Add `AudioCache` actor with SHA256-based cache keys
- Refactor `SpeechService` to check cache before API calls
- Second playback of the same sentence is now instant (no network request)

## Changes
| File | Description |
|------|-------------|
| `AudioCache.swift` | New: Memory (50 entries) + Disk (50MB) cache with LRU eviction |
| `SpeechService.swift` | Use cache, extract `fetchVoicevoxAudio()` and `playAudioData()` |

## Cache Behavior
```
speakWithVoicevox(text)
  ├→ Cache hit  → Instant playback
  └→ Cache miss → API call → Cache → Playback
```

## Test plan
- [ ] Play a VOICEVOX sentence for the first time (API call occurs)
- [ ] Play the same sentence again (instant, no network delay)
- [ ] Restart app and play cached sentence (still instant from disk cache)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented an audio caching system for voice playback to make repeated audio play faster and reduce external API usage.
  * Playback now prefers cached audio and falls back to fetching when needed, then caches results for future use.
* **Improvements**
  * Better playback reliability and centralized audio handling with automatic disk cache size management and eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->