### PR TITLE
feat: Phase 0 PoC as React pages — CORS, Web Speech API, IndexedDB, VOICEVOX

### DIFF
--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -154,12 +154,29 @@ export class VoicevoxStack extends cdk.Stack {
     });
 
     // ----------------------------------------------------------------
-    // API Gateway: HTTP API (CORS disabled for native iOS app)
+    // API Gateway: HTTP API
+    // CORS is required for the Web SPA (browser fetch).
+    // iOS native app is unaffected by CORS headers.
+    // poc: wildcard origin for PoC validation
+    // dev/pro: restrict to the deployed CloudFront domain once known
     // ----------------------------------------------------------------
+    const corsAllowOrigins = stackEnv === 'poc'
+      ? ['*']
+      : [`https://voicevox-${stackEnv}.example.com`]; // Replace with actual CloudFront domain
+
     const httpApi = new apigatewayv2.HttpApi(this, 'VoicevoxHttpApi', {
       apiName: `voicevox-api-${stackEnv}`,
       description: `VOICEVOX TTS API (${stackEnv})`,
-      // CORS removed: native iOS app does not require CORS
+      corsPreflight: {
+        allowOrigins: corsAllowOrigins,
+        allowMethods: [
+          apigatewayv2.CorsHttpMethod.POST,
+          apigatewayv2.CorsHttpMethod.GET,
+          apigatewayv2.CorsHttpMethod.OPTIONS,
+        ],
+        allowHeaders: ['Content-Type', 'x-api-key'],
+        maxAge: cdk.Duration.days(1),
+      },
     });
 
     // Apply per-environment throttling to the $default stage

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,6 @@
 VITE_APP_VERSION=0.1.0
 VITE_APP_ENV=poc
+
+# Phase 0 PoC — VOICEVOX Lambda (poc environment)
+VITE_VOICEVOX_ENDPOINT_POC=https://xxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com
+VITE_VOICEVOX_API_KEY_POC=your-api-key-here

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+.vite
 .env
 .env.local
 playwright-report

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import ArchivePage from '@/pages/ArchivePage'
 import AddPage from '@/pages/AddPage'
 import TrashPage from '@/pages/TrashPage'
 import SettingsPage from '@/pages/SettingsPage'
+import PocPage from '@/pages/PocPage'
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
         <Route path="/trash" element={<TrashPage />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Route>
+      <Route path="/poc" element={<PocPage />} />
     </Routes>
   )
 }

--- a/web/src/pages/PocPage.tsx
+++ b/web/src/pages/PocPage.tsx
@@ -1,20 +1,11 @@
 import { useState, useCallback } from 'react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import WebSpeechTab from './poc/WebSpeechTab'
 import IndexedDbTab from './poc/IndexedDbTab'
 import VoicevoxTab from './poc/VoicevoxTab'
 import SummaryTab from './poc/SummaryTab'
 
