### PR TITLE
feat: add Developer Tools section to Settings page

### DIFF
--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,10 +1,36 @@
+import { useNavigate } from 'react-router'
+import { ChevronRight, FlaskConical } from 'lucide-react'
+
 export default function SettingsPage() {
+  const navigate = useNavigate()
+
   return (
     <div className="max-w-2xl mx-auto px-4 py-4">
       <header className="sticky top-0 bg-[var(--ios-grouped-bg)] py-3 z-10">
         <h1 className="text-xl font-bold">設定</h1>
       </header>
-      <p className="text-muted-foreground text-sm mt-4">設定項目はここに表示されます。</p>
+
+      <div className="mt-4 space-y-6">
+        <p className="text-muted-foreground text-sm">設定項目はここに表示されます。</p>
+
+        {/* Developer Tools */}
+        <div>
+          <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">Developer Tools</p>
+          <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
+            <button
+              onClick={() => navigate('/poc')}
+              className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+            >
+              <FlaskConical size={18} className="text-[var(--ios-blue)] shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium">Phase 0 Validation</p>
+                <p className="text-xs text-muted-foreground">Web Speech API · IndexedDB · VOICEVOX CORS</p>
+              </div>
+              <ChevronRight size={16} className="text-muted-foreground shrink-0" />
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,8 +1,73 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
-import { ChevronRight, FlaskConical } from 'lucide-react'
+import { ChevronRight, FlaskConical, TriangleAlert } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+// Matches iOS VoicevoxStyle enum (SettingsManager.swift)
+const VOICEVOX_STYLES = [
+  { id: '3',  label: 'ノーマル' },
+  { id: '1',  label: 'あまあま' },
+  { id: '7',  label: 'ツンツン' },
+  { id: '5',  label: 'セクシー' },
+  { id: '22', label: 'ささやき' },
+  { id: '38', label: 'ヒソヒソ' },
+]
+
+// Matches iOS OpenAI model options
+const OPENAI_MODELS = [
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini（高速・低コスト）' },
+  { id: 'gpt-4o',      label: 'GPT-4o' },
+  { id: 'gpt-4.1-mini',label: 'GPT-4.1 mini' },
+]
+
+const PRESET_LABELS: Record<string, string> = {
+  general: '一般',
+  business: 'ビジネス',
+  academic: '学術',
+}
+
+function SectionLabel({ label }: { label: string }) {
+  return (
+    <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">{label}</p>
+  )
+}
+
+function GroupCard({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn('bg-white rounded-2xl divide-y divide-border overflow-hidden', className)}>
+      {children}
+    </div>
+  )
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return <div className="px-4 py-3">{children}</div>
+}
+
+function NavRow({ label, value, onClick }: { label: string; value?: string; onClick?: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+    >
+      <span className="text-sm">{label}</span>
+      <div className="flex items-center gap-1 text-muted-foreground">
+        {value && <span className="text-sm">{value}</span>}
+        <ChevronRight size={16} />
+      </div>
+    </button>
+  )
+}
 
 export default function SettingsPage() {
   const navigate = useNavigate()
+
+  const [openAIKey, setOpenAIKey] = useState('')
+  const [voicevoxStyle, setVoicevoxStyle] = useState('22')
+  const [voicevoxKey, setVoicevoxKey] = useState('')
+  const [openAIModel, setOpenAIModel] = useState('gpt-4o-mini')
+  const [preset] = useState('general')
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-4">
@@ -11,12 +76,100 @@ export default function SettingsPage() {
       </header>
 
       <div className="mt-4 space-y-6">
-        <p className="text-muted-foreground text-sm">設定項目はここに表示されます。</p>
+
+        {/* OpenAI API設定 */}
+        <div>
+          <SectionLabel label="OpenAI API設定" />
+          <GroupCard>
+            <Row>
+              <Input
+                type="password"
+                placeholder="APIキー"
+                value={openAIKey}
+                onChange={(e) => setOpenAIKey(e.target.value)}
+                className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
+              />
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* VOICEVOX設定 */}
+        <div>
+          <SectionLabel label="VOICEVOX設定" />
+          <GroupCard>
+            {/* スタイル */}
+            <Row>
+              <div className="flex items-center justify-between">
+                <span className="text-sm">スタイル</span>
+                <select
+                  className="text-sm text-muted-foreground bg-transparent border-0 outline-none cursor-pointer"
+                  value={voicevoxStyle}
+                  onChange={(e) => setVoicevoxStyle(e.target.value)}
+                >
+                  {VOICEVOX_STYLES.map((s) => (
+                    <option key={s.id} value={s.id}>{s.label}</option>
+                  ))}
+                </select>
+              </div>
+            </Row>
+
+            {/* APIキー */}
+            <Row>
+              <Input
+                type="password"
+                placeholder="APIキー"
+                value={voicevoxKey}
+                onChange={(e) => setVoicevoxKey(e.target.value)}
+                className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
+              />
+              {!voicevoxKey && (
+                <div className="flex items-center gap-1.5 mt-1.5">
+                  <TriangleAlert size={13} className="text-[var(--ios-orange)] shrink-0" />
+                  <p className="text-xs text-[var(--ios-orange)]">
+                    AppConfigのキーを使用中（設定で上書き可）
+                  </p>
+                </div>
+              )}
+            </Row>
+
+            {/* クレジット */}
+            <Row>
+              <p className="text-xs text-muted-foreground">© VOICEVOX:ずんだもん</p>
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* AIモデル設定 */}
+        <div>
+          <SectionLabel label="AIモデル設定" />
+          <GroupCard>
+            <Row>
+              <p className="text-xs text-muted-foreground mb-1">使用モデル</p>
+              <select
+                className="w-full text-sm text-[var(--ios-blue)] bg-transparent border-0 outline-none cursor-pointer"
+                value={openAIModel}
+                onChange={(e) => setOpenAIModel(e.target.value)}
+              >
+                {OPENAI_MODELS.map((m) => (
+                  <option key={m.id} value={m.id}>{m.label}</option>
+                ))}
+              </select>
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* 例文生成の条件 */}
+        <div>
+          <SectionLabel label="例文生成の条件" />
+          <GroupCard>
+            <NavRow label="プリセット管理" value={PRESET_LABELS[preset]} />
+          </GroupCard>
+        </div>
 
         {/* Developer Tools */}
         <div>
