### PR TITLE
feat: add SentenceListPage with per-sentence TTS playback

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router'
 import AppLayout from '@/components/layout/AppLayout'
 import WordListPage from '@/pages/WordListPage'
+import SentenceListPage from '@/pages/SentenceListPage'
 import ArchivePage from '@/pages/ArchivePage'
 import AddPage from '@/pages/AddPage'
 import TrashPage from '@/pages/TrashPage'
@@ -12,6 +13,7 @@ function App() {
     <Routes>
       <Route element={<AppLayout />}>
         <Route path="/" element={<WordListPage />} />
+        <Route path="/words/:id/sentences" element={<SentenceListPage />} />
         <Route path="/archive" element={<ArchivePage />} />
         <Route path="/add" element={<AddPage />} />
         <Route path="/trash" element={<TrashPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import ArchivePage from '@/pages/ArchivePage'
 import AddPage from '@/pages/AddPage'
 import TrashPage from '@/pages/TrashPage'
 import SettingsPage from '@/pages/SettingsPage'
+import PronunciationPage from '@/pages/PronunciationPage'
 import PocPage from '@/pages/PocPage'
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
       <Route element={<AppLayout />}>
         <Route path="/" element={<WordListPage />} />
         <Route path="/words/:id/sentences" element={<SentenceListPage />} />
+        <Route path="/words/:id/pronunciation/:sentenceId" element={<PronunciationPage />} />
         <Route path="/archive" element={<ArchivePage />} />
         <Route path="/add" element={<AddPage />} />
         <Route path="/trash" element={<TrashPage />} />

--- a/web/src/data/sampleWords.ts
+++ b/web/src/data/sampleWords.ts
@@ -1,0 +1,98 @@
+export interface Sentence {
+  id: string
+  english: string
+  japanese: string
+  category: string
+}
+
+export interface Word {
+  id: string
+  word: string
+  meaning: string
+  phonetic: string
+  sentences: Sentence[]
+}
+
+export const SAMPLE_WORDS: Word[] = [
+  {
+    id: '1',
+    word: 'rarity',
+    meaning: '珍しさ・希少性',
+    phonetic: 'ˈreər.ɪ.ti',
+    sentences: [
+      { id: '1-1', english: 'True friendship is a rarity in this world.', japanese: '本当の友情はこの世では珍しいものだ。', category: '一般的な使い方' },
+      { id: '1-2', english: 'Snow is a rarity in this region.', japanese: 'この地域では雪は珍しい。', category: '一般的な使い方' },
+      { id: '1-3', english: 'Kindness like hers is a rarity these days.', japanese: '彼女のような優しさは、今では稀だ。', category: '一般的な使い方' },
+      { id: '1-4', english: 'This antique watch is a true rarity.', japanese: 'このアンティーク時計は本当に希少品だ。', category: 'コレクション・骨董' },
+      { id: '1-5', english: 'Such talent is a rarity among young athletes.', japanese: 'そのような才能は若いアスリートの中では珍しい。', category: 'スポーツ' },
+    ],
+  },
+  {
+    id: '2',
+    word: 'experience',
+    meaning: '経験、体験',
+    phonetic: 'ɪkˈspɪər.i.əns',
+    sentences: [
+      { id: '2-1', english: 'I had a wonderful experience during my trip to Italy.', japanese: 'イタリア旅行中に素晴らしい体験をした。', category: '一般的な経験' },
+      { id: '2-2', english: 'Experience is the best teacher.', japanese: '経験は最良の教師である。', category: '教育・人生の教訓' },
+      { id: '2-3', english: 'She has ten years of experience in marketing.', japanese: '彼女はマーケティングで10年の経験がある。', category: 'ビジネス・キャリア' },
+      { id: '2-4', english: 'The near-death experience changed his perspective on life.', japanese: '臨死体験が人生への見方を変えた。', category: '特別な体験' },
+      { id: '2-5', english: 'This… is my Stand! Gold Experience!', japanese: 'これが……オレのスタンド！「ゴールド・エクスペリエンス」だッ！', category: 'Gold Experience' },
+    ],
+  },
+  {
+    id: '3',
+    word: 'perspective',
+    meaning: '視点・観点',
+    phonetic: 'pəˈspek.tɪv',
+    sentences: [
+      { id: '3-1', english: 'Try to see things from a different perspective.', japanese: '物事を別の視点から見てみよう。', category: '思考・考え方' },
+      { id: '3-2', english: 'Travel broadens your perspective on the world.', japanese: '旅行すると世界に対する視野が広がる。', category: '旅行・文化' },
+      { id: '3-3', english: 'Keep things in perspective — it\'s not the end of the world.', japanese: 'バランスを保って — 世界の終わりじゃない。', category: 'アドバイス' },
+    ],
+  },
+  {
+    id: '4',
+    word: 'accomplish',
+    meaning: '達成する・成し遂げる',
+    phonetic: 'əˈkʌm.plɪʃ',
+    sentences: [
+      { id: '4-1', english: 'She accomplished her goal of running a marathon.', japanese: '彼女はマラソンを走るという目標を達成した。', category: '目標・達成' },
+      { id: '4-2', english: 'What do you hope to accomplish this year?', japanese: '今年は何を達成したいですか？', category: '目標・達成' },
+      { id: '4-3', english: 'Hard work and dedication will help you accomplish anything.', japanese: '努力と献身があればなんでも達成できる。', category: '励まし・モチベーション' },
+    ],
+  },
+  {
+    id: '5',
+    word: 'remarkable',
+    meaning: '注目すべき・素晴らしい',
+    phonetic: 'rɪˈmɑːk.ə.bəl',
+    sentences: [
+      { id: '5-1', english: 'The patient made a remarkable recovery.', japanese: '患者は驚くべき回復を見せた。', category: '医療・健康' },
+      { id: '5-2', english: 'It\'s remarkable how quickly children learn languages.', japanese: '子どもたちが言語を覚える早さは驚くほどだ。', category: '教育・子ども' },
+      { id: '5-3', english: 'She gave a remarkable performance on stage.', japanese: '彼女は舞台で素晴らしい演技を見せた。', category: '芸術・エンターテインメント' },
+    ],
+  },
+  {
+    id: '6',
+    word: 'challenge',
+    meaning: '挑戦・困難',
+    phonetic: 'ˈtʃæl.ɪndʒ',
+    sentences: [
+      { id: '6-1', english: 'Learning a new language is a challenging but rewarding experience.', japanese: '新しい言語を学ぶのは難しいが、やりがいのある体験だ。', category: '学習' },
+      { id: '6-2', english: 'I love a good challenge.', japanese: '良い挑戦は大好きだ。', category: '前向きな姿勢' },
+      { id: '6-3', english: 'The team faced many challenges during the project.', japanese: 'チームはプロジェクト中に多くの困難に直面した。', category: 'ビジネス' },
+    ],
+  },
+  {
+    id: '7',
+    word: 'opportunity',
+    meaning: '機会・チャンス',
+    phonetic: 'ˌɒp.əˈtjuː.nɪ.ti',
+    sentences: [
+      { id: '7-1', english: 'Don\'t miss this opportunity — it won\'t come again.', japanese: 'このチャンスを逃すな — 二度と来ないかもしれない。', category: 'アドバイス' },
+      { id: '7-2', english: 'Studying abroad is a great opportunity to grow.', japanese: '留学は成長する素晴らしい機会だ。', category: '留学・教育' },
+      { id: '7-3', english: 'Every challenge is an opportunity in disguise.', japanese: 'すべての困難は変装した機会だ。', category: '人生の教訓' },
+    ],
+  },
+]

--- a/web/src/pages/PronunciationPage.tsx
+++ b/web/src/pages/PronunciationPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import { useParams, useNavigate } from 'react-router'
+import { ChevronLeft, Volume2, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { playTTS, type VoiceType } from '@/services/AudioService'
+import { loadSettings } from '@/services/SettingsService'
+import { SAMPLE_WORDS } from '@/data/sampleWords'
+
+export default function PronunciationPage() {
+  const { id, sentenceId } = useParams<{ id: string; sentenceId: string }>()
+  const navigate = useNavigate()
+
+  const word = SAMPLE_WORDS.find((w) => w.id === id)
+  const sentence = word?.sentences.find((s) => s.id === sentenceId)
+
+  const [playingLang, setPlayingLang] = useState<'en' | 'ja' | null>(null)
+
+  if (!word || !sentence) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+        <p className="text-sm">例文が見つかりません</p>
+        <button
+          onClick={() => navigate(`/words/${id}/sentences`)}
+          className="mt-2 text-sm text-[var(--ios-blue)]"
+        >
+          例文一覧に戻る
+        </button>
+      </div>
+    )
+  }
+
+  async function play(lang: 'en' | 'ja') {
+    if (playingLang) return
+    setPlayingLang(lang)
+    const s = loadSettings()
+    const resolvedVvKey = s.voicevoxApiKey || (import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? '')
+    try {
+      await playTTS(lang === 'en' ? sentence!.english : sentence!.japanese, {
+        voice: (lang === 'en' ? s.enVoice : s.jaVoice) as VoiceType,
+        speakerId: s.voicevoxStyle,
+        apiKey: resolvedVvKey,
+        lang,
+      })
+    } catch (err) {
+      console.error('[PronunciationPage] playback failed:', err)
+    } finally {
+      setPlayingLang(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--ios-grouped-bg)]">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-[var(--ios-grouped-bg)] px-4 pt-4 pb-2 max-w-2xl mx-auto">
+        <div className="flex items-center gap-2 mb-3">
+          <button
+            onClick={() => navigate(`/words/${id}/sentences`)}
+            className="flex items-center gap-0.5 text-[var(--ios-blue)] text-sm font-medium"
+          >
+            <ChevronLeft size={18} />
+            例文一覧
+          </button>
+        </div>
+        <h1 className="text-xl font-bold text-center">発音練習</h1>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 pb-8 space-y-4">
+        {/* Sentence card */}
+        <div className="bg-white rounded-2xl px-6 py-8 text-center space-y-4">
+          <p className="text-lg font-semibold leading-relaxed">{sentence.english}</p>
+          <p className="text-sm text-muted-foreground leading-relaxed">{sentence.japanese}</p>
+
+          {/* TTS buttons */}
+          <div className="flex justify-center gap-3 pt-2">
+            {(['en', 'ja'] as const).map((lang) => {
+              const isPlaying = playingLang === lang
+              return (
+                <Button
+                  key={lang}
+                  size="sm"
+                  disabled={!!playingLang && !isPlaying}
+                  onClick={() => play(lang)}
+                  aria-label={
+                    isPlaying
+                      ? `再生を停止`
+                      : lang === 'en' ? '英語を聞く' : '日本語を聞く'
+                  }
+                  className={cn(
+                    'rounded-full px-4 text-white',
+                    lang === 'en'
+                      ? 'bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90'
+                      : 'bg-[var(--ios-orange)] hover:bg-[var(--ios-orange)]/90',
+                  )}
+                >
+                  {isPlaying
+                    ? <Loader2 size={14} className="animate-spin mr-1" />
+                    : <Volume2 size={14} className="mr-1" />}
+                  {lang === 'en' ? '英語を聞く' : '日本語を聞く'}
+                </Button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Word context */}
+        <div className="bg-white rounded-2xl px-4 py-3 text-sm text-muted-foreground text-center">
+          <span className="font-semibold text-foreground">{word.word}</span>
+          {' — '}
+          {word.meaning}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/web/src/pages/PronunciationPage.tsx
+++ b/web/src/pages/PronunciationPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router'
 import { ChevronLeft, Volume2, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
-import { playTTS, type VoiceType } from '@/services/AudioService'
+import { playTTS, stopTTS, type VoiceType } from '@/services/AudioService'
 import { loadSettings } from '@/services/SettingsService'
 import { SAMPLE_WORDS } from '@/data/sampleWords'
 
@@ -15,6 +15,11 @@ export default function PronunciationPage() {
   const sentence = word?.sentences.find((s) => s.id === sentenceId)
 
   const [playingLang, setPlayingLang] = useState<'en' | 'ja' | null>(null)
+
+  // Stop audio on unmount
+  useEffect(() => {
+    return () => { stopTTS() }
+  }, [])
 
   if (!word || !sentence) {
     return (
@@ -79,13 +84,9 @@ export default function PronunciationPage() {
                 <Button
                   key={lang}
                   size="sm"
-                  disabled={!!playingLang && !isPlaying}
+                  disabled={!!playingLang}
                   onClick={() => play(lang)}
-                  aria-label={
-                    isPlaying
-                      ? `再生を停止`
-                      : lang === 'en' ? '英語を聞く' : '日本語を聞く'
-                  }
+                  aria-label={lang === 'en' ? '英語を聞く' : '日本語を聞く'}
                   className={cn(
                     'rounded-full px-4 text-white',
                     lang === 'en'

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -38,6 +38,14 @@ export default function SentenceListPage() {
     sentenceRefs.current[playingId]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }, [playingId])
 
+  // Stop audio on unmount
+  useEffect(() => {
+    return () => {
+      cancelRef.current = true
+      stopTTS()
+    }
+  }, [])
+
   if (!word) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground">

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from 'react'
+import { useParams, useNavigate } from 'react-router'
+import { ChevronLeft, Volume2, Loader2, Play, Square } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import { playTTS, type VoiceType } from '@/services/AudioService'
+import { loadSettings } from '@/services/SettingsService'
+import { SAMPLE_WORDS, type Sentence } from '@/data/sampleWords'
+
+// ---- Helpers ----
+
+function groupByCategory(sentences: Sentence[]): [string, Sentence[]][] {
+  const map = new Map<string, Sentence[]>()
+  for (const s of sentences) {
+    const key = s.category || 'その他'
+    const arr = map.get(key) ?? []
+    arr.push(s)
+    map.set(key, arr)
+  }
+  return [...map.entries()].sort(([a], [b]) => a.localeCompare(b))
+}
+
+// ---- Page ----
+
+export default function SentenceListPage() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const word = SAMPLE_WORDS.find((w) => w.id === id)
+
+  const [playingId, setPlayingId]   = useState<string | null>(null) // sentence id or `word-en` / `word-ja`
+  const sentenceRefs = useRef<Record<string, HTMLDivElement | null>>({})
+
+  // Scroll active sentence into view
+  useEffect(() => {
+    if (!playingId || playingId.startsWith('word-')) return
+    sentenceRefs.current[playingId]?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }, [playingId])
+
+  if (!word) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+        <p className="text-sm">単語が見つかりません</p>
+        <button onClick={() => navigate('/')} className="mt-2 text-sm text-[var(--ios-blue)]">
+          一覧に戻る
+        </button>
+      </div>
+    )
+  }
+
+  const grouped = groupByCategory(word.sentences)
+  const s = loadSettings()
+  const resolvedVvKey = s.voicevoxApiKey || (import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? '')
+
+  async function playWord(lang: 'en' | 'ja') {
+    const key = `word-${lang}`
+    if (playingId) return
+    setPlayingId(key)
+    try {
+      await playTTS(lang === 'en' ? word!.word : word!.meaning, {
+        voice: (lang === 'en' ? s.enVoice : s.jaVoice) as VoiceType,
+        speakerId: s.voicevoxStyle,
+        apiKey: resolvedVvKey,
+        lang,
+      })
+    } catch (err) {
+      console.error('[SentenceListPage] word playback failed:', err)
+    } finally {
+      setPlayingId(null)
+    }
+  }
+
+  async function playSentence(sentence: Sentence) {
+    if (playingId) return
+    setPlayingId(sentence.id)
+    try {
+      await playTTS(sentence.english, {
+        voice: s.enVoice as VoiceType,
+        speakerId: s.voicevoxStyle,
+        apiKey: resolvedVvKey,
+        lang: 'en',
+      })
+    } catch (err) {
+      console.error('[SentenceListPage] sentence playback failed:', err)
+    } finally {
+      setPlayingId(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--ios-grouped-bg)]">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-[var(--ios-grouped-bg)] px-4 pt-4 pb-2 max-w-2xl mx-auto">
+        <div className="flex items-center gap-2 mb-3">
+          <button
+            onClick={() => navigate('/')}
+            className="flex items-center gap-0.5 text-[var(--ios-blue)] text-sm font-medium"
+          >
+            <ChevronLeft size={18} />
+            単語一覧
+          </button>
+        </div>
+        <h1 className="text-xl font-bold text-center">例文一覧</h1>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 pb-8 space-y-4">
+        {/* Word info card */}
+        <div className="bg-white rounded-2xl px-4 py-5 text-center space-y-1">
+          <p className="text-3xl font-bold tracking-tight">{word.word}</p>
+          <p className="text-sm text-muted-foreground font-mono">{word.phonetic}</p>
+          <p className="text-base text-[var(--ios-blue)]">{word.meaning}</p>
+          <div className="flex justify-center gap-3 pt-2">
+            {(['en', 'ja'] as const).map((lang) => {
+              const key = `word-${lang}`
+              const isPlaying = playingId === key
+              return (
+                <Button
+                  key={lang}
+                  size="sm"
+                  disabled={!!playingId}
+                  onClick={() => playWord(lang)}
+                  className={cn(
+                    'rounded-full px-4 text-white',
+                    lang === 'en'
+                      ? 'bg-[var(--ios-blue)] hover:bg-[var(--ios-blue)]/90'
+                      : 'bg-[var(--ios-orange)] hover:bg-[var(--ios-orange)]/90',
+                  )}
+                >
+                  {isPlaying
+                    ? <Loader2 size={14} className="animate-spin mr-1" />
+                    : <Volume2 size={14} className="mr-1" />}
+                  {lang === 'en' ? '英語を聞く' : '日本語を聞く'}
+                </Button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Sentences grouped by category */}
+        {grouped.map(([category, sentences]) => (
+          <div key={category}>
+            <p className="text-xs text-muted-foreground uppercase tracking-wide px-1 mb-1">
+              {category}
+            </p>
+            <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
+              {sentences.map((sentence) => {
+                const isPlaying = playingId === sentence.id
+                return (
+                  <div
+                    key={sentence.id}
+                    ref={(el) => { sentenceRefs.current[sentence.id] = el }}
+                    className={cn(
+                      'flex items-start gap-3 px-4 py-3 transition-colors',
+                      isPlaying && 'bg-[var(--ios-blue)]/8',
+                    )}
+                  >
+                    {/* Text */}
+                    <div className="flex-1 min-w-0 space-y-1">
+                      <p className={cn('text-sm leading-snug', isPlaying && 'font-medium text-[var(--ios-blue)]')}>
+                        {sentence.english}
+                      </p>
+                      <p className="text-xs text-muted-foreground leading-snug">
+                        {sentence.japanese}
+                      </p>
+                      <Badge
+                        variant="secondary"
+                        className="text-[10px] px-1.5 py-0 bg-[var(--ios-teal)]/15 text-[var(--ios-teal)] border-0"
+                      >
+                        {sentence.category}
+                      </Badge>
+                    </div>
+
+                    {/* Play button */}
+                    <button
+                      disabled={!!playingId && !isPlaying}
+                      onClick={() => playSentence(sentence)}
+                      className={cn(
+                        'shrink-0 mt-0.5 w-8 h-8 flex items-center justify-center rounded-full transition-colors',
+                        isPlaying
+                          ? 'bg-[var(--ios-blue)] text-white'
+                          : 'text-muted-foreground hover:bg-muted disabled:opacity-40',
+                      )}
+                    >
+                      {isPlaying
+                        ? <Square size={13} fill="currentColor" />
+                        : <Play size={13} fill="currentColor" />}
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+
+        <p className="text-center text-xs text-muted-foreground pt-2">
+          {word.sentences.length} 例文
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -80,6 +80,10 @@ export default function SentenceListPage() {
     }
   }
 
+  function sleep(sec: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, sec * 1000))
+  }
+
   async function startPlaybackFrom(startIndex: number) {
     if (playingId) { doStop(); return }
     cancelRef.current = false
@@ -94,6 +98,17 @@ export default function SentenceListPage() {
           apiKey: resolvedVvKey,
           lang: 'en',
         })
+        if (s.playPattern === 'bilingual' && !cancelRef.current) {
+          await sleep(s.intervalSec)
+          if (!cancelRef.current) {
+            await playTTS(sentence.japanese, {
+              voice: s.jaVoice as VoiceType,
+              speakerId: s.voicevoxStyle,
+              apiKey: resolvedVvKey,
+              lang: 'ja',
+            })
+          }
+        }
       } catch (err) {
         if (!cancelRef.current) console.error('[SentenceListPage] sentence playback failed:', err)
         break

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -4,7 +4,7 @@ import { ChevronLeft, Volume2, Loader2, Play, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import { playTTS, type VoiceType } from '@/services/AudioService'
+import { playTTS, stopTTS, type VoiceType } from '@/services/AudioService'
 import { loadSettings } from '@/services/SettingsService'
 import { SAMPLE_WORDS, type Sentence } from '@/data/sampleWords'
 
@@ -28,8 +28,9 @@ export default function SentenceListPage() {
   const navigate = useNavigate()
   const word = SAMPLE_WORDS.find((w) => w.id === id)
 
-  const [playingId, setPlayingId]   = useState<string | null>(null) // sentence id or `word-en` / `word-ja`
+  const [playingId, setPlayingId] = useState<string | null>(null) // sentence id or `word-en` / `word-ja`
   const sentenceRefs = useRef<Record<string, HTMLDivElement | null>>({})
+  const cancelRef = useRef(false)
 
   // Scroll active sentence into view
   useEffect(() => {
@@ -49,12 +50,21 @@ export default function SentenceListPage() {
   }
 
   const grouped = groupByCategory(word.sentences)
+  const flatSentences = grouped.flatMap(([, sents]) => sents)
   const s = loadSettings()
   const resolvedVvKey = s.voicevoxApiKey || (import.meta.env.VITE_VOICEVOX_API_KEY_POC ?? '')
 
+  function doStop() {
+    cancelRef.current = true
+    stopTTS()
+    setPlayingId(null)
+  }
+
   async function playWord(lang: 'en' | 'ja') {
     const key = `word-${lang}`
+    if (playingId === key) { doStop(); return }
     if (playingId) return
+    cancelRef.current = false
     setPlayingId(key)
     try {
       await playTTS(lang === 'en' ? word!.word : word!.meaning, {
@@ -64,28 +74,35 @@ export default function SentenceListPage() {
         lang,
       })
     } catch (err) {
-      console.error('[SentenceListPage] word playback failed:', err)
+      if (!cancelRef.current) console.error('[SentenceListPage] word playback failed:', err)
     } finally {
-      setPlayingId(null)
+      setPlayingId((prev) => (prev === key ? null : prev))
     }
   }
 
-  async function playSentence(sentence: Sentence) {
-    if (playingId) return
-    setPlayingId(sentence.id)
-    try {
-      await playTTS(sentence.english, {
-        voice: s.enVoice as VoiceType,
-        speakerId: s.voicevoxStyle,
-        apiKey: resolvedVvKey,
-        lang: 'en',
-      })
-    } catch (err) {
-      console.error('[SentenceListPage] sentence playback failed:', err)
-    } finally {
-      setPlayingId(null)
+  async function startPlaybackFrom(startIndex: number) {
+    if (playingId) { doStop(); return }
+    cancelRef.current = false
+    for (let i = startIndex; i < flatSentences.length; i++) {
+      if (cancelRef.current) break
+      const sentence = flatSentences[i]
+      setPlayingId(sentence.id)
+      try {
+        await playTTS(sentence.english, {
+          voice: s.enVoice as VoiceType,
+          speakerId: s.voicevoxStyle,
+          apiKey: resolvedVvKey,
+          lang: 'en',
+        })
+      } catch (err) {
+        if (!cancelRef.current) console.error('[SentenceListPage] sentence playback failed:', err)
+        break
+      }
     }
+    if (!cancelRef.current) setPlayingId(null)
   }
+
+  const isAnyPlaying = !!playingId
 
   return (
     <div className="min-h-screen bg-[var(--ios-grouped-bg)]">
@@ -117,8 +134,13 @@ export default function SentenceListPage() {
                 <Button
                   key={lang}
                   size="sm"
-                  disabled={!!playingId}
+                  disabled={isAnyPlaying && !isPlaying}
                   onClick={() => playWord(lang)}
+                  aria-label={
+                    isPlaying
+                      ? `「${lang === 'en' ? word.word : word.meaning}」の再生を停止`
+                      : lang === 'en' ? '英語を聞く' : '日本語を聞く'
+                  }
                   className={cn(
                     'rounded-full px-4 text-white',
                     lang === 'en'
@@ -133,6 +155,21 @@ export default function SentenceListPage() {
                 </Button>
               )
             })}
+            {/* Play all sentences button */}
+            <Button
+              size="sm"
+              disabled={isAnyPlaying && !playingId}
+              onClick={() => {
+                if (isAnyPlaying) { doStop(); return }
+                startPlaybackFrom(0)
+              }}
+              aria-label={isAnyPlaying ? '再生を停止' : '全例文を再生'}
+              className="rounded-full px-4 bg-[var(--ios-teal)] hover:bg-[var(--ios-teal)]/90 text-white"
+            >
+              {isAnyPlaying && !playingId?.startsWith('word-')
+                ? <><Square size={14} className="mr-1" fill="currentColor" />停止</>
+                : <><Play size={14} className="mr-1" fill="currentColor" />全て再生</>}
+            </Button>
           </div>
         </div>
 
@@ -145,12 +182,23 @@ export default function SentenceListPage() {
             <div className="bg-white rounded-2xl divide-y divide-border overflow-hidden">
               {sentences.map((sentence) => {
                 const isPlaying = playingId === sentence.id
+                const sentenceIndex = flatSentences.indexOf(sentence)
                 return (
                   <div
                     key={sentence.id}
                     ref={(el) => { sentenceRefs.current[sentence.id] = el }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`${sentence.english} — 発音練習へ`}
+                    onClick={() => navigate(`/words/${id}/pronunciation/${sentence.id}`)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        navigate(`/words/${id}/pronunciation/${sentence.id}`)
+                      }
+                    }}
                     className={cn(
-                      'flex items-start gap-3 px-4 py-3 transition-colors',
+                      'flex items-start gap-3 px-4 py-3 transition-colors cursor-pointer hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ios-blue)] focus-visible:ring-inset',
                       isPlaying && 'bg-[var(--ios-blue)]/8',
                     )}
                   >
@@ -170,10 +218,22 @@ export default function SentenceListPage() {
                       </Badge>
                     </div>
 
-                    {/* Play button */}
+                    {/* Play/Stop button */}
                     <button
-                      disabled={!!playingId && !isPlaying}
-                      onClick={() => playSentence(sentence)}
+                      aria-label={
+                        isPlaying
+                          ? `「${sentence.english}」の再生を停止`
+                          : `「${sentence.english}」を再生`
+                      }
+                      disabled={isAnyPlaying && !isPlaying}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (isPlaying) {
+                          doStop()
+                        } else {
+                          startPlaybackFrom(sentenceIndex)
+                        }
+                      }}
                       className={cn(
                         'shrink-0 mt-0.5 w-8 h-8 flex items-center justify-center rounded-full transition-colors',
                         isPlaying

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -112,24 +112,17 @@ export default function SentenceListPage() {
         if (cancelRef.current) break
 
         if (s.playPattern === 'bilingual') {
-          // EN → JA → EN
+          // EN → JA
           await playTTS(sentence.japanese, {
             voice: s.jaVoice as VoiceType,
             speakerId: s.voicevoxStyle,
             apiKey: resolvedVvKey,
             lang: 'ja',
           })
-          if (cancelRef.current) break
-          await sleep(s.intervalSec)
-          if (cancelRef.current) break
-          await playTTS(sentence.english, {
-            voice: s.enVoice as VoiceType,
-            speakerId: s.voicevoxStyle,
-            apiKey: resolvedVvKey,
-            lang: 'en',
-          })
         } else {
           // EN → EN
+          await sleep(s.intervalSec)
+          if (cancelRef.current) break
           await playTTS(sentence.english, {
             voice: s.enVoice as VoiceType,
             speakerId: s.voicevoxStyle,
@@ -209,7 +202,7 @@ export default function SentenceListPage() {
               aria-label={isAnyPlaying ? '再生を停止' : '全例文を再生'}
               className="rounded-full px-4 bg-[var(--ios-teal)] hover:bg-[var(--ios-teal)]/90 text-white"
             >
-              {isAnyPlaying && !playingId?.startsWith('word-')
+              {isAnyPlaying
                 ? <><Square size={14} className="mr-1" fill="currentColor" />停止</>
                 : <><Play size={14} className="mr-1" fill="currentColor" />全て再生</>}
             </Button>

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -92,22 +92,42 @@ export default function SentenceListPage() {
       const sentence = flatSentences[i]
       setPlayingId(sentence.id)
       try {
+        // 1st EN
         await playTTS(sentence.english, {
           voice: s.enVoice as VoiceType,
           speakerId: s.voicevoxStyle,
           apiKey: resolvedVvKey,
           lang: 'en',
         })
-        if (s.playPattern === 'bilingual' && !cancelRef.current) {
+        if (cancelRef.current) break
+        await sleep(s.intervalSec)
+        if (cancelRef.current) break
+
+        if (s.playPattern === 'bilingual') {
+          // EN → JA → EN
+          await playTTS(sentence.japanese, {
+            voice: s.jaVoice as VoiceType,
+            speakerId: s.voicevoxStyle,
+            apiKey: resolvedVvKey,
+            lang: 'ja',
+          })
+          if (cancelRef.current) break
           await sleep(s.intervalSec)
-          if (!cancelRef.current) {
-            await playTTS(sentence.japanese, {
-              voice: s.jaVoice as VoiceType,
-              speakerId: s.voicevoxStyle,
-              apiKey: resolvedVvKey,
-              lang: 'ja',
-            })
-          }
+          if (cancelRef.current) break
+          await playTTS(sentence.english, {
+            voice: s.enVoice as VoiceType,
+            speakerId: s.voicevoxStyle,
+            apiKey: resolvedVvKey,
+            lang: 'en',
+          })
+        } else {
+          // EN → EN
+          await playTTS(sentence.english, {
+            voice: s.enVoice as VoiceType,
+            speakerId: s.voicevoxStyle,
+            apiKey: resolvedVvKey,
+            lang: 'en',
+          })
         }
       } catch (err) {
         if (!cancelRef.current) console.error('[SentenceListPage] sentence playback failed:', err)

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -112,17 +112,24 @@ export default function SentenceListPage() {
         if (cancelRef.current) break
 
         if (s.playPattern === 'bilingual') {
-          // EN → JA
+          // EN → JA → EN
           await playTTS(sentence.japanese, {
             voice: s.jaVoice as VoiceType,
             speakerId: s.voicevoxStyle,
             apiKey: resolvedVvKey,
             lang: 'ja',
           })
-        } else {
-          // EN → EN
+          if (cancelRef.current) break
           await sleep(s.intervalSec)
           if (cancelRef.current) break
+          await playTTS(sentence.english, {
+            voice: s.enVoice as VoiceType,
+            speakerId: s.voicevoxStyle,
+            apiKey: resolvedVvKey,
+            lang: 'en',
+          })
+        } else {
+          // EN → EN
           await playTTS(sentence.english, {
             voice: s.enVoice as VoiceType,
             speakerId: s.voicevoxStyle,

--- a/web/src/pages/SentenceListPage.tsx
+++ b/web/src/pages/SentenceListPage.tsx
@@ -257,7 +257,7 @@ export default function SentenceListPage() {
                         variant="secondary"
                         className="text-[10px] px-1.5 py-0 bg-[var(--ios-teal)]/15 text-[var(--ios-teal)] border-0"
                       >
-                        {sentence.category}
+                        {sentence.category || 'その他'}
                       </Badge>
                     </div>
 
@@ -269,6 +269,17 @@ export default function SentenceListPage() {
                           : `「${sentence.english}」を再生`
                       }
                       disabled={isAnyPlaying && !isPlaying}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          e.stopPropagation()
+                          if (isPlaying) {
+                            doStop()
+                          } else {
+                            startPlaybackFrom(sentenceIndex)
+                          }
+                        }
+                      }}
                       onClick={(e) => {
                         e.stopPropagation()
                         if (isPlaying) {

--- a/web/src/pages/WordListPage.tsx
+++ b/web/src/pages/WordListPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -6,23 +7,15 @@ import { cn } from '@/lib/utils'
 import { Volume2, Loader2 } from 'lucide-react'
 import { playTTS, type VoiceType } from '@/services/AudioService'
 import { loadSettings } from '@/services/SettingsService'
+import { SAMPLE_WORDS } from '@/data/sampleWords'
 
 const appVersion = import.meta.env.VITE_APP_VERSION ?? '—'
 const appEnv = import.meta.env.VITE_APP_ENV ?? '—'
 
-const SAMPLE_WORDS = [
-  { id: '1', word: 'rarity',      meaning: '珍しさ・希少性',          phonetic: 'ˈreər.ɪ.ti',        sentences: 30 },
-  { id: '2', word: 'experience',  meaning: '経験、体験',              phonetic: 'ɪkˈspɪər.i.əns',    sentences: 40 },
-  { id: '3', word: 'perspective', meaning: '視点・観点',              phonetic: 'pəˈspek.tɪv',        sentences: 12 },
-  { id: '4', word: 'accomplish',  meaning: '達成する・成し遂げる',    phonetic: 'əˈkʌm.plɪʃ',         sentences: 12 },
-  { id: '5', word: 'remarkable',  meaning: '注目すべき・素晴らしい',  phonetic: 'rɪˈmɑːk.ə.bəl',      sentences: 10 },
-  { id: '6', word: 'challenge',   meaning: '挑戦・困難',              phonetic: 'ˈtʃæl.ɪndʒ',         sentences: 12 },
-  { id: '7', word: 'opportunity', meaning: '機会・チャンス',          phonetic: 'ˌɒp.əˈtjuː.nɪ.ti',  sentences: 12 },
-]
-
 const LETTERS = ['ALL', ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')]
 
 export default function WordListPage() {
+  const navigate = useNavigate()
   const [search, setSearch] = useState('')
   const [activeLetter, setActiveLetter] = useState('ALL')
   const [playingId, setPlayingId] = useState<string | null>(null) // `${id}-en` | `${id}-ja`
@@ -38,7 +31,8 @@ export default function WordListPage() {
     return matchesSearch && matchesLetter
   })
 
-  async function play(id: string, text: string, lang: 'en' | 'ja') {
+  async function play(id: string, text: string, lang: 'en' | 'ja', e: React.MouseEvent) {
+    e.stopPropagation()
     const key = `${id}-${lang}`
     if (playingId) return
     setPlayingId(key)
@@ -98,7 +92,7 @@ export default function WordListPage() {
 
         {/* Stats row */}
         <p className="text-xs text-muted-foreground mt-2">
-          {filtered.length} 単語 · {filtered.reduce((s, w) => s + w.sentences, 0)} 例文
+          {filtered.length} 単語 · {filtered.reduce((s, w) => s + w.sentences.length, 0)} 例文
         </p>
       </header>
 
@@ -110,6 +104,7 @@ export default function WordListPage() {
           filtered.map((word) => (
             <div
               key={word.id}
+              onClick={() => navigate(`/words/${word.id}/sentences`)}
               className="bg-white rounded-2xl px-4 py-3 flex items-center gap-3 cursor-pointer active:opacity-70 transition-opacity"
             >
               {/* Left: text info */}
@@ -120,7 +115,7 @@ export default function WordListPage() {
                     variant="secondary"
                     className="text-[10px] px-1.5 py-0 bg-[var(--ios-orange)]/15 text-[var(--ios-orange)] border-0"
                   >
-                    {word.sentences}
+                    {word.sentences.length}
                   </Badge>
                 </div>
                 <p className="text-[11px] text-muted-foreground font-mono mt-0.5">{word.phonetic}</p>
@@ -138,7 +133,7 @@ export default function WordListPage() {
                       size="sm"
                       variant="ghost"
                       disabled={!!playingId}
-                      onClick={() => play(word.id, lang === 'en' ? word.word : word.meaning, lang)}
+                      onClick={(e) => play(word.id, lang === 'en' ? word.word : word.meaning, lang, e)}
                       className={cn(
                         'h-8 px-2 rounded-lg',
                         lang === 'en'

--- a/web/src/pages/WordListPage.tsx
+++ b/web/src/pages/WordListPage.tsx
@@ -104,8 +104,17 @@ export default function WordListPage() {
           filtered.map((word) => (
             <div
               key={word.id}
+              role="button"
+              tabIndex={0}
+              aria-label={`${word.word} — 例文一覧へ`}
               onClick={() => navigate(`/words/${word.id}/sentences`)}
-              className="bg-white rounded-2xl px-4 py-3 flex items-center gap-3 cursor-pointer active:opacity-70 transition-opacity"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  navigate(`/words/${word.id}/sentences`)
+                }
+              }}
+              className="bg-white rounded-2xl px-4 py-3 flex items-center gap-3 cursor-pointer active:opacity-70 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ios-blue)]"
             >
               {/* Left: text info */}
               <div className="flex-1 min-w-0">

--- a/web/src/services/AudioService.ts
+++ b/web/src/services/AudioService.ts
@@ -97,7 +97,11 @@ function playBlob(blob: Blob): Promise<void> {
     _currentAudio = audio
     audio.onended = () => { _currentAudio = null; URL.revokeObjectURL(url); resolve() }
     audio.onerror = () => { _currentAudio = null; URL.revokeObjectURL(url); reject(new Error('Audio playback failed')) }
-    audio.play().catch(reject)
+    audio.play().catch((err) => {
+      _currentAudio = null
+      URL.revokeObjectURL(url)
+      reject(err)
+    })
   })
 }
 

--- a/web/src/services/AudioService.ts
+++ b/web/src/services/AudioService.ts
@@ -27,24 +27,37 @@ export type PlaySource = 'cache' | 'voicevox' | 'webspeech'
 
 // ---- Web Speech API helpers ----
 
-function getEnVoice(type: VoiceType): SpeechSynthesisVoice | null {
-  const voices = window.speechSynthesis.getVoices().filter((v) => v.lang.startsWith('en'))
+function loadVoices(): Promise<SpeechSynthesisVoice[]> {
+  return new Promise((resolve) => {
+    const voices = window.speechSynthesis.getVoices()
+    if (voices.length > 0) { resolve(voices); return }
+    window.speechSynthesis.addEventListener(
+      'voiceschanged',
+      () => resolve(window.speechSynthesis.getVoices()),
+      { once: true },
+    )
+  })
+}
+
+function pickEnVoice(voices: SpeechSynthesisVoice[], type: VoiceType): SpeechSynthesisVoice | null {
+  const en = voices.filter((v) => v.lang.startsWith('en'))
   if (type === 'female' || type === 'default') {
-    return voices.find((v) => /female/i.test(v.name)) ?? null
+    return en.find((v) => /female/i.test(v.name)) ?? null
   }
   if (type === 'male') {
-    return voices.find((v) => /male/i.test(v.name) && !/female/i.test(v.name)) ?? null
+    return en.find((v) => /male/i.test(v.name) && !/female/i.test(v.name)) ?? null
   }
   return null
 }
 
-function speakWebSpeech(text: string, lang: 'en' | 'ja', voice: VoiceType): Promise<void> {
+async function speakWebSpeech(text: string, lang: 'en' | 'ja', voice: VoiceType): Promise<void> {
+  const voices = await loadVoices()
   return new Promise((resolve, reject) => {
     window.speechSynthesis.cancel()
     const utt = new SpeechSynthesisUtterance(text)
     utt.lang = lang === 'en' ? 'en-US' : 'ja-JP'
     if (lang === 'en') {
-      const v = getEnVoice(voice)
+      const v = pickEnVoice(voices, voice)
       if (v) utt.voice = v
     }
     utt.onend = () => resolve()

--- a/web/src/services/AudioService.ts
+++ b/web/src/services/AudioService.ts
@@ -88,14 +88,27 @@ async function fetchVoicevoxWav(
   }
 }
 
+let _currentAudio: HTMLAudioElement | null = null
+
 function playBlob(blob: Blob): Promise<void> {
   return new Promise((resolve, reject) => {
     const url = URL.createObjectURL(blob)
     const audio = new Audio(url)
-    audio.onended = () => { URL.revokeObjectURL(url); resolve() }
-    audio.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Audio playback failed')) }
+    _currentAudio = audio
+    audio.onended = () => { _currentAudio = null; URL.revokeObjectURL(url); resolve() }
+    audio.onerror = () => { _currentAudio = null; URL.revokeObjectURL(url); reject(new Error('Audio playback failed')) }
     audio.play().catch(reject)
   })
+}
+
+/** Stop any currently playing TTS audio immediately. */
+export function stopTTS(): void {
+  window.speechSynthesis.cancel()
+  if (_currentAudio) {
+    _currentAudio.pause()
+    _currentAudio.src = ''
+    _currentAudio = null
+  }
 }
 
 // ---- Public API ----

--- a/web/src/test/App.test.tsx
+++ b/web/src/test/App.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react'
 import { HashRouter } from 'react-router'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import App from '@/App'
+
+vi.mock('@/services/AudioService', () => ({
+  playTTS: vi.fn().mockResolvedValue('webspeech'),
+  stopTTS: vi.fn(),
+}))
 
 describe('App', () => {
   it('renders the word list page heading', () => {
@@ -10,6 +15,6 @@ describe('App', () => {
         <App />
       </HashRouter>,
     )
-    expect(screen.getByText('English Learn App')).toBeInTheDocument()
+    expect(screen.getByText('単語一覧')).toBeInTheDocument()
   })
 })

--- a/web/src/test/AudioService.test.ts
+++ b/web/src/test/AudioService.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock IndexedDB cache so AudioService can be imported in jsdom
+vi.mock('@/services/AudioCacheService', () => ({
+  getCache: vi.fn().mockResolvedValue(null),
+  putCache: vi.fn().mockResolvedValue(undefined),
+  makeCacheKey: vi.fn().mockResolvedValue('key'),
+  evictCache: vi.fn().mockResolvedValue(undefined),
+}))
+
+describe('stopTTS', () => {
+  beforeEach(() => {
+    vi.stubGlobal('speechSynthesis', {
+      cancel: vi.fn(),
+      speak: vi.fn(),
+      getVoices: () => [],
+    })
+  })
+
+  it('calls speechSynthesis.cancel()', async () => {
+    const { stopTTS } = await import('@/services/AudioService')
+    stopTTS()
+    expect(window.speechSynthesis.cancel).toHaveBeenCalledOnce()
+  })
+
+  it('pauses and nulls out a playing HTMLAudioElement', async () => {
+    const pause = vi.fn()
+    const mockAudio = { pause, src: 'blob:fake' } as unknown as HTMLAudioElement
+
+    // Inject the private _currentAudio by constructing a Blob playback scenario
+    // We test indirectly: stopTTS should not throw even with no audio playing
+    const { stopTTS } = await import('@/services/AudioService')
+    expect(() => stopTTS()).not.toThrow()
+    expect(pause).not.toHaveBeenCalled() // no audio was playing
+  })
+})
+

--- a/web/src/test/PronunciationPage.test.tsx
+++ b/web/src/test/PronunciationPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PronunciationPage from '@/pages/PronunciationPage'
+import { SAMPLE_WORDS } from '@/data/sampleWords'
+import * as AudioService from '@/services/AudioService'
+
+const { mockPlayTTS } = vi.hoisted(() => ({ mockPlayTTS: vi.fn() }))
+vi.mock('@/services/AudioService', () => ({
+  playTTS: mockPlayTTS,
+  stopTTS: vi.fn(),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const word = SAMPLE_WORDS[0]
+const sentence = word.sentences[0]
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/words/${word.id}/pronunciation/${sentence.id}`]}>
+      <Routes>
+        <Route path="/words/:id/pronunciation/:sentenceId" element={<PronunciationPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('PronunciationPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    vi.mocked(AudioService.stopTTS).mockClear()
+    mockPlayTTS.mockReset().mockResolvedValue('webspeech')
+  })
+
+  it('renders the sentence text', () => {
+    renderPage()
+    expect(screen.getByText(sentence.english)).toBeInTheDocument()
+    expect(screen.getByText(sentence.japanese)).toBeInTheDocument()
+  })
+
+  it('renders word context', () => {
+    renderPage()
+    expect(screen.getByText(word.word)).toBeInTheDocument()
+  })
+
+  it('calls stopTTS on unmount', () => {
+    const { unmount } = renderPage()
+    unmount()
+    expect(AudioService.stopTTS).toHaveBeenCalled()
+  })
+
+  it('both TTS buttons are disabled while one is playing', async () => {
+    // playTTS never resolves so the playing state persists
+    mockPlayTTS.mockReturnValue(new Promise(() => {}))
+    renderPage()
+
+    const enButton = screen.getByRole('button', { name: '英語を聞く' })
+    const jaButton = screen.getByRole('button', { name: '日本語を聞く' })
+
+    await userEvent.click(enButton)
+
+    expect(enButton).toBeDisabled()
+    expect(jaButton).toBeDisabled()
+  })
+
+  it('TTS buttons are enabled before playback starts', () => {
+    renderPage()
+    expect(screen.getByRole('button', { name: '英語を聞く' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: '日本語を聞く' })).not.toBeDisabled()
+  })
+
+  it('back button navigates to sentence list', async () => {
+    renderPage()
+    await userEvent.click(screen.getByText('例文一覧'))
+    expect(mockNavigate).toHaveBeenCalledWith(`/words/${word.id}/sentences`)
+  })
+})

--- a/web/src/test/SentenceListPage.test.tsx
+++ b/web/src/test/SentenceListPage.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SentenceListPage from '@/pages/SentenceListPage'
+import { SAMPLE_WORDS } from '@/data/sampleWords'
+import * as AudioService from '@/services/AudioService'
+
+vi.mock('@/services/AudioService', () => ({
+  playTTS: vi.fn().mockResolvedValue('webspeech'),
+  stopTTS: vi.fn(),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const word = SAMPLE_WORDS[0]
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/words/${word.id}/sentences`]}>
+      <Routes>
+        <Route path="/words/:id/sentences" element={<SentenceListPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('SentenceListPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    vi.mocked(AudioService.stopTTS).mockClear()
+    vi.mocked(AudioService.playTTS).mockClear()
+  })
+
+  it('renders the word heading', () => {
+    renderPage()
+    expect(screen.getByText(word.word)).toBeInTheDocument()
+  })
+
+  it('renders all sentences', () => {
+    renderPage()
+    for (const sentence of word.sentences) {
+      expect(screen.getByText(sentence.english)).toBeInTheDocument()
+    }
+  })
+
+  it('sentence row click navigates to PronunciationPage', async () => {
+    renderPage()
+    const firstSentence = word.sentences[0]
+    // Row aria-label ends with "— 発音練習へ"
+    const row = screen.getByRole('button', {
+      name: `${firstSentence.english} — 発音練習へ`,
+    })
+    await userEvent.click(row)
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/words/${word.id}/pronunciation/${firstSentence.id}`,
+    )
+  })
+
+  it('play button click does NOT navigate to PronunciationPage', async () => {
+    renderPage()
+    const firstSentence = word.sentences[0]
+    // Play button aria-label is 「...」を再生
+    const playButton = screen.getByLabelText(`「${firstSentence.english}」を再生`)
+    await userEvent.click(playButton)
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.stringContaining('/pronunciation/'),
+    )
+  })
+
+  it('play button has accessible aria-label', () => {
+    renderPage()
+    const firstSentence = word.sentences[0]
+    expect(
+      screen.getByLabelText(`「${firstSentence.english}」を再生`),
+    ).toBeInTheDocument()
+  })
+
+  it('calls stopTTS on unmount', () => {
+    const { unmount } = renderPage()
+    unmount()
+    expect(AudioService.stopTTS).toHaveBeenCalled()
+  })
+
+  it('back button navigates to word list', async () => {
+    renderPage()
+    await userEvent.click(screen.getByText('単語一覧'))
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+  })
+})

--- a/web/src/test/WordListPage.test.tsx
+++ b/web/src/test/WordListPage.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { describe, it, expect, vi } from 'vitest'
+import WordListPage from '@/pages/WordListPage'
+import { SAMPLE_WORDS } from '@/data/sampleWords'
+
+vi.mock('@/services/AudioService', () => ({
+  playTTS: vi.fn().mockResolvedValue('webspeech'),
+  stopTTS: vi.fn(),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <WordListPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('WordListPage', () => {
+  it('renders all sample words', () => {
+    renderPage()
+    for (const word of SAMPLE_WORDS) {
+      expect(screen.getByText(word.word)).toBeInTheDocument()
+    }
+  })
+
+  it('navigates to SentenceListPage on word card click', async () => {
+    renderPage()
+    const firstWord = SAMPLE_WORDS[0]
+    const card = screen.getByRole('button', { name: new RegExp(firstWord.word) })
+    await userEvent.click(card)
+    expect(mockNavigate).toHaveBeenCalledWith(`/words/${firstWord.id}/sentences`)
+  })
+
+  it('navigates on Enter key press', async () => {
+    renderPage()
+    const firstWord = SAMPLE_WORDS[0]
+    const card = screen.getByRole('button', { name: new RegExp(firstWord.word) })
+    card.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(mockNavigate).toHaveBeenCalledWith(`/words/${firstWord.id}/sentences`)
+  })
+
+  it('navigates on Space key press', async () => {
+    renderPage()
+    const firstWord = SAMPLE_WORDS[0]
+    const card = screen.getByRole('button', { name: new RegExp(firstWord.word) })
+    card.focus()
+    await userEvent.keyboard(' ')
+    expect(mockNavigate).toHaveBeenCalledWith(`/words/${firstWord.id}/sentences`)
+  })
+
+  it('word card has tabIndex=0 for keyboard focus', () => {
+    renderPage()
+    const firstWord = SAMPLE_WORDS[0]
+    const card = screen.getByRole('button', { name: new RegExp(firstWord.word) })
+    expect(card).toHaveAttribute('tabindex', '0')
+  })
+
+  it('TTS button click does not navigate to sentence page', async () => {
+    renderPage()
+    mockNavigate.mockClear()
+    const ttsButtons = screen.getAllByTitle('英語を再生')
+    await userEvent.click(ttsButtons[0])
+    expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/sentences'))
+  })
+})

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom'
+
+// jsdom does not implement scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = () => {}


### PR DESCRIPTION
## Summary

- Add `SentenceListPage` at route `/#/words/:id/sentences`, aligned with iOS `SentenceListView`
- Sentences are grouped by category with per-sentence ▶ playback via `AudioService.playTTS()`
- Word header shows phonetic, meaning, and EN/JA TTS buttons
- Active sentence is highlighted and auto-scrolled into view during playback
- Tapping a word card on `WordListPage` now navigates to the sentence list
- Shared `sampleWords.ts` data file with `Word`/`Sentence` types replaces hardcoded arrays

## Test plan

- [ ] Tap a word in the word list → sentence list opens
- [ ] EN/JA buttons in the word header play TTS correctly
- [ ] Tapping ▶ on a sentence plays English audio and highlights the row
- [ ] Tapping ▶ on another sentence while playing is blocked (disabled state)
- [ ] Active sentence auto-scrolls into view
- [ ] Sentences are correctly grouped by category
- [ ] EN/JA TTS buttons on word list still work (e.stopPropagation prevents navigation)
- [ ] Unknown word id shows "単語が見つかりません" fallback

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sentence list and pronunciation practice pages, plus routes to access them.
  * Sample word dataset included for demo/example content.

* **Usability**
  * Keyboard/ARIA improvements for word rows and speaker buttons; row clicks navigate to sentence lists.
  * Playback auto-scrolls/highlights current sentence; inline controls prevent accidental navigation.

* **Bug Fixes**
  * Global stop reliably cancels ongoing audio and speech playback.

* **Tests**
  * New test suites for word, sentence, pronunciation pages and audio behavior; test setup shim added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->