### PR TITLE
Add configurable delay between sentences in continuous playback

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -332,9 +332,10 @@ final class GlobalPlaybackManager: ObservableObject {
         // Capture generation for validation
         let generation = manager.playbackGeneration
 
-        // Add delay before advancing (0.8 seconds)
+        // Add configurable delay before advancing
+        let delayNanoseconds = UInt64(settings.sentenceDelaySeconds * 1_000_000_000)
         Task {
-            try? await Task.sleep(nanoseconds: 800_000_000)
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
             await MainActor.run {
                 guard manager.isValidCompletion(generation: generation) else { return }
                 manager.advance()

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -94,8 +94,14 @@ class SettingsManager: ObservableObject {
     /// The delay in seconds between sentences during continuous playback.
     ///
     /// Range: 0.5 - 3.0 seconds. Default: 1.5 seconds.
+    /// Values outside this range are clamped automatically.
     @Published var sentenceDelaySeconds: Double {
         didSet {
+            let clamped = min(max(sentenceDelaySeconds, 0.5), 3.0)
+            if sentenceDelaySeconds != clamped {
+                sentenceDelaySeconds = clamped
+                return
+            }
             UserDefaults.standard.set(sentenceDelaySeconds, forKey: "sentenceDelaySeconds")
         }
     }

--- a/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/SettingsManager.swift
@@ -91,6 +91,15 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    /// The delay in seconds between sentences during continuous playback.
+    ///
+    /// Range: 0.5 - 3.0 seconds. Default: 1.5 seconds.
+    @Published var sentenceDelaySeconds: Double {
+        didSet {
+            UserDefaults.standard.set(sentenceDelaySeconds, forKey: "sentenceDelaySeconds")
+        }
+    }
+
     // MARK: - Computed Properties
 
     /// All presets: built-ins (with any user edits applied) first, then custom.
@@ -273,6 +282,14 @@ class SettingsManager: ObservableObject {
             self.playbackMode = mode
         } else {
             self.playbackMode = .bilingual
+        }
+
+        // Load sentence delay (default: 1.5 seconds)
+        let savedDelay = UserDefaults.standard.double(forKey: "sentenceDelaySeconds")
+        if savedDelay > 0 {
+            self.sentenceDelaySeconds = min(max(savedDelay, 0.5), 3.0)
+        } else {
+            self.sentenceDelaySeconds = 1.5
         }
 
         // Load custom presets

--- a/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SentencePracticeView.swift
@@ -127,25 +127,32 @@ struct SentencePracticeView: View {
         .navigationTitle(word.word)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
+            // Capture settings on main actor before entering Task
+            let shouldPrefetchEnglish = settings.englishVoiceGender == .zundamon
+            let shouldPrefetchJapanese = settings.japaneseVoiceGender == .zundamon
+            let japaneseSpeakerID = settings.voicevoxStyle.rawValue
+            let englishText = sentence.english
+            let japaneseText = sentence.japanese
+
             prefetchTask = Task {
                 // Prefetch both English and Japanese in parallel (if using VOICEVOX)
-                async let englishPrefetch = {
-                    if settings.englishVoiceGender == .zundamon {
+                async let englishPrefetch: Void = {
+                    if shouldPrefetchEnglish {
                         await PrefetchService.shared.prefetch(
-                            text: sentence.english,
+                            text: englishText,
                             speakerID: Constants.englishSpeakerID
                         )
                     }
                 }()
-                async let japanesePrefetch = {
-                    if settings.japaneseVoiceGender == .zundamon {
+                async let japanesePrefetch: Void = {
+                    if shouldPrefetchJapanese {
                         await PrefetchService.shared.prefetch(
-                            text: sentence.japanese,
-                            speakerID: settings.voicevoxStyle.rawValue
+                            text: japaneseText,
+                            speakerID: japaneseSpeakerID
                         )
                     }
                 }()
-                await (englishPrefetch, japanesePrefetch)
+                _ = await (englishPrefetch, japanesePrefetch)
             }
         }
         .onDisappear {

--- a/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/SettingsView.swift
@@ -79,6 +79,20 @@ struct SettingsView: View {
                     .pickerStyle(.segmented)
 
                     VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("例文間の間隔")
+                            Spacer()
+                            Text(String(format: "%.1f秒", settings.sentenceDelaySeconds))
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(
+                            value: $settings.sentenceDelaySeconds,
+                            in: 0.5...3.0,
+                            step: 0.5
+                        )
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
                         Text("連続再生時の音声パターンを選択できます")
                             .font(.body)
                         Text("バイリンガル: 英語→日本語→英語の順で再生")


### PR DESCRIPTION
## Summary

- Add `sentenceDelaySeconds` setting to allow users to configure the pause between sentences during continuous playback
- Default value changed from 0.8s to 1.5s (approximately "one breath")
- Users can adjust from 0.5s to 3.0s via slider in Settings > Continuous Playback section
- Fix Swift 6 concurrency warnings in SentencePracticeView

## Test plan

- [x] Open Settings > 連続再生設定
- [x] Verify slider shows "例文間の間隔" with current value (default: 1.5秒)
- [x] Adjust slider and verify value updates (0.5秒 to 3.0秒 in 0.5s increments)
- [ ] Start continuous playback and verify delay between sentences matches setting
- [ ] Close and reopen app to verify setting persists

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable sentence delay for playback with a settings slider (0.5–3.0s, default 1.5s) to adjust the pause between sentences.

* **Improvements**
  * Improved prefetch coordination during practice to reduce timing/race issues and provide smoother playback transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->