-          <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">Developer Tools</p>
-          <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
+          <SectionLabel label="Developer Tools" />
+          <GroupCard>
             <button
               onClick={() => navigate('/poc')}
               className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
@@ -28,8 +181,9 @@ export default function SettingsPage() {
               </div>
               <ChevronRight size={16} className="text-muted-foreground shrink-0" />
             </button>
-          </div>
+          </GroupCard>
         </div>
+
       </div>
     </div>
   )

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,22 +1,14 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router'
 import {
-  ChevronRight,
-  FlaskConical,
-  Volume2,
-  Upload,
-  Download,
-  Trash2,
-  FileText,
-  Shield,
-  CheckCircle2,
-  TriangleAlert,
+  ChevronRight, FlaskConical, Volume2,
+  Upload, Download, Trash2, FileText, Shield,
+  CheckCircle2, TriangleAlert,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
-// Matches iOS VoicevoxStyle enum (SettingsManager.swift)
 const VOICEVOX_STYLES = [
   { id: '3',  label: 'ノーマル' },
   { id: '1',  label: 'あまあま' },
@@ -27,64 +19,43 @@ const VOICEVOX_STYLES = [
 ]
 
 const OPENAI_MODELS = [
-  { id: 'gpt-4o-mini', label: 'GPT-4o mini（高速・低コスト）' },
-  { id: 'gpt-4o',      label: 'GPT-4o' },
-  { id: 'gpt-4.1-mini',label: 'GPT-4.1 mini' },
+  { id: 'gpt-4o-mini',  label: 'GPT-4o mini（高速・低コスト）' },
+  { id: 'gpt-4o',       label: 'GPT-4o' },
+  { id: 'gpt-4.1-mini', label: 'GPT-4.1 mini' },
 ]
 
-const EN_VOICES = ['デフォルト', '女性', '男性', 'ずんだもん'] as const
-const JA_VOICES = ['ずんだもん', 'デフォルト'] as const
-const PLAY_PATTERNS = ['バイリンガル (EN+JA)', '英語のみ (EN+EN)'] as const
+const EN_VOICES  = ['デフォルト', '女性', '男性', 'ずんだもん'] as const
+const JA_VOICES  = ['ずんだもん', 'デフォルト'] as const
+const PATTERNS   = ['バイリンガル (EN+JA)', '英語のみ (EN+EN)'] as const
 
-type EnVoice = typeof EN_VOICES[number]
-type JaVoice = typeof JA_VOICES[number]
-type PlayPattern = typeof PLAY_PATTERNS[number]
+type EnVoice  = typeof EN_VOICES[number]
+type JaVoice  = typeof JA_VOICES[number]
+type Pattern  = typeof PATTERNS[number]
 
-// --- Sub components ---
+// ---- UI primitives ----
 
 function SectionLabel({ label }: { label: string }) {
   return <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">{label}</p>
 }
 
 function GroupCard({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
-      {children}
-    </div>
-  )
+  return <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">{children}</div>
 }
 
 function Row({ children, className }: { children: React.ReactNode; className?: string }) {
   return <div className={cn('px-4 py-3', className)}>{children}</div>
 }
 
-function NavRow({ label, value, onClick, icon: Icon, iconColor }: {
+function ListRow({
+  icon: Icon, iconColor, label, sublabel, value, chevron, onClick, destructive,
+}: {
+  icon?: React.ElementType
+  iconColor?: string
   label: string
+  sublabel?: string
   value?: string
+  chevron?: boolean
   onClick?: () => void
-  icon?: React.ElementType
-  iconColor?: string
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-    >
-      {Icon && <Icon size={18} className={cn('shrink-0', iconColor ?? 'text-[var(--ios-blue)]')} />}
-      <span className="flex-1 text-sm">{label}</span>
-      <div className="flex items-center gap-1 text-muted-foreground">
-        {value && <span className="text-sm">{value}</span>}
-        <ChevronRight size={16} />
-      </div>
-    </button>
-  )
-}
-
-function ActionRow({ label, onClick, icon: Icon, iconColor, destructive }: {
-  label: string
-  onClick?: () => void
-  icon?: React.ElementType
-  iconColor?: string
   destructive?: boolean
 }) {
   return (
@@ -93,17 +64,20 @@ function ActionRow({ label, onClick, icon: Icon, iconColor, destructive }: {
       className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
     >
       {Icon && <Icon size={18} className={cn('shrink-0', iconColor ?? 'text-[var(--ios-blue)]')} />}
-      <span className={cn('flex-1 text-sm', destructive ? 'text-[var(--ios-red)]' : 'text-[var(--ios-blue)]')}>
-        {label}
-      </span>
+      <div className="flex-1 min-w-0">
+        <p className={cn('text-sm', destructive ? 'text-[var(--ios-red)]' : !Icon ? '' : 'text-[var(--ios-blue)]')}>
+          {label}
+        </p>
+        {sublabel && <p className="text-xs text-muted-foreground">{sublabel}</p>}
+      </div>
+      {value && <span className="text-sm text-muted-foreground">{value}</span>}
+      {chevron && <ChevronRight size={16} className="text-muted-foreground shrink-0" />}
     </button>
   )
 }
 
 function SegmentedControl<T extends string>({
-  options,
-  value,
-  onChange,
+  options, value, onChange,
 }: {
   options: readonly T[]
   value: T
@@ -117,9 +91,7 @@ function SegmentedControl<T extends string>({
           onClick={() => onChange(opt)}
           className={cn(
             'flex-1 text-xs font-medium py-1.5 px-2 rounded-md transition-all',
-            value === opt
-              ? 'bg-white text-foreground shadow-sm'
-              : 'text-muted-foreground hover:text-foreground',
+            value === opt ? 'bg-white text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
           )}
         >
           {opt}
@@ -129,48 +101,97 @@ function SegmentedControl<T extends string>({
   )
 }
 
-// --- Main ---
+// ---- Helpers ----
+
+function resolveEnVoice(
+  selection: EnVoice,
+  voices: SpeechSynthesisVoice[],
+): SpeechSynthesisVoice | null {
+  const female = voices.find((v) => /female/i.test(v.name)) ?? null
+  if (selection === 'デフォルト') return female
+  if (selection === '女性') return female
+  if (selection === '男性') return voices.find((v) => /male/i.test(v.name) && !/female/i.test(v.name)) ?? null
+  return null
+}
+
+async function playVoicevoxAudio(
+  text: string,
+  speakerId: string,
+  apiKey: string,
+  onEnd: () => void,
+): Promise<boolean> {
+  const base = import.meta.env.VITE_VOICEVOX_ENDPOINT_POC ?? ''
+  if (!base || !apiKey) return false
+  const headers = { 'Content-Type': 'application/json', 'x-api-key': apiKey }
+  try {
+    const qRes = await fetch(`${base}/audio_query?text=${encodeURIComponent(text)}&speaker=${speakerId}`, { method: 'POST', headers })
+    if (!qRes.ok) return false
+    const sRes = await fetch(`${base}/synthesis?speaker=${speakerId}`, {
+      method: 'POST', headers, body: JSON.stringify(await qRes.json()),
+    })
+    if (!sRes.ok) return false
+    const url = URL.createObjectURL(await sRes.blob())
+    const audio = new Audio(url)
+    audio.onended = () => { URL.revokeObjectURL(url); onEnd() }
+    audio.onerror = () => { URL.revokeObjectURL(url); onEnd() }
+    await audio.play()
+    return true
+  } catch {
+    return false
+  }
+}
+
+// ---- Page ----
 
 export default function SettingsPage() {
   const navigate = useNavigate()
 
-  const [enVoice, setEnVoice] = useState<EnVoice>('デフォルト')
-  const [jaVoice, setJaVoice] = useState<JaVoice>('ずんだもん')
-  const [playPattern, setPlayPattern] = useState<PlayPattern>('バイリンガル (EN+JA)')
-  const [interval, setInterval] = useState(1.5)
-
-  const [voicevoxStyle, setVoicevoxStyle] = useState('22')
-  const [voicevoxKey, setVoicevoxKey] = useState('')
-
+  const [enVoice,   setEnVoice]   = useState<EnVoice>('デフォルト')
+  const [jaVoice,   setJaVoice]   = useState<JaVoice>('ずんだもん')
+  const [pattern,   setPattern]   = useState<Pattern>('バイリンガル (EN+JA)')
+  const [interval,  setIntervalS] = useState(1.5)
+  const [vvStyle,   setVvStyle]   = useState('22')
+  const [vvKey,     setVvKey]     = useState('')
   const [openAIKey, setOpenAIKey] = useState('')
-  const [openAIModel, setOpenAIModel] = useState('gpt-4o-mini')
+  const [aiModel,   setAiModel]   = useState('gpt-4o-mini')
+  const [enVoices,  setEnVoices]  = useState<SpeechSynthesisVoice[]>([])
+  const [playing,   setPlaying]   = useState(false)
 
-  const [ttsStatus, setTtsStatus] = useState<'idle' | 'playing'>('idle')
+  useEffect(() => {
+    const load = () =>
+      setEnVoices(window.speechSynthesis.getVoices().filter((v) => v.lang.startsWith('en')))
+    load()
+    window.speechSynthesis.onvoiceschanged = load
+  }, [])
 
-  function playEnSample() {
+  const resolvedVvKey = vvKey || (import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? '')
+
+  async function playSample(text: string, lang: 'en' | 'ja', useZundamon: boolean) {
+    if (playing) return
     window.speechSynthesis.cancel()
-    setTtsStatus('playing')
-    const utt = new SpeechSynthesisUtterance('This is a sample of the English voice.')
-    utt.lang = 'en-US'
-    utt.onend = () => setTtsStatus('idle')
-    utt.onerror = () => setTtsStatus('idle')
+    setPlaying(true)
+    const done = () => setPlaying(false)
+
+    if (useZundamon) {
+      const ok = await playVoicevoxAudio(text, vvStyle, resolvedVvKey, done)
+      if (!ok) done()
+      return
+    }
+
+    const utt = new SpeechSynthesisUtterance(text)
+    utt.lang = lang === 'en' ? 'en-US' : 'ja-JP'
+    if (lang === 'en') {
+      const voice = resolveEnVoice(enVoice, enVoices)
+      if (voice) utt.voice = voice
+    }
+    utt.onend = done
+    utt.onerror = done
     window.speechSynthesis.speak(utt)
   }
 
-  function playJaSample() {
-    window.speechSynthesis.cancel()
-    setTtsStatus('playing')
-    const utt = new SpeechSynthesisUtterance('これは日本語の音声サンプルです。')
-    utt.lang = 'ja-JP'
-    utt.onend = () => setTtsStatus('idle')
-    utt.onerror = () => setTtsStatus('idle')
-    window.speechSynthesis.speak(utt)
-  }
-
-  const patternDesc =
-    playPattern === 'バイリンガル (EN+JA)'
-      ? 'バイリンガル: 英語 → 日本語 → 英語 の順で再生します'
-      : '英語のみ: 英語のみ 2 回繰り返します'
+  const patternDesc = pattern === 'バイリンガル (EN+JA)'
+    ? 'バイリンガル: 英語 → 日本語 → 英語 の順で再生します'
+    : '英語のみ: 英語のみ 2 回繰り返します'
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-4">
@@ -184,17 +205,14 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="英語の音声設定" />
           <GroupCard>
-            <Row>
-              <SegmentedControl options={EN_VOICES} value={enVoice} onChange={setEnVoice} />
-            </Row>
+            <Row><SegmentedControl options={EN_VOICES} value={enVoice} onChange={setEnVoice} /></Row>
             <Row>
               <Button
                 className="w-full bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90 text-white"
-                onClick={playEnSample}
-                disabled={ttsStatus === 'playing'}
+                disabled={playing}
+                onClick={() => playSample('This is a sample of the English voice.', 'en', enVoice === 'ずんだもん')}
               >
-                <Volume2 size={16} className="mr-1.5" />
-                英語サンプルを再生
+                <Volume2 size={16} className="mr-1.5" />英語サンプルを再生
               </Button>
             </Row>
           </GroupCard>
@@ -204,17 +222,14 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="日本語の音声設定" />
           <GroupCard>
-            <Row>
-              <SegmentedControl options={JA_VOICES} value={jaVoice} onChange={setJaVoice} />
-            </Row>
+            <Row><SegmentedControl options={JA_VOICES} value={jaVoice} onChange={setJaVoice} /></Row>
             <Row>
               <Button
                 className="w-full bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90 text-white"
-                onClick={playJaSample}
-                disabled={ttsStatus === 'playing'}
+                disabled={playing}
+                onClick={() => playSample('これは日本語の音声サンプルです。', 'ja', jaVoice === 'ずんだもん')}
               >
-                <Volume2 size={16} className="mr-1.5" />
-                日本語サンプルを再生
+                <Volume2 size={16} className="mr-1.5" />日本語サンプルを再生
               </Button>
             </Row>
           </GroupCard>
@@ -224,21 +239,15 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="連続再生設定" />
           <GroupCard>
-            <Row>
-              <SegmentedControl options={PLAY_PATTERNS} value={playPattern} onChange={setPlayPattern} />
-            </Row>
+            <Row><SegmentedControl options={PATTERNS} value={pattern} onChange={setPattern} /></Row>
             <Row>
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm">例文間の間隔</span>
                 <span className="text-sm text-muted-foreground">{interval.toFixed(1)}秒</span>
               </div>
               <input
-                type="range"
-                min={0.5}
-                max={5.0}
-                step={0.5}
-                value={interval}
-                onChange={(e) => setInterval(Number(e.target.value))}
+                type="range" min={0.5} max={5.0} step={0.5} value={interval}
+                onChange={(e) => setIntervalS(Number(e.target.value))}
                 className="w-full accent-[var(--ios-blue)]"
               />
             </Row>
@@ -258,35 +267,26 @@ export default function SettingsPage() {
                 <span className="text-sm">スタイル</span>
                 <select
                   className="text-sm text-muted-foreground bg-transparent border-0 outline-none cursor-pointer"
-                  value={voicevoxStyle}
-                  onChange={(e) => setVoicevoxStyle(e.target.value)}
+                  value={vvStyle} onChange={(e) => setVvStyle(e.target.value)}
                 >
-                  {VOICEVOX_STYLES.map((s) => (
-                    <option key={s.id} value={s.id}>{s.label}</option>
-                  ))}
+                  {VOICEVOX_STYLES.map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
                 </select>
               </div>
             </Row>
             <Row>
               <Input
-                type="password"
-                placeholder="APIキー"
-                value={voicevoxKey}
-                onChange={(e) => setVoicevoxKey(e.target.value)}
+                type="password" placeholder="APIキー" value={vvKey}
+                onChange={(e) => setVvKey(e.target.value)}
                 className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
               />
-              {!voicevoxKey && (
+              {!vvKey && (
                 <div className="flex items-center gap-1.5 mt-1.5">
                   <TriangleAlert size={13} className="text-[var(--ios-orange)] shrink-0" />
-                  <p className="text-xs text-[var(--ios-orange)]">
-                    AppConfigのキーを使用中（設定で上書き可）
-                  </p>
+                  <p className="text-xs text-[var(--ios-orange)]">AppConfigのキーを使用中（設定で上書き可）</p>
                 </div>
               )}
             </Row>
-            <Row>
-              <p className="text-xs text-muted-foreground">© VOICEVOX:ずんだもん</p>
-            </Row>
+            <Row><p className="text-xs text-muted-foreground">© VOICEVOX:ずんだもん</p></Row>
           </GroupCard>
         </div>
 
@@ -296,9 +296,7 @@ export default function SettingsPage() {
           <GroupCard>
             <Row>
               <Input
-                type="password"
-                placeholder="APIキー"
-                value={openAIKey}
+                type="password" placeholder="APIキー" value={openAIKey}
                 onChange={(e) => setOpenAIKey(e.target.value)}
                 className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
               />
@@ -320,12 +318,9 @@ export default function SettingsPage() {
               <p className="text-xs text-muted-foreground mb-1">使用モデル</p>
               <select
                 className="w-full text-sm text-[var(--ios-blue)] bg-transparent border-0 outline-none cursor-pointer"
-                value={openAIModel}
-                onChange={(e) => setOpenAIModel(e.target.value)}
+                value={aiModel} onChange={(e) => setAiModel(e.target.value)}
               >
-                {OPENAI_MODELS.map((m) => (
-                  <option key={m.id} value={m.id}>{m.label}</option>
-                ))}
+                {OPENAI_MODELS.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
               </select>
             </Row>
           </GroupCard>
@@ -335,7 +330,7 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="例文生成の条件" />
           <GroupCard>
-            <NavRow label="プリセット管理" value="一般" />
+            <ListRow label="プリセット管理" value="一般" chevron />
           </GroupCard>
         </div>
 
@@ -343,15 +338,15 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="データ管理" />
           <GroupCard>
-            <ActionRow label="単語リストをエクスポート" icon={Upload} />
-            <ActionRow label="単語リストをインポート" icon={Download} />
+            <ListRow icon={Upload}  label="単語リストをエクスポート" />
+            <ListRow icon={Download} label="単語リストをインポート" />
             <Row>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">音声キャッシュ</span>
                 <span className="text-sm text-muted-foreground">0バイト</span>
               </div>
             </Row>
-            <ActionRow label="キャッシュをクリア" icon={Trash2} iconColor="text-[var(--ios-red)]" destructive />
+            <ListRow icon={Trash2} iconColor="text-[var(--ios-red)]" label="キャッシュをクリア" destructive />
           </GroupCard>
         </div>
 
@@ -359,8 +354,8 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="法的情報" />
           <GroupCard>
-            <NavRow label="プライバシーポリシー" icon={Shield} />
-            <NavRow label="利用規約" icon={FileText} />
+            <ListRow icon={Shield}   label="プライバシーポリシー" chevron />
+            <ListRow icon={FileText} label="利用規約"             chevron />
           </GroupCard>
         </div>
 
@@ -368,17 +363,13 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="Developer Tools" />
           <GroupCard>
-            <button
+            <ListRow
+              icon={FlaskConical}
+              label="Phase 0 Validation"
+              sublabel="Web Speech API · IndexedDB · VOICEVOX CORS"
+              chevron
               onClick={() => navigate('/poc')}
-              className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
-            >
-              <FlaskConical size={18} className="text-[var(--ios-blue)] shrink-0" />
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium">Phase 0 Validation</p>
-                <p className="text-xs text-muted-foreground">Web Speech API · IndexedDB · VOICEVOX CORS</p>
-              </div>
-              <ChevronRight size={16} className="text-muted-foreground shrink-0" />
-            </button>
+            />
           </GroupCard>
         </div>
 
@@ -387,27 +378,29 @@ export default function SettingsPage() {
           <SectionLabel label="説明" />
           <GroupCard>
             <Row className="space-y-3">
-              <div>
-                <p className="text-sm font-medium mb-0.5">英語・日本語それぞれの音声を個別に設定できます。</p>
-                <p className="text-xs text-muted-foreground">
-                  英語音声: デフォルト/女性/男性/ずんだもん から選択<br />
-                  日本語音声: ずんだもん/デフォルト から選択
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium mb-0.5">OpenAI APIキーを設定すると、単語追加時に自動で例文を生成できます。</p>
-                <p className="text-xs text-muted-foreground">APIキーはOpenAIのウェブサイトで取得できます。</p>
-              </div>
-              <div>
-                <p className="text-sm font-medium mb-0.5">AIモデルは精度やコストに応じて選択できます。</p>
-                <p className="text-xs text-muted-foreground">
-                  GPT-4o miniは高速で低コスト、GPT-4oは高性能です。
-                </p>
-              </div>
-              <div>
-                <p className="text-sm font-medium mb-0.5">例文の条件は「プリセット管理」から選択・編集できます。</p>
-                <p className="text-xs text-muted-foreground">組み込みプリセットはデフォルトに戻すことができます。</p>
-              </div>
+              {[
+                {
+                  title: '英語・日本語それぞれの音声を個別に設定できます。',
+                  body: '英語音声: デフォルト/女性/男性/ずんだもん から選択\n日本語音声: ずんだもん/デフォルト から選択',
+                },
+                {
+                  title: 'OpenAI APIキーを設定すると、単語追加時に自動で例文を生成できます。',
+                  body: 'APIキーはOpenAIのウェブサイトで取得できます。',
+                },
+                {
+                  title: 'AIモデルは精度やコストに応じて選択できます。',
+                  body: 'GPT-4o miniは高速で低コスト、GPT-4oは高性能です。',
+                },
+                {
+                  title: '例文の条件は「プリセット管理」から選択・編集できます。',
+                  body: '組み込みプリセットはデフォルトに戻すことができます。',
+                },
+              ].map(({ title, body }) => (
+                <div key={title}>
+                  <p className="text-sm font-medium mb-0.5">{title}</p>
+                  <p className="text-xs text-muted-foreground whitespace-pre-line">{body}</p>
+                </div>
+              ))}
             </Row>
           </GroupCard>
         </div>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,6 +1,18 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router'
-import { ChevronRight, FlaskConical, TriangleAlert } from 'lucide-react'
+import {
+  ChevronRight,
+  FlaskConical,
+  Volume2,
+  Upload,
+  Download,
+  Trash2,
+  FileText,
+  Shield,
+  CheckCircle2,
+  TriangleAlert,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
 
@@ -14,44 +26,52 @@ const VOICEVOX_STYLES = [
   { id: '38', label: 'ヒソヒソ' },
 ]
 
-// Matches iOS OpenAI model options
 const OPENAI_MODELS = [
   { id: 'gpt-4o-mini', label: 'GPT-4o mini（高速・低コスト）' },
   { id: 'gpt-4o',      label: 'GPT-4o' },
   { id: 'gpt-4.1-mini',label: 'GPT-4.1 mini' },
 ]
 
-const PRESET_LABELS: Record<string, string> = {
-  general: '一般',
-  business: 'ビジネス',
-  academic: '学術',
-}
+const EN_VOICES = ['デフォルト', '女性', '男性', 'ずんだもん'] as const
+const JA_VOICES = ['ずんだもん', 'デフォルト'] as const
+const PLAY_PATTERNS = ['バイリンガル (EN+JA)', '英語のみ (EN+EN)'] as const
+
+type EnVoice = typeof EN_VOICES[number]
+type JaVoice = typeof JA_VOICES[number]
+type PlayPattern = typeof PLAY_PATTERNS[number]
+
+// --- Sub components ---
 
 function SectionLabel({ label }: { label: string }) {
-  return (
-    <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">{label}</p>
-  )
+  return <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">{label}</p>
 }
 
-function GroupCard({ children, className }: { children: React.ReactNode; className?: string }) {
+function GroupCard({ children }: { children: React.ReactNode }) {
   return (
-    <div className={cn('bg-white rounded-2xl divide-y divide-border overflow-hidden', className)}>
+    <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
       {children}
     </div>
   )
 }
 
-function Row({ children }: { children: React.ReactNode }) {
-  return <div className="px-4 py-3">{children}</div>
+function Row({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('px-4 py-3', className)}>{children}</div>
 }
 
-function NavRow({ label, value, onClick }: { label: string; value?: string; onClick?: () => void }) {
+function NavRow({ label, value, onClick, icon: Icon, iconColor }: {
+  label: string
+  value?: string
+  onClick?: () => void
+  icon?: React.ElementType
+  iconColor?: string
+}) {
   return (
     <button
       onClick={onClick}
-      className="w-full flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
     >
-      <span className="text-sm">{label}</span>
+      {Icon && <Icon size={18} className={cn('shrink-0', iconColor ?? 'text-[var(--ios-blue)]')} />}
+      <span className="flex-1 text-sm">{label}</span>
       <div className="flex items-center gap-1 text-muted-foreground">
         {value && <span className="text-sm">{value}</span>}
         <ChevronRight size={16} />
@@ -60,14 +80,97 @@ function NavRow({ label, value, onClick }: { label: string; value?: string; onCl
   )
 }
 
+function ActionRow({ label, onClick, icon: Icon, iconColor, destructive }: {
+  label: string
+  onClick?: () => void
+  icon?: React.ElementType
+  iconColor?: string
+  destructive?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-full flex items-center gap-3 px-4 py-3 hover:bg-muted/50 transition-colors text-left"
+    >
+      {Icon && <Icon size={18} className={cn('shrink-0', iconColor ?? 'text-[var(--ios-blue)]')} />}
+      <span className={cn('flex-1 text-sm', destructive ? 'text-[var(--ios-red)]' : 'text-[var(--ios-blue)]')}>
+        {label}
+      </span>
+    </button>
+  )
+}
+
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly T[]
+  value: T
+  onChange: (v: T) => void
+}) {
+  return (
+    <div className="flex bg-muted rounded-lg p-0.5 gap-0.5">
+      {options.map((opt) => (
+        <button
+          key={opt}
+          onClick={() => onChange(opt)}
+          className={cn(
+            'flex-1 text-xs font-medium py-1.5 px-2 rounded-md transition-all',
+            value === opt
+              ? 'bg-white text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// --- Main ---
+
 export default function SettingsPage() {
   const navigate = useNavigate()
 
-  const [openAIKey, setOpenAIKey] = useState('')
+  const [enVoice, setEnVoice] = useState<EnVoice>('デフォルト')
+  const [jaVoice, setJaVoice] = useState<JaVoice>('ずんだもん')
+  const [playPattern, setPlayPattern] = useState<PlayPattern>('バイリンガル (EN+JA)')
+  const [interval, setInterval] = useState(1.5)
+
   const [voicevoxStyle, setVoicevoxStyle] = useState('22')
   const [voicevoxKey, setVoicevoxKey] = useState('')
+
+  const [openAIKey, setOpenAIKey] = useState('')
   const [openAIModel, setOpenAIModel] = useState('gpt-4o-mini')
-  const [preset] = useState('general')
+
+  const [ttsStatus, setTtsStatus] = useState<'idle' | 'playing'>('idle')
+
+  function playEnSample() {
+    window.speechSynthesis.cancel()
+    setTtsStatus('playing')
+    const utt = new SpeechSynthesisUtterance('This is a sample of the English voice.')
+    utt.lang = 'en-US'
+    utt.onend = () => setTtsStatus('idle')
+    utt.onerror = () => setTtsStatus('idle')
+    window.speechSynthesis.speak(utt)
+  }
+
+  function playJaSample() {
+    window.speechSynthesis.cancel()
+    setTtsStatus('playing')
+    const utt = new SpeechSynthesisUtterance('これは日本語の音声サンプルです。')
+    utt.lang = 'ja-JP'
+    utt.onend = () => setTtsStatus('idle')
+    utt.onerror = () => setTtsStatus('idle')
+    window.speechSynthesis.speak(utt)
+  }
+
+  const patternDesc =
+    playPattern === 'バイリンガル (EN+JA)'
+      ? 'バイリンガル: 英語 → 日本語 → 英語 の順で再生します'
+      : '英語のみ: 英語のみ 2 回繰り返します'
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-4">
@@ -77,18 +180,71 @@ export default function SettingsPage() {
 
       <div className="mt-4 space-y-6">
 
-        {/* OpenAI API設定 */}
+        {/* 英語の音声設定 */}
         <div>
-          <SectionLabel label="OpenAI API設定" />
+          <SectionLabel label="英語の音声設定" />
           <GroupCard>
             <Row>
-              <Input
-                type="password"
-                placeholder="APIキー"
-                value={openAIKey}
-                onChange={(e) => setOpenAIKey(e.target.value)}
-                className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
+              <SegmentedControl options={EN_VOICES} value={enVoice} onChange={setEnVoice} />
+            </Row>
+            <Row>
+              <Button
+                className="w-full bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90 text-white"
+                onClick={playEnSample}
+                disabled={ttsStatus === 'playing'}
+              >
+                <Volume2 size={16} className="mr-1.5" />
+                英語サンプルを再生
+              </Button>
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* 日本語の音声設定 */}
+        <div>
+          <SectionLabel label="日本語の音声設定" />
+          <GroupCard>
+            <Row>
+              <SegmentedControl options={JA_VOICES} value={jaVoice} onChange={setJaVoice} />
+            </Row>
+            <Row>
+              <Button
+                className="w-full bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90 text-white"
+                onClick={playJaSample}
+                disabled={ttsStatus === 'playing'}
+              >
+                <Volume2 size={16} className="mr-1.5" />
+                日本語サンプルを再生
+              </Button>
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* 連続再生設定 */}
+        <div>
+          <SectionLabel label="連続再生設定" />
+          <GroupCard>
+            <Row>
+              <SegmentedControl options={PLAY_PATTERNS} value={playPattern} onChange={setPlayPattern} />
+            </Row>
+            <Row>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm">例文間の間隔</span>
+                <span className="text-sm text-muted-foreground">{interval.toFixed(1)}秒</span>
+              </div>
+              <input
+                type="range"
+                min={0.5}
+                max={5.0}
+                step={0.5}
+                value={interval}
+                onChange={(e) => setInterval(Number(e.target.value))}
+                className="w-full accent-[var(--ios-blue)]"
               />
+            </Row>
+            <Row>
+              <p className="text-xs text-muted-foreground">連続再生時の音声パターンを選択できます</p>
+              <p className="text-xs text-muted-foreground mt-1">{patternDesc}</p>
             </Row>
           </GroupCard>
         </div>
@@ -97,7 +253,6 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="VOICEVOX設定" />
           <GroupCard>
-            {/* スタイル */}
             <Row>
               <div className="flex items-center justify-between">
                 <span className="text-sm">スタイル</span>
@@ -112,8 +267,6 @@ export default function SettingsPage() {
                 </select>
               </div>
             </Row>
-
-            {/* APIキー */}
             <Row>
               <Input
                 type="password"
@@ -131,10 +284,30 @@ export default function SettingsPage() {
                 </div>
               )}
             </Row>
-
-            {/* クレジット */}
             <Row>
               <p className="text-xs text-muted-foreground">© VOICEVOX:ずんだもん</p>
+            </Row>
+          </GroupCard>
+        </div>
+
+        {/* OpenAI API設定 */}
+        <div>
+          <SectionLabel label="OpenAI API設定" />
+          <GroupCard>
+            <Row>
+              <Input
+                type="password"
+                placeholder="APIキー"
+                value={openAIKey}
+                onChange={(e) => setOpenAIKey(e.target.value)}
+                className="border-0 shadow-none px-0 focus-visible:ring-0 text-sm"
+              />
+              {openAIKey && (
+                <div className="flex items-center gap-1.5 mt-1.5">
+                  <CheckCircle2 size={13} className="text-[var(--ios-green)] shrink-0" />
+                  <p className="text-xs text-[var(--ios-green)]">APIキーが設定されています</p>
+                </div>
+              )}
             </Row>
           </GroupCard>
         </div>
@@ -162,7 +335,32 @@ export default function SettingsPage() {
         <div>
           <SectionLabel label="例文生成の条件" />
           <GroupCard>
-            <NavRow label="プリセット管理" value={PRESET_LABELS[preset]} />
+            <NavRow label="プリセット管理" value="一般" />
+          </GroupCard>
+        </div>
+
+        {/* データ管理 */}
+        <div>
+          <SectionLabel label="データ管理" />
+          <GroupCard>
+            <ActionRow label="単語リストをエクスポート" icon={Upload} />
+            <ActionRow label="単語リストをインポート" icon={Download} />
+            <Row>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">音声キャッシュ</span>
+                <span className="text-sm text-muted-foreground">0バイト</span>
+              </div>
+            </Row>
+            <ActionRow label="キャッシュをクリア" icon={Trash2} iconColor="text-[var(--ios-red)]" destructive />
+          </GroupCard>
+        </div>
+
+        {/* 法的情報 */}
+        <div>
+          <SectionLabel label="法的情報" />
+          <GroupCard>
+            <NavRow label="プライバシーポリシー" icon={Shield} />
+            <NavRow label="利用規約" icon={FileText} />
           </GroupCard>
         </div>
 
@@ -181,6 +379,36 @@ export default function SettingsPage() {
               </div>
               <ChevronRight size={16} className="text-muted-foreground shrink-0" />
             </button>
+          </GroupCard>
+        </div>
+
+        {/* 説明 */}
+        <div>
+          <SectionLabel label="説明" />
+          <GroupCard>
+            <Row className="space-y-3">
+              <div>
+                <p className="text-sm font-medium mb-0.5">英語・日本語それぞれの音声を個別に設定できます。</p>
+                <p className="text-xs text-muted-foreground">
+                  英語音声: デフォルト/女性/男性/ずんだもん から選択<br />
+                  日本語音声: ずんだもん/デフォルト から選択
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium mb-0.5">OpenAI APIキーを設定すると、単語追加時に自動で例文を生成できます。</p>
+                <p className="text-xs text-muted-foreground">APIキーはOpenAIのウェブサイトで取得できます。</p>
+              </div>
+              <div>
+                <p className="text-sm font-medium mb-0.5">AIモデルは精度やコストに応じて選択できます。</p>
+                <p className="text-xs text-muted-foreground">
+                  GPT-4o miniは高速で低コスト、GPT-4oは高性能です。
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium mb-0.5">例文の条件は「プリセット管理」から選択・編集できます。</p>
+                <p className="text-xs text-muted-foreground">組み込みプリセットはデフォルトに戻すことができます。</p>
+              </div>
+            </Row>
           </GroupCard>
         </div>
 


### PR DESCRIPTION
## Summary

- Full Settings page implementation matching iOS `SettingsView`
- **英語の音声設定**: segmented control (デフォルト/女性/男性/ずんだもん) + EN sample TTS playback
  - デフォルト and 女性 resolve to the same female voice (by name match)
  - 男性 resolves by `/male/i` name match excluding female
  - ずんだもん routes to VOICEVOX API
- **日本語の音声設定**: segmented control (ずんだもん/デフォルト) + JA sample TTS playback
- **連続再生設定**: playback pattern selector + 例文間の間隔 slider
- **VOICEVOX設定**: style selector + API key input + AppConfig warning + © credit
- **OpenAI API設定**: key input + green ✓ confirmation when set
- **AIモデル設定**: model dropdown
- **例文生成の条件**: プリセット管理 nav row
- **データ管理**: export / import / cache size / clear cache
- **法的情報**: privacy policy / terms rows
- **Developer Tools**: link to \`/poc\` validation page
- **説明**: explanation text block
- Refactor: `NavRow`/`ActionRow` unified into `ListRow`; `playSample` deduplicates EN/JA TTS logic

## Test plan

- [x] `npm run dev` → open Settings tab
- [x] EN voice: デフォルト/女性 → same female voice plays; 男性 → male voice plays
- [x] EN/JA ずんだもん → VOICEVOX WAV plays (requires env vars)
- [x] 例文間の間隔 slider updates value display
- [x] OpenAI key input → green confirmation appears
- [x] Developer Tools row → navigates to \`/#/poc\`

Closes #133