-const TABS = [
-  { id: 'speech', label: '1. Web Speech API' },
-  { id: 'idb', label: '2. IndexedDB' },
-  { id: 'voicevox', label: '3. VOICEVOX / CORS' },
-  { id: 'summary', label: '4. Summary' },
-] as const
-
-type TabId = (typeof TABS)[number]['id']
-
 export default function PocPage() {
-  const [active, setActive] = useState<TabId>('speech')
   const [results, setResults] = useState<Record<string, boolean>>({})
 
   const onResult = useCallback((key: string, value: boolean) => {
@@ -22,36 +13,36 @@ export default function PocPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="bg-blue-600 text-white px-6 py-4">
+    <div className="min-h-screen bg-[var(--ios-grouped-bg)]">
+      <header className="bg-[var(--ios-blue)] text-white px-6 py-4">
         <h1 className="text-lg font-semibold">EnglishLearnApp Web — Phase 0 PoC</h1>
-        <p className="text-sm text-blue-200 mt-0.5">
+        <p className="text-sm text-white/70 mt-0.5">
           Validates: Web Speech API · IndexedDB · VOICEVOX CORS
         </p>
       </header>
 
-      <nav className="bg-white border-b border-blue-200 flex">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActive(tab.id)}
-            className={`flex-1 py-3 text-sm font-medium border-b-2 transition-colors ${
-              active === tab.id
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </nav>
-
-      <main className="max-w-2xl mx-auto p-4">
-        {active === 'speech' && <WebSpeechTab onResult={onResult} />}
-        {active === 'idb' && <IndexedDbTab onResult={onResult} />}
-        {active === 'voicevox' && <VoicevoxTab onResult={onResult} />}
-        {active === 'summary' && <SummaryTab results={results} />}
-      </main>
+      <div className="max-w-2xl mx-auto px-4 py-4">
+        <Tabs defaultValue="speech">
+          <TabsList className="w-full grid grid-cols-4 mb-4">
+            <TabsTrigger value="speech">1. Speech</TabsTrigger>
+            <TabsTrigger value="idb">2. IDB</TabsTrigger>
+            <TabsTrigger value="voicevox">3. VOICEVOX</TabsTrigger>
+            <TabsTrigger value="summary">4. Summary</TabsTrigger>
+          </TabsList>
+          <TabsContent value="speech">
+            <WebSpeechTab onResult={onResult} />
+          </TabsContent>
+          <TabsContent value="idb">
+            <IndexedDbTab onResult={onResult} />
+          </TabsContent>
+          <TabsContent value="voicevox">
+            <VoicevoxTab onResult={onResult} />
+          </TabsContent>
+          <TabsContent value="summary">
+            <SummaryTab results={results} />
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/PocPage.tsx
+++ b/web/src/pages/PocPage.tsx
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react'
+import WebSpeechTab from './poc/WebSpeechTab'
+import IndexedDbTab from './poc/IndexedDbTab'
+import VoicevoxTab from './poc/VoicevoxTab'
+import SummaryTab from './poc/SummaryTab'
+
+const TABS = [
+  { id: 'speech', label: '1. Web Speech API' },
+  { id: 'idb', label: '2. IndexedDB' },
+  { id: 'voicevox', label: '3. VOICEVOX / CORS' },
+  { id: 'summary', label: '4. Summary' },
+] as const
+
+type TabId = (typeof TABS)[number]['id']
+
+export default function PocPage() {
+  const [active, setActive] = useState<TabId>('speech')
+  const [results, setResults] = useState<Record<string, boolean>>({})
+
+  const onResult = useCallback((key: string, value: boolean) => {
+    setResults((prev) => ({ ...prev, [key]: value }))
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <header className="bg-blue-600 text-white px-6 py-4">
+        <h1 className="text-lg font-semibold">EnglishLearnApp Web — Phase 0 PoC</h1>
+        <p className="text-sm text-blue-200 mt-0.5">
+          Validates: Web Speech API · IndexedDB · VOICEVOX CORS
+        </p>
+      </header>
+
+      <nav className="bg-white border-b border-blue-200 flex">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActive(tab.id)}
+            className={`flex-1 py-3 text-sm font-medium border-b-2 transition-colors ${
+              active === tab.id
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      <main className="max-w-2xl mx-auto p-4">
+        {active === 'speech' && <WebSpeechTab onResult={onResult} />}
+        {active === 'idb' && <IndexedDbTab onResult={onResult} />}
+        {active === 'voicevox' && <VoicevoxTab onResult={onResult} />}
+        {active === 'summary' && <SummaryTab results={results} />}
+      </main>
+    </div>
+  )
+}

--- a/web/src/pages/poc/IndexedDbTab.tsx
+++ b/web/src/pages/poc/IndexedDbTab.tsx
@@ -1,6 +1,22 @@
 import { useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
 
 type ResultState = { text: string; type: 'ok' | 'err' | 'warn' | '' }
+
+const resultStyle: Record<string, string> = {
+  ok: 'bg-green-50 text-green-800',
+  err: 'bg-red-50 text-red-800',
+  warn: 'bg-yellow-50 text-yellow-800',
+  '': 'bg-muted text-muted-foreground',
+}
+
+function Result({ state }: { state: ResultState }) {
+  return (
+    <pre className={`text-xs px-3 py-2 rounded-lg whitespace-pre-wrap break-all mt-2 ${resultStyle[state.type]}`}>
+      {state.text}
+    </pre>
+  )
+}
 
 export default function IndexedDbTab({
   onResult,
@@ -217,75 +233,41 @@ export default function IndexedDbTab({
     onResult('idb_purge', true)
   }
 
-  const resultStyle: Record<string, string> = {
-    ok: 'bg-green-50 text-green-800',
-    err: 'bg-red-50 text-red-800',
-    warn: 'bg-yellow-50 text-yellow-800',
-    '': 'bg-gray-50 text-gray-600',
-  }
-
-  function Result({ state }: { state: ResultState }) {
-    return (
-      <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap break-all mt-2 ${resultStyle[state.type]}`}>
-        {state.text}
-      </pre>
-    )
-  }
-
-  function Btn({ onClick, label, danger }: { onClick: () => void; label: string; danger?: boolean }) {
-    return (
-      <button
-        onClick={onClick}
-        className={`px-3 py-1.5 rounded text-sm font-medium ${danger ? 'bg-red-500 text-white' : 'bg-gray-200 text-gray-800'}`}
-      >
-        {label}
-      </button>
-    )
-  }
-
   return (
-    <div className="space-y-4">
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+    <div className="space-y-3">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Database Initialization</h3>
         <div className="flex gap-2">
-          <button onClick={initDB} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
-            Open / Init DB
-          </button>
-          <Btn onClick={deleteDB} label="Delete DB" danger />
+          <Button size="sm" onClick={initDB} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">Open / Init DB</Button>
+          <Button size="sm" variant="destructive" onClick={deleteDB}>Delete DB</Button>
         </div>
         <Result state={initResult} />
       </div>
 
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Word Store — CRUD</h3>
         <div className="flex flex-wrap gap-2">
-          <button onClick={saveWord} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
-            Save sample word
-          </button>
-          <Btn onClick={getAllWords} label="Get all words" />
-          <Btn onClick={filterActive} label="Filter status=active" />
-          <Btn onClick={clearWords} label="Clear store" danger />
+          <Button size="sm" onClick={saveWord} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">Save sample word</Button>
+          <Button size="sm" variant="outline" onClick={getAllWords}>Get all words</Button>
+          <Button size="sm" variant="outline" onClick={filterActive}>Filter status=active</Button>
+          <Button size="sm" variant="destructive" onClick={clearWords}>Clear store</Button>
         </div>
         <Result state={wordResult} />
       </div>
 
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Audio Cache Store — Blob Storage</h3>
-        <p className="text-xs text-gray-500">Stores a 100 KB simulated WAV Blob.</p>
+        <p className="text-xs text-muted-foreground">Stores a 100 KB simulated WAV Blob.</p>
         <div className="flex flex-wrap gap-2">
-          <button onClick={saveBlob} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
-            Store 100 KB Blob
-          </button>
-          <Btn onClick={getBlob} label="Retrieve Blob" />
+          <Button size="sm" onClick={saveBlob} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">Store 100 KB Blob</Button>
+          <Button size="sm" variant="outline" onClick={getBlob}>Retrieve Blob</Button>
         </div>
         <Result state={blobResult} />
       </div>
 
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Soft-delete Auto-purge (10-day)</h3>
-        <button onClick={runPurge} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
-          Run purge test
-        </button>
+        <Button size="sm" onClick={runPurge} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">Run purge test</Button>
         <Result state={purgeResult} />
       </div>
     </div>

--- a/web/src/pages/poc/IndexedDbTab.tsx
+++ b/web/src/pages/poc/IndexedDbTab.tsx
@@ -1,0 +1,293 @@
+import { useRef, useState } from 'react'
+
+type ResultState = { text: string; type: 'ok' | 'err' | 'warn' | '' }
+
+export default function IndexedDbTab({
+  onResult,
+}: {
+  onResult: (key: string, value: boolean) => void
+}) {
+  const dbRef = useRef<IDBDatabase | null>(null)
+  const [initResult, setInitResult] = useState<ResultState>({ text: '—', type: '' })
+  const [wordResult, setWordResult] = useState<ResultState>({ text: '—', type: '' })
+  const [blobResult, setBlobResult] = useState<ResultState>({ text: '—', type: '' })
+  const [purgeResult, setPurgeResult] = useState<ResultState>({ text: '—', type: '' })
+
+  function requireDB(): IDBDatabase | null {
+    if (!dbRef.current) {
+      alert('Click "Open / Initialize DB" first')
+      return null
+    }
+    return dbRef.current
+  }
+
+  async function initDB() {
+    try {
+      const req = indexedDB.open('EnglishLearnDB', 1)
+      req.onupgradeneeded = (e) => {
+        const d = (e.target as IDBOpenDBRequest).result
+
+        const words = d.createObjectStore('words', { keyPath: 'id' })
+        words.createIndex('status', 'status')
+        words.createIndex('created_at', 'created_at')
+        words.createIndex('word', 'word')
+
+        const sentences = d.createObjectStore('sentences', { keyPath: 'id' })
+        sentences.createIndex('word_id', 'word_id')
+
+        const audioCache = d.createObjectStore('audio_cache', { keyPath: 'id' })
+        audioCache.createIndex('created_at', 'created_at')
+        audioCache.createIndex('last_accessed_at', 'last_accessed_at')
+      }
+      const db = await new Promise<IDBDatabase>((res, rej) => {
+        req.onsuccess = () => res(req.result)
+        req.onerror = () => rej(req.error)
+      })
+      dbRef.current = db
+      const stores = Array.from(db.objectStoreNames).join(', ')
+      setInitResult({ text: `✓ EnglishLearnDB v${db.version}\nStores: ${stores}`, type: 'ok' })
+      onResult('idb_init', true)
+    } catch (err) {
+      setInitResult({ text: `✗ ${err}`, type: 'err' })
+      onResult('idb_init', false)
+    }
+  }
+
+  async function deleteDB() {
+    dbRef.current?.close()
+    dbRef.current = null
+    await new Promise<void>((res, rej) => {
+      const req = indexedDB.deleteDatabase('EnglishLearnDB')
+      req.onsuccess = () => res()
+      req.onerror = () => rej(req.error)
+    })
+    setInitResult({ text: '✓ Database deleted', type: 'ok' })
+    onResult('idb_init', false)
+  }
+
+  async function saveWord() {
+    const db = requireDB()
+    if (!db) return
+    const word = {
+      id: crypto.randomUUID(),
+      word: 'validate',
+      meaning: '検証する',
+      phonetic: 'ˈvæl.ɪ.deɪt',
+      status: 'active',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      deleted_at: null,
+      archived_at: null,
+    }
+    const tx = db.transaction('words', 'readwrite')
+    await new Promise<void>((res, rej) => {
+      const req = tx.objectStore('words').add(word)
+      req.onsuccess = () => res()
+      req.onerror = () => rej(req.error)
+    })
+    setWordResult({ text: `✓ Saved:\n${JSON.stringify(word, null, 2)}`, type: 'ok' })
+  }
+
+  async function getAllWords() {
+    const db = requireDB()
+    if (!db) return
+    const tx = db.transaction('words', 'readonly')
+    const words = await new Promise<object[]>((res, rej) => {
+      const req = tx.objectStore('words').getAll()
+      req.onsuccess = () => res(req.result as object[])
+      req.onerror = () => rej(req.error)
+    })
+    setWordResult({ text: `✓ ${words.length} word(s):\n${JSON.stringify(words, null, 2)}`, type: 'ok' })
+  }
+
+  async function filterActive() {
+    const db = requireDB()
+    if (!db) return
+    const tx = db.transaction('words', 'readonly')
+    const words = await new Promise<object[]>((res, rej) => {
+      const req = tx.objectStore('words').index('status').getAll('active')
+      req.onsuccess = () => res(req.result as object[])
+      req.onerror = () => rej(req.error)
+    })
+    setWordResult({ text: `✓ ${words.length} active word(s):\n${JSON.stringify(words, null, 2)}`, type: 'ok' })
+  }
+
+  async function clearWords() {
+    const db = requireDB()
+    if (!db) return
+    const tx = db.transaction('words', 'readwrite')
+    await new Promise<void>((res, rej) => {
+      const req = tx.objectStore('words').clear()
+      req.onsuccess = () => res()
+      req.onerror = () => rej(req.error)
+    })
+    setWordResult({ text: '✓ words store cleared', type: 'ok' })
+  }
+
+  async function saveBlob() {
+    const db = requireDB()
+    if (!db) return
+    const bytes = new Uint8Array(100 * 1024)
+    crypto.getRandomValues(bytes)
+    const blob = new Blob([bytes], { type: 'audio/wav' })
+    const record = {
+      id: 'test-audio-key-001',
+      text: 'こんにちは',
+      speaker_id: 3,
+      audio_data: blob,
+      size_bytes: blob.size,
+      created_at: new Date().toISOString(),
+      last_accessed_at: new Date().toISOString(),
+    }
+    const tx = db.transaction('audio_cache', 'readwrite')
+    await new Promise<void>((res, rej) => {
+      const req = tx.objectStore('audio_cache').put(record)
+      req.onsuccess = () => res()
+      req.onerror = () => rej(req.error)
+    })
+    setBlobResult({
+      text: `✓ Stored 100 KB Blob\nKey: ${record.id}\nSize: ${(blob.size / 1024).toFixed(1)} KB`,
+      type: 'ok',
+    })
+    onResult('idb_blob', true)
+  }
+
+  async function getBlob() {
+    const db = requireDB()
+    if (!db) return
+    const tx = db.transaction('audio_cache', 'readonly')
+    const record = await new Promise<Record<string, unknown> | undefined>((res, rej) => {
+      const req = tx.objectStore('audio_cache').get('test-audio-key-001')
+      req.onsuccess = () => res(req.result as Record<string, unknown> | undefined)
+      req.onerror = () => rej(req.error)
+    })
+    if (!record) {
+      setBlobResult({ text: '⚠ No cache found. Click "Store Blob" first.', type: 'warn' })
+      return
+    }
+    setBlobResult({
+      text: `✓ Retrieved Blob\nKey: ${record.id}\nSize: ${((record.size_bytes as number) / 1024).toFixed(1)} KB\nBlob valid: ${record.audio_data instanceof Blob}`,
+      type: 'ok',
+    })
+  }
+
+  async function runPurge() {
+    const db = requireDB()
+    if (!db) return
+    const oldDate = new Date(Date.now() - 11 * 24 * 60 * 60 * 1000).toISOString()
+    const word = {
+      id: `purge-test-${Date.now()}`,
+      word: 'obsolete',
+      meaning: '廃れた',
+      phonetic: '',
+      status: 'deleted',
+      created_at: oldDate,
+      updated_at: oldDate,
+      deleted_at: oldDate,
+      archived_at: null,
+    }
+    const tx1 = db.transaction('words', 'readwrite')
+    await new Promise<void>((res, rej) => {
+      const req = tx1.objectStore('words').put(word)
+      req.onsuccess = () => res()
+      req.onerror = () => rej(req.error)
+    })
+
+    const threshold = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString()
+    const tx2 = db.transaction('words', 'readwrite')
+    let purged = 0
+    await new Promise<void>((res, rej) => {
+      const req = tx2.objectStore('words').index('status').openCursor('deleted')
+      req.onsuccess = (e) => {
+        const cursor = (e.target as IDBRequest<IDBCursorWithValue>).result
+        if (!cursor) { res(); return }
+        const val = cursor.value as { deleted_at: string | null }
+        if (val.deleted_at && val.deleted_at < threshold) {
+          cursor.delete()
+          purged++
+        }
+        cursor.continue()
+      }
+      req.onerror = () => rej(req.error)
+    })
+    setPurgeResult({
+      text: `✓ Purge complete: ${purged} record(s) deleted (deleted_at > 10 days)`,
+      type: 'ok',
+    })
+    onResult('idb_purge', true)
+  }
+
+  const resultStyle: Record<string, string> = {
+    ok: 'bg-green-50 text-green-800',
+    err: 'bg-red-50 text-red-800',
+    warn: 'bg-yellow-50 text-yellow-800',
+    '': 'bg-gray-50 text-gray-600',
+  }
+
+  function Result({ state }: { state: ResultState }) {
+    return (
+      <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap break-all mt-2 ${resultStyle[state.type]}`}>
+        {state.text}
+      </pre>
+    )
+  }
+
+  function Btn({ onClick, label, danger }: { onClick: () => void; label: string; danger?: boolean }) {
+    return (
+      <button
+        onClick={onClick}
+        className={`px-3 py-1.5 rounded text-sm font-medium ${danger ? 'bg-red-500 text-white' : 'bg-gray-200 text-gray-800'}`}
+      >
+        {label}
+      </button>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Database Initialization</h3>
+        <div className="flex gap-2">
+          <button onClick={initDB} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+            Open / Init DB
+          </button>
+          <Btn onClick={deleteDB} label="Delete DB" danger />
+        </div>
+        <Result state={initResult} />
+      </div>
+
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Word Store — CRUD</h3>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={saveWord} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+            Save sample word
+          </button>
+          <Btn onClick={getAllWords} label="Get all words" />
+          <Btn onClick={filterActive} label="Filter status=active" />
+          <Btn onClick={clearWords} label="Clear store" danger />
+        </div>
+        <Result state={wordResult} />
+      </div>
+
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Audio Cache Store — Blob Storage</h3>
+        <p className="text-xs text-gray-500">Stores a 100 KB simulated WAV Blob.</p>
+        <div className="flex flex-wrap gap-2">
+          <button onClick={saveBlob} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+            Store 100 KB Blob
+          </button>
+          <Btn onClick={getBlob} label="Retrieve Blob" />
+        </div>
+        <Result state={blobResult} />
+      </div>
+
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Soft-delete Auto-purge (10-day)</h3>
+        <button onClick={runPurge} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+          Run purge test
+        </button>
+        <Result state={purgeResult} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/poc/SummaryTab.tsx
+++ b/web/src/pages/poc/SummaryTab.tsx
@@ -1,3 +1,5 @@
+import { Badge } from '@/components/ui/badge'
+
 type Results = Record<string, boolean>
 
 const ITEMS: { key: string; label: string; note: string }[] = [
@@ -15,19 +17,19 @@ export default function SummaryTab({ results }: { results: Results }) {
   const passed = ITEMS.filter((i) => results[i.key] === true).length
 
   return (
-    <div className="space-y-4">
-      <div className="bg-white rounded-lg p-4 shadow-sm">
+    <div className="space-y-3">
+      <div className="bg-white rounded-2xl p-4">
         <div className="flex items-center justify-between mb-3">
           <h3 className="font-semibold text-sm">Validation Checklist</h3>
           {allTested && (
-            <span className="text-xs font-semibold text-blue-600">
+            <span className="text-xs font-semibold text-[var(--ios-blue)]">
               {passed} / {ITEMS.length} passed
             </span>
           )}
         </div>
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b text-left text-xs text-gray-500">
+            <tr className="border-b text-left text-xs text-muted-foreground">
               <th className="pb-2 font-medium">Item</th>
               <th className="pb-2 font-medium text-center">Status</th>
               <th className="pb-2 font-medium">Notes</th>
@@ -38,21 +40,17 @@ export default function SummaryTab({ results }: { results: Results }) {
               const val = results[key]
               const badge =
                 val === undefined ? (
-                  <span className="text-gray-400 text-xs">Not tested</span>
+                  <span className="text-muted-foreground text-xs">Not tested</span>
                 ) : val ? (
-                  <span className="px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs font-semibold">
-                    ✓ Pass
-                  </span>
+                  <Badge className="bg-green-100 text-green-700 hover:bg-green-100 text-xs">✓ Pass</Badge>
                 ) : (
-                  <span className="px-2 py-0.5 bg-red-100 text-red-700 rounded-full text-xs font-semibold">
-                    ✗ Fail
-                  </span>
+                  <Badge variant="destructive" className="text-xs">✗ Fail</Badge>
                 )
               return (
                 <tr key={key} className="border-b last:border-0">
                   <td className="py-2 pr-4">{label}</td>
                   <td className="py-2 text-center">{badge}</td>
-                  <td className="py-2 text-xs text-gray-500">{note}</td>
+                  <td className="py-2 text-xs text-muted-foreground">{note}</td>
                 </tr>
               )
             })}
@@ -61,7 +59,7 @@ export default function SummaryTab({ results }: { results: Results }) {
       </div>
 
       {!allTested && (
-        <p className="text-sm text-gray-500 text-center">
+        <p className="text-sm text-muted-foreground text-center">
           Run validations on each tab to populate this table.
         </p>
       )}

--- a/web/src/pages/poc/SummaryTab.tsx
+++ b/web/src/pages/poc/SummaryTab.tsx
@@ -1,0 +1,70 @@
+type Results = Record<string, boolean>
+
+const ITEMS: { key: string; label: string; note: string }[] = [
+  { key: 'tts_support', label: 'Web Speech API — TTS', note: 'All modern browsers' },
+  { key: 'stt_support', label: 'Web Speech API — STT', note: 'Chrome / Edge only; Safari ✗' },
+  { key: 'idb_init', label: 'IndexedDB — schema init', note: '' },
+  { key: 'idb_blob', label: 'IndexedDB — Blob storage', note: '100 KB WAV Blob stored/retrieved' },
+  { key: 'idb_purge', label: 'IndexedDB — soft-delete purge', note: '10-day threshold verified' },
+  { key: 'cors_ok', label: 'VOICEVOX Lambda — CORS', note: 'Must be deployed via CDK' },
+  { key: 'voicevox_ok', label: 'VOICEVOX Lambda — WAV fetch & play', note: 'Requires CORS first' },
+]
+
+export default function SummaryTab({ results }: { results: Results }) {
+  const allTested = ITEMS.every((i) => i.key in results)
+  const passed = ITEMS.filter((i) => results[i.key] === true).length
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg p-4 shadow-sm">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="font-semibold text-sm">Validation Checklist</h3>
+          {allTested && (
+            <span className="text-xs font-semibold text-blue-600">
+              {passed} / {ITEMS.length} passed
+            </span>
+          )}
+        </div>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-xs text-gray-500">
+              <th className="pb-2 font-medium">Item</th>
+              <th className="pb-2 font-medium text-center">Status</th>
+              <th className="pb-2 font-medium">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ITEMS.map(({ key, label, note }) => {
+              const val = results[key]
+              const badge =
+                val === undefined ? (
+                  <span className="text-gray-400 text-xs">Not tested</span>
+                ) : val ? (
+                  <span className="px-2 py-0.5 bg-green-100 text-green-700 rounded-full text-xs font-semibold">
+                    ✓ Pass
+                  </span>
+                ) : (
+                  <span className="px-2 py-0.5 bg-red-100 text-red-700 rounded-full text-xs font-semibold">
+                    ✗ Fail
+                  </span>
+                )
+              return (
+                <tr key={key} className="border-b last:border-0">
+                  <td className="py-2 pr-4">{label}</td>
+                  <td className="py-2 text-center">{badge}</td>
+                  <td className="py-2 text-xs text-gray-500">{note}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {!allTested && (
+        <p className="text-sm text-gray-500 text-center">
+          Run validations on each tab to populate this table.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/poc/VoicevoxTab.tsx
+++ b/web/src/pages/poc/VoicevoxTab.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 
 const BASE_URL = import.meta.env.VITE_VOICEVOX_ENDPOINT_POC ?? ''
 const API_KEY = import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? ''
@@ -20,6 +22,13 @@ type Timing = {
   wavSizeKB: number
 }
 
+const resultStyle: Record<string, string> = {
+  ok: 'bg-green-50 text-green-800',
+  err: 'bg-red-50 text-red-800',
+  warn: 'bg-yellow-50 text-yellow-800',
+  '': 'bg-muted text-muted-foreground',
+}
+
 export default function VoicevoxTab({
   onResult,
 }: {
@@ -34,7 +43,6 @@ export default function VoicevoxTab({
   const [timing, setTiming] = useState<Timing | null>(null)
   const [versionResult, setVersionResult] = useState('')
   const [versionType, setVersionType] = useState<'ok' | 'err' | ''>('')
-
 
   async function checkVersion() {
     if (!BASE_URL) { setVersionResult('⚠ VITE_VOICEVOX_ENDPOINT_POC not set in .env'); setVersionType('err'); return }
@@ -133,52 +141,38 @@ export default function VoicevoxTab({
     }
   }
 
-  const resultStyle: Record<string, string> = {
-    ok: 'bg-green-50 text-green-800',
-    err: 'bg-red-50 text-red-800',
-    warn: 'bg-yellow-50 text-yellow-800',
-    '': 'bg-gray-50 text-gray-600',
-  }
-
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {/* Version */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Version Endpoint (public, no auth)</h3>
-        <button onClick={checkVersion} className="px-3 py-1.5 bg-gray-200 rounded text-sm font-medium">
-          GET /version
-        </button>
+        <Button size="sm" variant="outline" onClick={checkVersion}>GET /version</Button>
         {versionResult && (
-          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[versionType]}`}>
+          <pre className={`text-xs px-3 py-2 rounded-lg whitespace-pre-wrap ${resultStyle[versionType]}`}>
             {versionResult}
           </pre>
         )}
       </div>
 
       {/* CORS preflight */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">CORS Preflight Check</h3>
-        <button onClick={checkCORS} className="px-3 py-1.5 bg-gray-200 rounded text-sm font-medium">
-          🔍 OPTIONS /audio_query
-        </button>
+        <Button size="sm" variant="outline" onClick={checkCORS}>🔍 OPTIONS /audio_query</Button>
         {corsResult && (
-          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[corsType]}`}>
+          <pre className={`text-xs px-3 py-2 rounded-lg whitespace-pre-wrap ${resultStyle[corsType]}`}>
             {corsResult}
           </pre>
         )}
       </div>
 
       {/* Fetch & Play */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">End-to-end WAV Fetch &amp; Play</h3>
-        <p className="text-xs text-gray-400 flex items-center gap-1">
-          <span>©</span>
-          <span>VOICEVOX:ずんだもん</span>
-        </p>
+        <p className="text-xs text-muted-foreground">© VOICEVOX:ずんだもん</p>
         <div className="flex gap-3 items-center">
-          <label className="text-xs text-gray-500 w-20">スタイル</label>
+          <label className="text-xs text-muted-foreground w-16 shrink-0">スタイル</label>
           <select
-            className="border rounded px-2 py-1 text-sm"
+            className="border rounded-lg px-2 py-1.5 text-sm bg-white flex-1"
             value={speakerId}
             onChange={(e) => setSpeakerId(e.target.value)}
           >
@@ -190,18 +184,18 @@ export default function VoicevoxTab({
           </select>
         </div>
         <div className="flex gap-3 items-center">
-          <label className="text-xs text-gray-500 w-20">Text</label>
-          <input
-            className="border rounded px-2 py-1 text-sm flex-1"
+          <label className="text-xs text-muted-foreground w-16 shrink-0">Text</label>
+          <Input
             value={text}
             onChange={(e) => setText(e.target.value)}
+            className="flex-1"
           />
         </div>
-        <button onClick={testVoicevox} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+        <Button size="sm" onClick={testVoicevox} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">
           ▶ Fetch &amp; Play WAV
-        </button>
+        </Button>
         {vvResult && (
-          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[vvType]}`}>
+          <pre className={`text-xs px-3 py-2 rounded-lg whitespace-pre-wrap ${resultStyle[vvType]}`}>
             {vvResult}
           </pre>
         )}
@@ -213,9 +207,9 @@ export default function VoicevoxTab({
               { label: 'total', value: `${timing.totalMs} ms` },
               { label: 'WAV size', value: `${timing.wavSizeKB} KB` },
             ].map(({ label, value }) => (
-              <div key={label} className="bg-gray-100 rounded p-2 text-center">
+              <div key={label} className="bg-muted rounded-lg p-2 text-center">
                 <div className="text-lg font-bold">{value}</div>
-                <div className="text-xs text-gray-500">{label}</div>
+                <div className="text-xs text-muted-foreground">{label}</div>
               </div>
             ))}
             {timing.totalMs > 10000 && (

--- a/web/src/pages/poc/VoicevoxTab.tsx
+++ b/web/src/pages/poc/VoicevoxTab.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react'
+
+const BASE_URL = import.meta.env.VITE_VOICEVOX_ENDPOINT_POC ?? ''
+const API_KEY = import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? ''
+
+// Matches iOS VoicevoxStyle enum (SettingsManager.swift)
+const ZUNDAMON_STYLES = [
+  { id: '3',  label: 'ノーマル' },
+  { id: '1',  label: 'あまあま' },
+  { id: '7',  label: 'ツンツン' },
+  { id: '5',  label: 'セクシー' },
+  { id: '22', label: 'ささやき' },
+  { id: '38', label: 'ヒソヒソ' },
+]
+
+type Timing = {
+  audioQueryMs: number
+  synthesisMs: number
+  totalMs: number
+  wavSizeKB: number
+}
+
+export default function VoicevoxTab({
+  onResult,
+}: {
+  onResult: (key: string, value: boolean) => void
+}) {
+  const [speakerId, setSpeakerId] = useState('3')
+  const [text, setText] = useState('こんにちは、ずんだもんです。')
+  const [corsResult, setCorsResult] = useState('')
+  const [corsType, setCorsType] = useState<'ok' | 'err' | 'warn' | ''>('')
+  const [vvResult, setVvResult] = useState('')
+  const [vvType, setVvType] = useState<'ok' | 'err' | 'warn' | ''>('')
+  const [timing, setTiming] = useState<Timing | null>(null)
+  const [versionResult, setVersionResult] = useState('')
+  const [versionType, setVersionType] = useState<'ok' | 'err' | ''>('')
+
+
+  async function checkVersion() {
+    if (!BASE_URL) { setVersionResult('⚠ VITE_VOICEVOX_ENDPOINT_POC not set in .env'); setVersionType('err'); return }
+    setVersionResult('⋯ Fetching…'); setVersionType('')
+    try {
+      const t0 = performance.now()
+      const res = await fetch(`${BASE_URL}/version`)
+      const ms = Math.round(performance.now() - t0)
+      const body = await res.text()
+      setVersionResult(`✓ ${res.status} OK (${ms} ms)\n${body}`)
+      setVersionType('ok')
+    } catch (err) {
+      setVersionResult(`✗ ${err}\n\nCORS may not be configured on API Gateway.`)
+      setVersionType('err')
+    }
+  }
+
+  async function checkCORS() {
+    if (!BASE_URL) { setCorsResult('⚠ VITE_VOICEVOX_ENDPOINT_POC not set in .env'); setCorsType('warn'); return }
+    setCorsResult('⋯ Sending OPTIONS preflight…'); setCorsType('')
+    try {
+      const res = await fetch(`${BASE_URL}/audio_query`, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: location.origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'Content-Type, x-api-key',
+        },
+      })
+      const acao = res.headers.get('access-control-allow-origin')
+      const acam = res.headers.get('access-control-allow-methods')
+      const acah = res.headers.get('access-control-allow-headers')
+      if (acao) {
+        setCorsResult(
+          `✓ CORS preflight succeeded (${res.status})\nAccess-Control-Allow-Origin: ${acao}\nAccess-Control-Allow-Methods: ${acam}\nAccess-Control-Allow-Headers: ${acah}`,
+        )
+        setCorsType('ok')
+        onResult('cors_ok', true)
+      } else {
+        setCorsResult(`✗ No CORS headers (${res.status})\nAdd corsPreflight to CDK HttpApi.`)
+        setCorsType('err')
+        onResult('cors_ok', false)
+      }
+    } catch (err) {
+      setCorsResult(`✗ Preflight blocked: ${err}\nCORS is NOT configured on API Gateway.`)
+      setCorsType('err')
+      onResult('cors_ok', false)
+    }
+  }
+
+  async function testVoicevox() {
+    if (!BASE_URL || !API_KEY) {
+      setVvResult('⚠ VITE_VOICEVOX_ENDPOINT_POC / VITE_VOICEVOX_API_KEY_POC not set in .env')
+      setVvType('warn')
+      return
+    }
+    const headers = { 'Content-Type': 'application/json', 'x-api-key': API_KEY }
+    setTiming(null)
+    setVvResult('⋯ Step 1: POST /audio_query (cold start may take 10–30s)…'); setVvType('')
+    try {
+      const t0 = performance.now()
+      const queryRes = await fetch(
+        `${BASE_URL}/audio_query?text=${encodeURIComponent(text)}&speaker=${speakerId}`,
+        { method: 'POST', headers },
+      )
+      if (!queryRes.ok) throw new Error(`audio_query failed: ${queryRes.status} ${await queryRes.text()}`)
+      const queryJson = await queryRes.json()
+      const t1 = performance.now()
+      const audioQueryMs = Math.round(t1 - t0)
+
+      setVvResult(`✓ Step 1 done (${audioQueryMs} ms)\n⋯ Step 2: POST /synthesis…`); setVvType('')
+
+      const synthRes = await fetch(`${BASE_URL}/synthesis?speaker=${speakerId}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(queryJson),
+      })
+      if (!synthRes.ok) throw new Error(`synthesis failed: ${synthRes.status}`)
+      const wavBlob = await synthRes.blob()
+      const t2 = performance.now()
+      const synthesisMs = Math.round(t2 - t1)
+      const totalMs = Math.round(t2 - t0)
+      const wavSizeKB = Math.round(wavBlob.size / 1024)
+
+      const url = URL.createObjectURL(wavBlob)
+      const audio = new Audio(url)
+      audio.onended = () => URL.revokeObjectURL(url)
+      await audio.play()
+
+      setVvResult(`✓ WAV received and playing (${wavSizeKB} KB)`); setVvType('ok')
+      setTiming({ audioQueryMs, synthesisMs, totalMs, wavSizeKB })
+      onResult('voicevox_ok', true)
+    } catch (err) {
+      setVvResult(`✗ ${err}`); setVvType('err')
+      onResult('voicevox_ok', false)
+    }
+  }
+
+  const resultStyle: Record<string, string> = {
+    ok: 'bg-green-50 text-green-800',
+    err: 'bg-red-50 text-red-800',
+    warn: 'bg-yellow-50 text-yellow-800',
+    '': 'bg-gray-50 text-gray-600',
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Version */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Version Endpoint (public, no auth)</h3>
+        <button onClick={checkVersion} className="px-3 py-1.5 bg-gray-200 rounded text-sm font-medium">
+          GET /version
+        </button>
+        {versionResult && (
+          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[versionType]}`}>
+            {versionResult}
+          </pre>
+        )}
+      </div>
+
+      {/* CORS preflight */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">CORS Preflight Check</h3>
+        <button onClick={checkCORS} className="px-3 py-1.5 bg-gray-200 rounded text-sm font-medium">
+          🔍 OPTIONS /audio_query
+        </button>
+        {corsResult && (
+          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[corsType]}`}>
+            {corsResult}
+          </pre>
+        )}
+      </div>
+
+      {/* Fetch & Play */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">End-to-end WAV Fetch &amp; Play</h3>
+        <p className="text-xs text-gray-400 flex items-center gap-1">
+          <span>©</span>
+          <span>VOICEVOX:ずんだもん</span>
+        </p>
+        <div className="flex gap-3 items-center">
+          <label className="text-xs text-gray-500 w-20">スタイル</label>
+          <select
+            className="border rounded px-2 py-1 text-sm"
+            value={speakerId}
+            onChange={(e) => setSpeakerId(e.target.value)}
+          >
+            {ZUNDAMON_STYLES.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.label}（ID: {s.id}）
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex gap-3 items-center">
+          <label className="text-xs text-gray-500 w-20">Text</label>
+          <input
+            className="border rounded px-2 py-1 text-sm flex-1"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+        </div>
+        <button onClick={testVoicevox} className="px-3 py-1.5 bg-blue-600 text-white rounded text-sm font-medium">
+          ▶ Fetch &amp; Play WAV
+        </button>
+        {vvResult && (
+          <pre className={`text-xs px-3 py-2 rounded whitespace-pre-wrap ${resultStyle[vvType]}`}>
+            {vvResult}
+          </pre>
+        )}
+        {timing && (
+          <div className="grid grid-cols-4 gap-2 mt-2">
+            {[
+              { label: 'audio_query', value: `${timing.audioQueryMs} ms` },
+              { label: 'synthesis', value: `${timing.synthesisMs} ms` },
+              { label: 'total', value: `${timing.totalMs} ms` },
+              { label: 'WAV size', value: `${timing.wavSizeKB} KB` },
+            ].map(({ label, value }) => (
+              <div key={label} className="bg-gray-100 rounded p-2 text-center">
+                <div className="text-lg font-bold">{value}</div>
+                <div className="text-xs text-gray-500">{label}</div>
+              </div>
+            ))}
+            {timing.totalMs > 10000 && (
+              <p className="col-span-4 text-xs text-yellow-700">⚠ Cold start detected (&gt;10 s) — loading UI required</p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/poc/WebSpeechTab.tsx
+++ b/web/src/pages/poc/WebSpeechTab.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useRef, useState } from 'react'
+
+type SupportStatus = { tts: boolean; stt: boolean; isSafari: boolean }
+type JudgeLevel = 'PERFECT' | 'CLOSE' | 'RETRY' | null
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) => [
+    i,
+    ...Array<number>(n).fill(0),
+  ])
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+  return dp[m][n]
+}
+
+function normalize(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9 ]/g, '').trim()
+}
+
+function judge(transcript: string, target: string): JudgeLevel {
+  const t = normalize(transcript)
+  const g = normalize(target)
+  if (t === g) return 'PERFECT'
+  const dist = levenshtein(t, g)
+  const similarity = 1 - dist / Math.max(t.length, g.length, 1)
+  return similarity >= 0.7 ? 'CLOSE' : 'RETRY'
+}
+
+const JUDGE_STYLE: Record<NonNullable<JudgeLevel>, string> = {
+  PERFECT: 'bg-green-100 text-green-800',
+  CLOSE: 'bg-yellow-100 text-yellow-800',
+  RETRY: 'bg-red-100 text-red-800',
+}
+const JUDGE_LABEL: Record<NonNullable<JudgeLevel>, string> = {
+  PERFECT: '完璧！',
+  CLOSE: '惜しい！',
+  RETRY: 'もう一度練習しましょう',
+}
+
+export default function WebSpeechTab({
+  onResult,
+}: {
+  onResult: (key: string, value: boolean) => void
+}) {
+  const [support, setSupport] = useState<SupportStatus | null>(null)
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([])
+  const [voiceIdx, setVoiceIdx] = useState(0)
+  const [ttsText, setTtsText] = useState(
+    'This is a technical validation for the English Learn App.',
+  )
+  const [ttsStatus, setTtsStatus] = useState('')
+
+  const [sttStatus, setSttStatus] = useState('')
+  const [sttRaw, setSttRaw] = useState('')
+  const recRef = useRef<SpeechRecognition | null>(null)
+
+  const [judgeTarget, setJudgeTarget] = useState(
+    'The quick brown fox jumps over the lazy dog',
+  )
+  const [judgeTranscript, setJudgeTranscript] = useState(
+    'the quick brown fox jumps over the lazy dog',
+  )
+  const [judgeResult, setJudgeResult] = useState<{
+    level: JudgeLevel
+    similarity: string
+    dist: number
+  } | null>(null)
+
+  useEffect(() => {
+    const tts = 'speechSynthesis' in window
+    const stt = 'SpeechRecognition' in window || 'webkitSpeechRecognition' in window
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+    setSupport({ tts, stt, isSafari })
+    onResult('tts_support', tts)
+    onResult('stt_support', stt)
+
+    const loadVoices = () => {
+      setVoices(window.speechSynthesis.getVoices().filter((v) => v.lang.startsWith('en')))
+    }
+    loadVoices()
+    window.speechSynthesis.onvoiceschanged = loadVoices
+  }, [onResult])
+
+  function speak() {
+    window.speechSynthesis.cancel()
+    const utt = new SpeechSynthesisUtterance(ttsText)
+    if (voices[voiceIdx]) utt.voice = voices[voiceIdx]
+    utt.onstart = () => setTtsStatus('▶ Speaking…')
+    utt.onend = () => setTtsStatus('✓ Finished')
+    utt.onerror = (e) => setTtsStatus(`✗ Error: ${e.error}`)
+    window.speechSynthesis.speak(utt)
+  }
+
+  function startSTT() {
+    const SpeechRec = window.SpeechRecognition ?? window.webkitSpeechRecognition
+    if (!SpeechRec) {
+      setSttStatus('✗ Not supported — use Chrome or Edge')
+      return
+    }
+    const rec = new SpeechRec()
+    rec.lang = 'en-US'
+    rec.interimResults = true
+    rec.onstart = () => setSttStatus('🎤 Listening…')
+    rec.onresult = (e) => {
+      let text = ''
+      for (let i = e.resultIndex; i < e.results.length; i++) text += e.results[i][0].transcript
+      const isFinal = e.results[e.results.length - 1].isFinal
+      setSttStatus((isFinal ? '✓ ' : '⋯ ') + text)
+      setSttRaw(
+        JSON.stringify(
+          { transcript: text, isFinal, confidence: e.results[e.results.length - 1][0].confidence },
+          null,
+          2,
+        ),
+      )
+    }
+    rec.onerror = (e) => setSttStatus(`✗ ${e.error}`)
+    rec.start()
+    recRef.current = rec
+  }
+
+  function stopSTT() {
+    recRef.current?.stop()
+    recRef.current = null
+  }
+
+  function runJudge() {
+    const level = judge(judgeTranscript, judgeTarget)
+    const t = normalize(judgeTranscript)
+    const g = normalize(judgeTarget)
+    const dist = levenshtein(t, g)
+    const similarity = (1 - dist / Math.max(t.length, g.length, 1)).toFixed(3)
+    setJudgeResult({ level, similarity, dist })
+  }
+
+  const Badge = ({ ok }: { ok: boolean }) => (
+    <span
+      className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${ok ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}
+    >
+      {ok ? '✓ Supported' : '✗ Not supported'}
+    </span>
+  )
+
+  return (
+    <div className="space-y-4">
+      {/* API Availability */}
+      <div className="bg-white rounded-lg p-4 shadow-sm">
+        <h3 className="font-semibold text-sm mb-3">API Availability</h3>
+        {support && (
+          <table className="w-full text-sm">
+            <tbody>
+              <tr className="border-b">
+                <td className="py-2 pr-4 font-medium">speechSynthesis (TTS)</td>
+                <td className="py-2">
+                  <Badge ok={support.tts} />
+                </td>
+                <td className="py-2 text-gray-500 text-xs">All modern browsers</td>
+              </tr>
+              <tr className="border-b">
+                <td className="py-2 pr-4 font-medium">SpeechRecognition (STT)</td>
+                <td className="py-2">
+                  <Badge ok={support.stt} />
+                </td>
+                <td className="py-2 text-gray-500 text-xs">Chrome / Edge only</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+        {support?.isSafari && (
+          <p className="mt-2 text-xs text-yellow-700 bg-yellow-50 p-2 rounded">
+            ⚠ Safari detected — STT will not work. Pronunciation check requires Chrome or Edge.
+          </p>
+        )}
+      </div>
+
+      {/* TTS */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">TTS — speechSynthesis</h3>
+        <input
+          className="w-full border rounded px-3 py-1.5 text-sm"
+          value={ttsText}
+          onChange={(e) => setTtsText(e.target.value)}
+        />
+        <select
+          className="w-full border rounded px-3 py-1.5 text-sm"
+          value={voiceIdx}
+          onChange={(e) => setVoiceIdx(Number(e.target.value))}
+        >
+          {voices.map((v, i) => (
+            <option key={i} value={i}>
+              {v.name} ({v.lang})
+            </option>
+          ))}
+        </select>
+        <div className="flex gap-2">
+          <button
+            onClick={speak}
+            className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
+          >
+            ▶ Speak
+          </button>
+          <button
+            onClick={() => window.speechSynthesis.cancel()}
+            className="px-4 py-1.5 bg-gray-200 rounded text-sm font-medium"
+          >
+            ■ Stop
+          </button>
+        </div>
+        {ttsStatus && <p className="text-sm text-gray-700 bg-gray-50 px-3 py-2 rounded">{ttsStatus}</p>}
+      </div>
+
+      {/* STT */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">STT — SpeechRecognition (en-US)</h3>
+        <p className="text-xs text-gray-500">Chrome / Edge only. Safari is not supported.</p>
+        <div className="flex gap-2">
+          <button
+            onClick={startSTT}
+            className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
+          >
+            🎤 Start
+          </button>
+          <button
+            onClick={stopSTT}
+            className="px-4 py-1.5 bg-gray-200 rounded text-sm font-medium"
+          >
+            ■ Stop
+          </button>
+        </div>
+        {sttStatus && (
+          <p className="text-sm bg-gray-50 px-3 py-2 rounded whitespace-pre-wrap">{sttStatus}</p>
+        )}
+        {sttRaw && (
+          <details className="text-xs">
+            <summary className="cursor-pointer text-blue-600">Raw event</summary>
+            <pre className="mt-1 bg-gray-100 p-2 rounded overflow-x-auto">{sttRaw}</pre>
+          </details>
+        )}
+      </div>
+
+      {/* Judge */}
+      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+        <h3 className="font-semibold text-sm">Pronunciation Judgment Logic</h3>
+        <label className="text-xs text-gray-500">Target text</label>
+        <input
+          className="w-full border rounded px-3 py-1.5 text-sm"
+          value={judgeTarget}
+          onChange={(e) => setJudgeTarget(e.target.value)}
+        />
+        <label className="text-xs text-gray-500">Transcript (simulated)</label>
+        <input
+          className="w-full border rounded px-3 py-1.5 text-sm"
+          value={judgeTranscript}
+          onChange={(e) => setJudgeTranscript(e.target.value)}
+        />
+        <button
+          onClick={runJudge}
+          className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
+        >
+          Judge
+        </button>
+        {judgeResult?.level && (
+          <div className={`px-3 py-2 rounded text-sm ${JUDGE_STYLE[judgeResult.level]}`}>
+            <span className="font-bold">{judgeResult.level}</span> —{' '}
+            {JUDGE_LABEL[judgeResult.level]}
+            <span className="ml-2 text-xs opacity-70">
+              similarity: {judgeResult.similarity} | distance: {judgeResult.dist}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/poc/WebSpeechTab.tsx
+++ b/web/src/pages/poc/WebSpeechTab.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
 
 type SupportStatus = { tts: boolean; stt: boolean; isSafari: boolean }
 type JudgeLevel = 'PERFECT' | 'CLOSE' | 'RETRY' | null
@@ -140,56 +143,48 @@ export default function WebSpeechTab({
     setJudgeResult({ level, similarity, dist })
   }
 
-  const Badge = ({ ok }: { ok: boolean }) => (
-    <span
-      className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${ok ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}`}
-    >
-      {ok ? '✓ Supported' : '✗ Not supported'}
-    </span>
-  )
-
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       {/* API Availability */}
-      <div className="bg-white rounded-lg p-4 shadow-sm">
-        <h3 className="font-semibold text-sm mb-3">API Availability</h3>
+      <div className="bg-white rounded-2xl p-4 space-y-2">
+        <h3 className="font-semibold text-sm">API Availability</h3>
         {support && (
           <table className="w-full text-sm">
             <tbody>
               <tr className="border-b">
                 <td className="py-2 pr-4 font-medium">speechSynthesis (TTS)</td>
                 <td className="py-2">
-                  <Badge ok={support.tts} />
+                  <Badge variant={support.tts ? 'default' : 'destructive'} className={support.tts ? 'bg-green-100 text-green-700 hover:bg-green-100' : ''}>
+                    {support.tts ? '✓ Supported' : '✗ Not supported'}
+                  </Badge>
                 </td>
-                <td className="py-2 text-gray-500 text-xs">All modern browsers</td>
+                <td className="py-2 text-muted-foreground text-xs">All modern browsers</td>
               </tr>
               <tr className="border-b">
                 <td className="py-2 pr-4 font-medium">SpeechRecognition (STT)</td>
                 <td className="py-2">
-                  <Badge ok={support.stt} />
+                  <Badge variant={support.stt ? 'default' : 'destructive'} className={support.stt ? 'bg-green-100 text-green-700 hover:bg-green-100' : ''}>
+                    {support.stt ? '✓ Supported' : '✗ Not supported'}
+                  </Badge>
                 </td>
-                <td className="py-2 text-gray-500 text-xs">Chrome / Edge only</td>
+                <td className="py-2 text-muted-foreground text-xs">Chrome / Edge only</td>
               </tr>
             </tbody>
           </table>
         )}
         {support?.isSafari && (
-          <p className="mt-2 text-xs text-yellow-700 bg-yellow-50 p-2 rounded">
+          <p className="text-xs text-yellow-700 bg-yellow-50 p-2 rounded-lg">
             ⚠ Safari detected — STT will not work. Pronunciation check requires Chrome or Edge.
           </p>
         )}
       </div>
 
       {/* TTS */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">TTS — speechSynthesis</h3>
-        <input
-          className="w-full border rounded px-3 py-1.5 text-sm"
-          value={ttsText}
-          onChange={(e) => setTtsText(e.target.value)}
-        />
+        <Input value={ttsText} onChange={(e) => setTtsText(e.target.value)} />
         <select
-          className="w-full border rounded px-3 py-1.5 text-sm"
+          className="w-full border rounded-lg px-3 py-1.5 text-sm bg-white"
           value={voiceIdx}
           onChange={(e) => setVoiceIdx(Number(e.target.value))}
         >
@@ -200,74 +195,41 @@ export default function WebSpeechTab({
           ))}
         </select>
         <div className="flex gap-2">
-          <button
-            onClick={speak}
-            className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
-          >
-            ▶ Speak
-          </button>
-          <button
-            onClick={() => window.speechSynthesis.cancel()}
-            className="px-4 py-1.5 bg-gray-200 rounded text-sm font-medium"
-          >
-            ■ Stop
-          </button>
+          <Button size="sm" onClick={speak} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">▶ Speak</Button>
+          <Button size="sm" variant="outline" onClick={() => window.speechSynthesis.cancel()}>■ Stop</Button>
         </div>
-        {ttsStatus && <p className="text-sm text-gray-700 bg-gray-50 px-3 py-2 rounded">{ttsStatus}</p>}
+        {ttsStatus && <p className="text-sm text-foreground bg-muted px-3 py-2 rounded-lg">{ttsStatus}</p>}
       </div>
 
       {/* STT */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">STT — SpeechRecognition (en-US)</h3>
-        <p className="text-xs text-gray-500">Chrome / Edge only. Safari is not supported.</p>
+        <p className="text-xs text-muted-foreground">Chrome / Edge only. Safari is not supported.</p>
         <div className="flex gap-2">
-          <button
-            onClick={startSTT}
-            className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
-          >
-            🎤 Start
-          </button>
-          <button
-            onClick={stopSTT}
-            className="px-4 py-1.5 bg-gray-200 rounded text-sm font-medium"
-          >
-            ■ Stop
-          </button>
+          <Button size="sm" onClick={startSTT} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">🎤 Start</Button>
+          <Button size="sm" variant="outline" onClick={stopSTT}>■ Stop</Button>
         </div>
         {sttStatus && (
-          <p className="text-sm bg-gray-50 px-3 py-2 rounded whitespace-pre-wrap">{sttStatus}</p>
+          <p className="text-sm bg-muted px-3 py-2 rounded-lg whitespace-pre-wrap">{sttStatus}</p>
         )}
         {sttRaw && (
           <details className="text-xs">
-            <summary className="cursor-pointer text-blue-600">Raw event</summary>
-            <pre className="mt-1 bg-gray-100 p-2 rounded overflow-x-auto">{sttRaw}</pre>
+            <summary className="cursor-pointer text-[var(--ios-blue)]">Raw event</summary>
+            <pre className="mt-1 bg-muted p-2 rounded-lg overflow-x-auto">{sttRaw}</pre>
           </details>
         )}
       </div>
 
       {/* Judge */}
-      <div className="bg-white rounded-lg p-4 shadow-sm space-y-2">
+      <div className="bg-white rounded-2xl p-4 space-y-2">
         <h3 className="font-semibold text-sm">Pronunciation Judgment Logic</h3>
-        <label className="text-xs text-gray-500">Target text</label>
-        <input
-          className="w-full border rounded px-3 py-1.5 text-sm"
-          value={judgeTarget}
-          onChange={(e) => setJudgeTarget(e.target.value)}
-        />
-        <label className="text-xs text-gray-500">Transcript (simulated)</label>
-        <input
-          className="w-full border rounded px-3 py-1.5 text-sm"
-          value={judgeTranscript}
-          onChange={(e) => setJudgeTranscript(e.target.value)}
-        />
-        <button
-          onClick={runJudge}
-          className="px-4 py-1.5 bg-blue-600 text-white rounded text-sm font-medium"
-        >
-          Judge
-        </button>
+        <label className="text-xs text-muted-foreground">Target text</label>
+        <Input value={judgeTarget} onChange={(e) => setJudgeTarget(e.target.value)} />
+        <label className="text-xs text-muted-foreground">Transcript (simulated)</label>
+        <Input value={judgeTranscript} onChange={(e) => setJudgeTranscript(e.target.value)} />
+        <Button size="sm" onClick={runJudge} className="bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90">Judge</Button>
         {judgeResult?.level && (
-          <div className={`px-3 py-2 rounded text-sm ${JUDGE_STYLE[judgeResult.level]}`}>
+          <div className={`px-3 py-2 rounded-lg text-sm ${JUDGE_STYLE[judgeResult.level]}`}>
             <span className="font-bold">{judgeResult.level}</span> —{' '}
             {JUDGE_LABEL[judgeResult.level]}
             <span className="ml-2 text-xs opacity-70">

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,8 +1,39 @@
 /// <reference types="vite/client" />
 
+// Web Speech API type declarations (not yet in lib.dom.d.ts for all environments)
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number
+  readonly results: SpeechRecognitionResultList
+}
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string
+}
+interface SpeechRecognition extends EventTarget {
+  lang: string
+  interimResults: boolean
+  maxAlternatives: number
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null
+  onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null
+  start(): void
+  stop(): void
+  abort(): void
+}
+declare var SpeechRecognition: {
+  prototype: SpeechRecognition
+  new (): SpeechRecognition
+}
+interface Window {
+  SpeechRecognition?: typeof SpeechRecognition
+  webkitSpeechRecognition?: typeof SpeechRecognition
+}
+
 interface ImportMetaEnv {
   readonly VITE_APP_VERSION: string
   readonly VITE_APP_ENV: string
+  readonly VITE_VOICEVOX_ENDPOINT_POC: string
+  readonly VITE_VOICEVOX_API_KEY_POC: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- **CORS added to VOICEVOX API Gateway** (CDK): `poc` uses wildcard origin, `dev`/`pro` use CloudFront domain placeholder (to be updated in #124). Deployed and verified working.
- **`/#/poc` validation page** built with React 19 + Tailwind CSS (replaces the raw HTML PoC from the closed PR #129):

| Tab | Validates |
|-----|-----------|
| 1. Web Speech API | TTS voice selector, STT recording (Chrome/Edge), pronunciation judgment (Levenshtein) |
| 2. IndexedDB | Schema init, word CRUD, 100 KB Blob cache, soft-delete auto-purge (10-day) |
| 3. VOICEVOX / CORS | CORS preflight check, `/version` health check, end-to-end WAV fetch & play with cold-start timing |
| 4. Summary | Pass/fail checklist across all validations |

**VOICEVOX tab details:**
- Zundamon style dropdown matches iOS `VoicevoxStyle` enum (`SettingsManager.swift`): ノーマル(3) / あまあま(1) / ツンツン(7) / セクシー(5) / ささやき(22) / ヒソヒソ(38)
- `© VOICEVOX:ずんだもん` credit displayed, matching iOS `SettingsView`

## Validation results (manually confirmed)

- `GET /version` ✓ 200 OK
- VOICEVOX WAV fetch & play ✓ (all 6 styles)
- IndexedDB Blob storage ✓
- Soft-delete purge ✓

## Test plan

- [ ] `cd web && npm run dev` → open `http://localhost:5173/#/poc`
- [ ] Tab 1: TTS speaks / STT records (Chrome)
- [ ] Tab 2: DB init → save word → filter → store Blob → purge test all pass
- [ ] Tab 3: CORS preflight ✓ → WAV plays for each Zundamon style
- [ ] Tab 4: Summary shows all items as Pass
- [ ] `npm run build` ✓ | `npm test` ✓

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Proof-of-Concept page with tabbed validation interface for testing Web Speech API capabilities, IndexedDB operations, and Voicevox endpoint integration.
  * Implemented CORS preflight support on API endpoints with environment-specific configuration.
  * Added validation checklist to summarize and track feature test results.

* **Chores**
  * Updated Vite cache directory ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->