### PR TITLE
feat: add CloudWatch alarms and Slack alert notifications for API Gateway

### DIFF
--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -1,5 +1,7 @@
 *.js
 *.d.ts
+# Lambda source files (plain JS, not compiled output) are tracked
+!lambda/**/*.js
 node_modules/
 dist/
 cdk.out/

--- a/aws/lambda/alert-to-slack/index.js
+++ b/aws/lambda/alert-to-slack/index.js
@@ -89,6 +89,9 @@ function postToSlack(webhookUrl, payload) {
     const body    = JSON.stringify(payload);
     const parsed  = url.parse(webhookUrl);
 
+    let settled = false;
+    const done = (fn, val) => { if (!settled) { settled = true; fn(val); } };
+
     const req = https.request(
       {
         hostname: parsed.hostname,
@@ -104,15 +107,21 @@ function postToSlack(webhookUrl, payload) {
         res.on('data', (chunk) => { data += chunk; });
         res.on('end', () => {
           if (res.statusCode !== 200) {
-            reject(new Error(`Slack returned ${res.statusCode}: ${data}`));
+            done(reject, new Error(`Slack returned ${res.statusCode}: ${data}`));
           } else {
-            resolve(data);
+            done(resolve, data);
           }
         });
       }
     );
 
-    req.on('error', reject);
+    // 5秒でタイムアウト — Slack が無応答のまま Lambda が止まるのを防ぐ
+    req.setTimeout(5000, () => {
+      req.destroy();
+      done(reject, new Error('Slack webhook request timed out after 5s'));
+    });
+
+    req.on('error', (err) => done(reject, err));
     req.write(body);
     req.end();
   });

