### PR TITLE
Fix native TTS not playing audio on individual playback (#99)

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SpeechService.swift
@@ -89,7 +89,16 @@ class SpeechService: NSObject, ObservableObject {
     ///   - language: The language code (default: "en-US")
     ///   - isContinuousPlayback: Set to true when called from continuous playback to prevent stopping the session (default: false)
     func speak(_ text: String, language: String = "en-US", isContinuousPlayback: Bool = false) {
-        stop()
+        // Only stop if actually playing to avoid putting synthesizer in unstable state
+        if synthesizer.isSpeaking || audioPlayer?.isPlaying == true {
+            stop()
+        } else {
+            // Reset state without calling stopSpeaking
+            currentUtterance = nil
+            audioPlayer = nil
+            isSpeaking = false
+            speakingLanguage = nil
+        }
 
         // Only notify when starting individual playback (not continuous playback)
         // This allows continuous playback views to stop cleanly when user taps individual play buttons
@@ -128,7 +137,16 @@ class SpeechService: NSObject, ObservableObject {
         } catch {
             print("Failed to configure audio session for native TTS: \(error.localizedDescription)")
         }
-        synthesizer.speak(utterance)
+
+        // Small delay to allow audio session to fully activate before speaking
+        // This fixes an issue where speak() fails silently on first call
+        if !isContinuousPlayback {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.synthesizer.speak(utterance)
+            }
+        } else {
+            synthesizer.speak(utterance)
+        }
     }
 
     /// Synthesizes speech using the VOICEVOX API and plays it via AVAudioPlayer.


### PR DESCRIPTION
## Summary
- Fix AVSpeechSynthesizer failing silently on individual word/sentence playback
- Add 50ms delay before `speak()` to allow audio session to fully activate
- Skip `stopSpeaking()` when synthesizer is idle to avoid unstable state

## Root Cause
`AVSpeechSynthesizer.speak()` fails silently when called immediately after audio session activation. The session needs a brief moment to fully initialize before accepting speech requests.

## Changes
| File | Description |
|------|-------------|
| `SpeechService.swift` | Add delay for individual playback, conditional stop() |

## Test plan
- [x] Individual word playback (English default/female/male)
- [x] Individual word playback (Japanese default)
- [x] Continuous playback (en → ja → en)
- [x] VOICEVOX playback (unaffected)

## Notes
The `AVAudioBuffer` and `IPCAUClient` warnings in console are known iOS 17+ framework bugs and do not affect functionality (documented in SpeechService.swift comments).

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech playback reliability by optimizing audio session activation for text-to-speech synthesis.
  * Enhanced handling of concurrent speech requests during continuous playback mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->