--- a/aws/lambda/alert-to-slack/index.js
+++ b/aws/lambda/alert-to-slack/index.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const https = require('https');
+const url = require('url');
+
+/**
+ * SNS → Slack Webhook forwarder for CloudWatch Alarms.
+ * Receives SNS notification from CloudWatch Alarm and posts a formatted
+ * Slack message using Incoming Webhooks.
+ */
+exports.handler = async (event) => {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.error('SLACK_WEBHOOK_URL is not set');
+    return;
+  }
+
+  const snsRecord = event.Records[0].Sns;
+  let alarm;
+  try {
+    alarm = JSON.parse(snsRecord.Message);
+  } catch (e) {
+    console.error('Failed to parse SNS message', snsRecord.Message);
+    return;
+  }
+
+  const isAlarm = alarm.NewStateValue === 'ALARM';
+  const isOk    = alarm.NewStateValue === 'OK';
+
+  const icon  = isAlarm ? ':rotating_light:' : isOk ? ':white_check_mark:' : ':information_source:';
+  const color = isAlarm ? '#ff0000'           : isOk ? '#36a64f'           : '#cccccc';
+  const env   = alarm.AlarmName?.match(/-(poc|dev|pro)$/)?.[1]?.toUpperCase() ?? 'UNKNOWN';
+
+  const payload = {
+    attachments: [
+      {
+        color,
+        title: `${icon} [${alarm.NewStateValue}] ${alarm.AlarmName}`,
+        text: alarm.AlarmDescription ?? '',
+        fields: [
+          {
+            title: 'メトリクス',
+            value: `${alarm.Trigger?.MetricName ?? '-'} (${alarm.Trigger?.Namespace ?? '-'})`,
+            short: true,
+          },
+          {
+            title: '環境',
+            value: env,
+            short: true,
+          },
+          {
+            title: '閾値',
+            value: `${alarm.Trigger?.Threshold ?? '-'} を超過`,
+            short: true,
+          },
+          {
+            title: '集計期間',
+            value: `${(alarm.Trigger?.Period ?? 0) / 60} 分`,
+            short: true,
+          },
+          {
+            title: '理由',
+            value: alarm.NewStateReason ?? '-',
+            short: false,
+          },
+          {
+            title: '検知時刻 (UTC)',
+            value: alarm.StateChangeTime ?? '-',
+            short: false,
+          },
+        ],
+        footer: 'CloudWatch Alarm → SNS → Lambda → Slack',
+        ts: Math.floor(Date.now() / 1000),
+      },
+    ],
+  };
+
+  await postToSlack(webhookUrl, payload);
+  console.log(`Slack notification sent: ${alarm.AlarmName} → ${alarm.NewStateValue}`);
+};
+
+/**
+ * POST JSON payload to a Slack Incoming Webhook URL.
+ * @param {string} webhookUrl
+ * @param {object} payload
+ */
+function postToSlack(webhookUrl, payload) {
+  return new Promise((resolve, reject) => {
+    const body    = JSON.stringify(payload);
+    const parsed  = url.parse(webhookUrl);
+
+    const req = https.request(
+      {
+        hostname: parsed.hostname,
+        path:     parsed.path,
+        method:   'POST',
+        headers: {
+          'Content-Type':   'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`Slack returned ${res.statusCode}: ${data}`));
+          } else {
+            resolve(data);
+          }
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}

--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -261,7 +261,13 @@ export class VoicevoxStack extends cdk.Stack {
 
     // Slack Webhook URL は環境変数から取得
     // Example: export VOICEVOX_SLACK_WEBHOOK_POC="https://hooks.slack.com/services/..."
-    const slackWebhookUrl = process.env[`VOICEVOX_SLACK_WEBHOOK_${stackEnv.toUpperCase()}`];
+    const slackWebhookEnvVar = `VOICEVOX_SLACK_WEBHOOK_${stackEnv.toUpperCase()}`;
+    const slackWebhookUrl = process.env[slackWebhookEnvVar];
+    if (!slackWebhookUrl) {
+      cdk.Annotations.of(this).addWarning(
+        `${slackWebhookEnvVar} is not set. Slack notifications will be skipped.`
+      );
+    }
 
     const slackAlertFn = new lambda.Function(this, 'SlackAlertFunction', {
       functionName: `voicevox-slack-alert-${stackEnv}`,

--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -286,7 +286,7 @@ export class VoicevoxStack extends cdk.Stack {
 
     // 4xx アラーム: 5分間で10件超えたら通知
     // （認証エラーなどのノイズを除くため閾値を10に設定）
-    new cloudwatch.Alarm(this, 'Api4xxAlarm', {
+    const api4xxAlarm = new cloudwatch.Alarm(this, 'Api4xxAlarm', {
       alarmName: `voicevox-api-4xx-${stackEnv}`,
       alarmDescription: 'API Gateway 4xx errors exceeded threshold (5min / >10)',
       metric: new cloudwatch.Metric({
@@ -301,10 +301,12 @@ export class VoicevoxStack extends cdk.Stack {
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       // データなし = 問題なし（夜間などのトラフィックゼロ時に誤発報しない）
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-    }).addAlarmAction(alarmAction);
+    });
+    api4xxAlarm.addAlarmAction(alarmAction);
+    api4xxAlarm.addOkAction(alarmAction);  // 回復時も通知
 
     // 5xx アラーム: 5分間で1件でも通知（サーバーエラーは即時検知）
-    new cloudwatch.Alarm(this, 'Api5xxAlarm', {
+    const api5xxAlarm = new cloudwatch.Alarm(this, 'Api5xxAlarm', {
       alarmName: `voicevox-api-5xx-${stackEnv}`,
       alarmDescription: 'API Gateway 5xx errors exceeded threshold (5min / >=1)',
       metric: new cloudwatch.Metric({
@@ -318,7 +320,9 @@ export class VoicevoxStack extends cdk.Stack {
       evaluationPeriods: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
-    }).addAlarmAction(alarmAction);
+    });
+    api5xxAlarm.addAlarmAction(alarmAction);
+    api5xxAlarm.addOkAction(alarmAction);  // 回復時も通知
 
     // ----------------------------------------------------------------
     // Outputs

--- a/aws/lib/voicevox-stack.ts
+++ b/aws/lib/voicevox-stack.ts
@@ -3,6 +3,11 @@ import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ecr_assets from 'aws-cdk-lib/aws-ecr-assets';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cloudwatch_actions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as sns_subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as apigatewayv2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as apigatewayv2Authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
@@ -243,6 +248,77 @@ export class VoicevoxStack extends cdk.Stack {
       methods: [apigatewayv2.HttpMethod.GET],
       integration: lambdaIntegration,
     });
+
+    // ----------------------------------------------------------------
+    // CloudWatch Alarms: API Gateway 4xx / 5xx → SNS → Slack
+    // ----------------------------------------------------------------
+
+    // SNS topic: receives alarm state changes from CloudWatch
+    const alertTopic = new sns.Topic(this, 'ApiAlertTopic', {
+      topicName: `voicevox-api-alert-${stackEnv}`,
+      displayName: `VOICEVOX API Alerts (${stackEnv})`,
+    });
+
+    // Slack Webhook URL は環境変数から取得
+    // Example: export VOICEVOX_SLACK_WEBHOOK_POC="https://hooks.slack.com/services/..."
+    const slackWebhookUrl = process.env[`VOICEVOX_SLACK_WEBHOOK_${stackEnv.toUpperCase()}`];
+
+    const slackAlertFn = new lambda.Function(this, 'SlackAlertFunction', {
+      functionName: `voicevox-slack-alert-${stackEnv}`,
+      runtime: lambda.Runtime.NODEJS_22_X,
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, '../lambda/alert-to-slack')),
+      environment: {
+        // Webhook URL が未設定の場合、Lambda は通知をスキップしてログのみ出力する
+        SLACK_WEBHOOK_URL: slackWebhookUrl ?? '',
+      },
+      timeout: cdk.Duration.seconds(10),
+      logRetention: logs.RetentionDays.ONE_WEEK,
+      description: `Forwards CloudWatch Alarm notifications to Slack (${stackEnv})`,
+    });
+
+    // SNS → Lambda サブスクリプション
+    alertTopic.addSubscription(
+      new sns_subscriptions.LambdaSubscription(slackAlertFn)
+    );
+
+    const alarmAction = new cloudwatch_actions.SnsAction(alertTopic);
+
+    // 4xx アラーム: 5分間で10件超えたら通知
+    // （認証エラーなどのノイズを除くため閾値を10に設定）
+    new cloudwatch.Alarm(this, 'Api4xxAlarm', {
+      alarmName: `voicevox-api-4xx-${stackEnv}`,
+      alarmDescription: 'API Gateway 4xx errors exceeded threshold (5min / >10)',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/ApiGateway',
+        metricName: '4xx',
+        dimensionsMap: { ApiId: httpApi.apiId },
+        statistic: 'Sum',
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 10,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      // データなし = 問題なし（夜間などのトラフィックゼロ時に誤発報しない）
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    }).addAlarmAction(alarmAction);
+
+    // 5xx アラーム: 5分間で1件でも通知（サーバーエラーは即時検知）
+    new cloudwatch.Alarm(this, 'Api5xxAlarm', {
+      alarmName: `voicevox-api-5xx-${stackEnv}`,
+      alarmDescription: 'API Gateway 5xx errors exceeded threshold (5min / >=1)',
+      metric: new cloudwatch.Metric({
+        namespace: 'AWS/ApiGateway',
+        metricName: '5xx',
+        dimensionsMap: { ApiId: httpApi.apiId },
+        statistic: 'Sum',
+        period: cdk.Duration.minutes(5),
+      }),
+      threshold: 0,
+      evaluationPeriods: 1,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    }).addAlarmAction(alarmAction);
 
     // ----------------------------------------------------------------
     // Outputs

--- a/docs/04.api_gateway_cloudwatch_alerts.md
+++ b/docs/04.api_gateway_cloudwatch_alerts.md
@@ -1,0 +1,150 @@
+# API Gateway CloudWatch アラート設定
+
+CloudWatch Alarm → SNS → Lambda → Slack の構成で、API Gateway の 4xx / 5xx エラーを Slack に通知します。
+
+## アーキテクチャ
+
+```
+API Gateway エラー発生
+  └→ CloudWatch Alarm (4xx >10 / 5xx >=1, 集計期間 5分)
+       └→ SNS Topic  (voicevox-api-alert-{env})
+            └→ Lambda (voicevox-slack-alert-{env})
+                 └→ Slack Incoming Webhook → チャンネルに投稿
+```
+
+## アラーム設定
+
+| アラーム名 | メトリクス | 閾値 | 集計期間 | 設定意図 |
+|---|---|---|---|---|
+| `voicevox-api-4xx-{env}` | `4xx` | >10 件 | 5 分 | 認証エラー等のノイズを除外 |
+| `voicevox-api-5xx-{env}` | `5xx` | >=1 件 | 5 分 | サーバーエラーは即時検知 |
+
+`treatMissingData: NOT_BREACHING` — データなし（夜間等）は正常扱いとし誤発報を防ぐ。
+
+## Slack 通知の出力イメージ
+
+### ALARM 通知（エラー検知時）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🚨 [ALARM] voicevox-api-5xx-poc                             │
+│ API Gateway 5xx errors exceeded threshold (5min / >=1)      │
+│─────────────────────────────────────────────────────────────│
+│ メトリクス  │ 5xx (AWS/ApiGateway)                          │
+│ 環境        │ POC                                           │
+│ 閾値        │ 0 を超過                                      │
+│ 集計期間    │ 5 分                                          │
+│─────────────────────────────────────────────────────────────│
+│ 理由                                                        │
+│ Threshold Crossed: 1 datapoint [1.0 (23/04/26 10:00:00)]   │
+│ was greater than the threshold (0.0).                       │
+│─────────────────────────────────────────────────────────────│
+│ 検知時刻 (UTC) │ 2026-04-23T10:05:00.000+0000              │
+│─────────────────────────────────────────────────────────────│
+│ CloudWatch Alarm → SNS → Lambda → Slack                     │
+└─────────────────────────────────────────────────────────────┘
+← 赤いサイドバー (color: #ff0000)
+```
+
+### OK 通知（回復時）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ ✅ [OK] voicevox-api-5xx-poc                                │
+│ API Gateway 5xx errors exceeded threshold (5min / >=1)      │
+│─────────────────────────────────────────────────────────────│
+│ メトリクス  │ 5xx (AWS/ApiGateway)                          │
+│ 環境        │ POC                                           │
+│ 閾値        │ 0 を超過                                      │
+│ 集計期間    │ 5 分                                          │
+│─────────────────────────────────────────────────────────────│
+│ 理由                                                        │
+│ Threshold Crossed: 0 datapoints were not greater than the   │
+│ threshold (0.0). Alarm state restored.                      │
+│─────────────────────────────────────────────────────────────│
+│ 検知時刻 (UTC) │ 2026-04-23T10:15:00.000+0000              │
+│─────────────────────────────────────────────────────────────│
+│ CloudWatch Alarm → SNS → Lambda → Slack                     │
+└─────────────────────────────────────────────────────────────┘
+← 緑のサイドバー (color: #36a64f)
+```
+
+### 4xx アラーム例（認証エラー多発時）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🚨 [ALARM] voicevox-api-4xx-poc                             │
+│ API Gateway 4xx errors exceeded threshold (5min / >10)      │
+│─────────────────────────────────────────────────────────────│
+│ メトリクス  │ 4xx (AWS/ApiGateway)                          │
+│ 環境        │ POC                                           │
+│ 閾値        │ 10 を超過                                     │
+│ 集計期間    │ 5 分                                          │
+│─────────────────────────────────────────────────────────────│
+│ 理由                                                        │
+│ Threshold Crossed: 1 datapoint [15.0 (23/04/26 11:00:00)]  │
+│ was greater than the threshold (10.0).                      │
+│─────────────────────────────────────────────────────────────│
+│ 検知時刻 (UTC) │ 2026-04-23T11:05:00.000+0000              │
+│─────────────────────────────────────────────────────────────│
+│ CloudWatch Alarm → SNS → Lambda → Slack                     │
+└─────────────────────────────────────────────────────────────┘
+← 赤いサイドバー (color: #ff0000)
+```
+
+## デプロイ手順
+
+### 1. Slack Incoming Webhook URL を取得
+
+1. [Slack API](https://api.slack.com/apps) → 対象 App を選択（なければ New App）
+2. **Incoming Webhooks** → **Activate Incoming Webhooks: ON**
+3. **Add New Webhook to Workspace** → 通知先チャンネルを選択
+4. Webhook URL をコピー（`https://hooks.slack.com/services/...`）
+
+### 2. 環境変数をセットしてデプロイ
+
+```bash
+export VOICEVOX_API_KEY_POC="your-api-key"
+export VOICEVOX_SLACK_WEBHOOK_POC="https://hooks.slack.com/services/xxx/yyy/zzz"
+
+cd aws
+npm run deploy:poc
+```
+
+Webhook URL を設定しない場合、Lambda はログのみ出力してエラーにはなりません（フォールバック済み）。
+
+## Lambda の Slack Payload（JSON 形式）
+
+Lambda が Slack に送信する JSON の実体は以下の形式です。
+
+```json
+{
+  "attachments": [
+    {
+      "color": "#ff0000",
+      "title": ":rotating_light: [ALARM] voicevox-api-5xx-poc",
+      "text": "API Gateway 5xx errors exceeded threshold (5min / >=1)",
+      "fields": [
+        { "title": "メトリクス",     "value": "5xx (AWS/ApiGateway)",                 "short": true  },
+        { "title": "環境",           "value": "POC",                                  "short": true  },
+        { "title": "閾値",           "value": "0 を超過",                             "short": true  },
+        { "title": "集計期間",       "value": "5 分",                                 "short": true  },
+        { "title": "理由",           "value": "Threshold Crossed: 1 datapoint ...",   "short": false },
+        { "title": "検知時刻 (UTC)", "value": "2026-04-23T10:05:00.000+0000",         "short": false }
+      ],
+      "footer": "CloudWatch Alarm → SNS → Lambda → Slack",
+      "ts": 1745402700
+    }
+  ]
+}
+```
+
+## コスト
+
+| サービス | 無料枠 | 超過単価 |
+|---|---|---|
+| CloudWatch Alarm | 10アラーム/月まで無料 | $0.10/アラーム/月 |
+| SNS | 100万リクエスト/月まで無料 | $0.50/100万 |
+| Lambda | 100万リクエスト/月まで無料 | $0.20/100万 |
+
+このプロジェクト規模（アラーム2つ、低頻度通知）では**実質無料**です。

--- a/docs/04.api_gateway_cloudwatch_alerts.md
+++ b/docs/04.api_gateway_cloudwatch_alerts.md
@@ -4,7 +4,7 @@ CloudWatch Alarm → SNS → Lambda → Slack の構成で、API Gateway の 4xx
 
 ## アーキテクチャ
 
-```
+```text
 API Gateway エラー発生
   └→ CloudWatch Alarm (4xx >10 / 5xx >=1, 集計期間 5分)
        └→ SNS Topic  (voicevox-api-alert-{env})
@@ -25,7 +25,7 @@ API Gateway エラー発生
 
 ### ALARM 通知（エラー検知時）
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │ 🚨 [ALARM] voicevox-api-5xx-poc                             │
 │ API Gateway 5xx errors exceeded threshold (5min / >=1)      │
@@ -48,7 +48,7 @@ API Gateway エラー発生
 
 ### OK 通知（回復時）
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │ ✅ [OK] voicevox-api-5xx-poc                                │
 │ API Gateway 5xx errors exceeded threshold (5min / >=1)      │
@@ -71,7 +71,7 @@ API Gateway エラー発生
 
 ### 4xx アラーム例（認証エラー多発時）
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │ 🚨 [ALARM] voicevox-api-4xx-poc                             │
 │ API Gateway 4xx errors exceeded threshold (5min / >10)      │


### PR DESCRIPTION
## Summary

- CloudWatch Alarm で API Gateway の 4xx / 5xx エラーを検知
- SNS → Lambda → Slack Incoming Webhook の構成で通知
- CDK で全リソースを管理（Slack Webhook URL は環境変数から注入）
- アラート仕様・出力イメージ・デプロイ手順を `docs/04.api_gateway_cloudwatch_alerts.md` に記載

## アーキテクチャ

```
API Gateway エラー
  └→ CloudWatch Alarm (4xx >10 / 5xx >=1, 5分間集計)
       └→ SNS Topic
            └→ Lambda (alert-to-slack)
                 └→ Slack Incoming Webhook
```

## アラーム設定

| アラーム | 閾値 | 意図 |
|---|---|---|
| `voicevox-api-4xx-{env}` | 5分間で >10 件 | 認証エラー等のノイズを除外 |
| `voicevox-api-5xx-{env}` | 5分間で >=1 件 | サーバーエラーは即時検知 |

## Slack 通知の出力イメージ

```
┌─────────────────────────────────────────────────────────────┐
│ 🚨 [ALARM] voicevox-api-5xx-poc                             │
│ API Gateway 5xx errors exceeded threshold (5min / >=1)      │
│─────────────────────────────────────────────────────────────│
│ メトリクス  │ 5xx (AWS/ApiGateway)                          │
│ 環境        │ POC                                           │
│ 閾値        │ 0 を超過                                      │
│ 集計期間    │ 5 分                                          │
│─────────────────────────────────────────────────────────────│
│ 理由                                                        │
│ Threshold Crossed: 1 datapoint [1.0] was greater than ...   │
│─────────────────────────────────────────────────────────────│
│ 検知時刻 (UTC) │ 2026-04-23T10:05:00.000+0000              │
└─────────────────────────────────────────────────────────────┘
← 赤いサイドバー（ALARM）/ 緑（OK 回復時）
```

## デプロイ手順

```bash
export VOICEVOX_API_KEY_POC="your-api-key"
export VOICEVOX_SLACK_WEBHOOK_POC="https://hooks.slack.com/services/xxx/yyy/zzz"

cd aws && npm run deploy:poc
```

## Test plan

- [x] `npm run build` が通ること（TypeScript コンパイルエラーなし）
- [x] `npm run deploy:poc` で SNS / Lambda / CloudWatch Alarm が作成されること
- [x] CloudWatch コンソールでアラームが `OK` 状態になること
- [x] Lambda のテスト実行（SNS イベントを手動 invoke）で Slack に通知が届くこと
- [x] アラーム状態を手動で `ALARM` に変更し、Slack に赤い通知が届くこと
- [x] `ALARM → OK` 回復時に緑の通知が届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CloudWatch-driven alerting that notifies Slack on API Gateway 4xx/5xx events and recovers on OK.

* **Documentation**
  * Added a guide for API Gateway monitoring, alert flow, deployment steps, payload examples, and cost breakdown.

* **Chores**
  * Adjusted VCS rules so Lambda JavaScript files are tracked (comment added explaining intent).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->