### PR TITLE
feat: replace stock TabView with custom bold tab bar

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00013238D1234567890AB /* MiniPlayerView.swift */; };
 		C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A00014238D1234567890AB /* FullPlayerView.swift */; };
 		D1A00031238D1234567890AB /* AudioCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A00021238D1234567890AB /* AudioCache.swift */; };
+		E1000002238D1234567890AB /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001238D1234567890AB /* Tab.swift */; };
+		E1000004238D1234567890AB /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000003238D1234567890AB /* TabBar.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -97,6 +99,8 @@
 		A1000088238D1234567890AB /* PronunciationResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PronunciationResultView.swift; sourceTree = "<group>"; };
 		A100008A238D1234567890AB /* RecognitionResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognitionResultView.swift; sourceTree = "<group>"; };
 		A100008C238D1234567890AB /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
+		E1000001238D1234567890AB /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
+		E1000003238D1234567890AB /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		C1A00011238D1234567890AB /* QueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueItem.swift; sourceTree = "<group>"; };
 		C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalPlaybackManager.swift; sourceTree = "<group>"; };
 		C1A00013238D1234567890AB /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
@@ -236,6 +240,8 @@
 				A1000088238D1234567890AB /* PronunciationResultView.swift */,
 				A100008A238D1234567890AB /* RecognitionResultView.swift */,
 				A100008C238D1234567890AB /* SpeechButton.swift */,
+				E1000001238D1234567890AB /* Tab.swift */,
+				E1000003238D1234567890AB /* TabBar.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -354,6 +360,8 @@
 				C1A00002238D1234567890AB /* GlobalPlaybackManager.swift in Sources */,
 				C1A00003238D1234567890AB /* MiniPlayerView.swift in Sources */,
 				C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */,
+				E1000002238D1234567890AB /* Tab.swift in Sources */,
+				E1000004238D1234567890AB /* TabBar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
@@ -3,61 +3,38 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject private var settings: SettingsManager
     @EnvironmentObject private var globalPlaybackManager: GlobalPlaybackManager
-    @State private var selectedTab = 0
+    @State private var selectedTab: Tab = .learn
     @State private var showingAddWordView = false
 
     var body: some View {
-        TabView(selection: $selectedTab) {
-            NavigationStack {
-                WordListView()
-            }
-            .tabItem {
-                Label("学習", systemImage: "books.vertical")
-            }
-            .tag(0)
+        ZStack {
+            NavigationStack { WordListView() }
+                .opacity(selectedTab == .learn ? 1 : 0)
+                .allowsHitTesting(selectedTab == .learn)
 
-            NavigationStack {
-                ArchiveView()
-            }
-            .tabItem {
-                Label("アーカイブ", systemImage: "archivebox")
-            }
-            .tag(1)
+            NavigationStack { ArchiveView() }
+                .opacity(selectedTab == .archive ? 1 : 0)
+                .allowsHitTesting(selectedTab == .archive)
 
-            Color.clear
-                .tabItem {
-                    Label("追加", systemImage: "plus.circle.fill")
-                }
-                .tag(2)
-
-            NavigationStack {
-                TrashView()
-            }
-            .tabItem {
-                Label("ゴミ箱", systemImage: "trash")
-            }
-            .tag(3)
+            NavigationStack { TrashView() }
+                .opacity(selectedTab == .trash ? 1 : 0)
+                .allowsHitTesting(selectedTab == .trash)
 
             SettingsView()
-                .tabItem {
-                    Label("設定", systemImage: "gear")
-                }
-                .tag(4)
+                .opacity(selectedTab == .settings ? 1 : 0)
+                .allowsHitTesting(selectedTab == .settings)
         }
-        .onChange(of: selectedTab) { oldValue, newValue in
-            if newValue == 2 {
-                showingAddWordView = true
-                selectedTab = oldValue
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                if !globalPlaybackManager.queue.isEmpty {
+                    MiniPlayerView()
+                }
+                TabBar(selected: $selectedTab, presentingAdd: $showingAddWordView)
             }
         }
         .sheet(isPresented: $showingAddWordView) {
             AddWordView { newWord in
                 WordDataManager.shared.addWord(newWord)
-            }
-        }
-        .safeAreaInset(edge: .bottom) {
-            if !globalPlaybackManager.queue.isEmpty {
-                MiniPlayerView()
             }
         }
     }

--- a/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
@@ -11,18 +11,22 @@ struct ContentView: View {
             NavigationStack { WordListView() }
                 .opacity(selectedTab == .learn ? 1 : 0)
                 .allowsHitTesting(selectedTab == .learn)
+                .accessibilityHidden(selectedTab != .learn)
 
             NavigationStack { ArchiveView() }
                 .opacity(selectedTab == .archive ? 1 : 0)
                 .allowsHitTesting(selectedTab == .archive)
+                .accessibilityHidden(selectedTab != .archive)
 
             NavigationStack { TrashView() }
                 .opacity(selectedTab == .trash ? 1 : 0)
                 .allowsHitTesting(selectedTab == .trash)
+                .accessibilityHidden(selectedTab != .trash)
 
             SettingsView()
                 .opacity(selectedTab == .settings ? 1 : 0)
                 .allowsHitTesting(selectedTab == .settings)
+                .accessibilityHidden(selectedTab != .settings)
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/Tab.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/Tab.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum Tab: Int, CaseIterable, Identifiable {
+    case learn = 0
+    case archive = 1
+    case add = 2
+    case trash = 3
+    case settings = 4
+
+    var id: Int { rawValue }
+
+    var icon: String {
+        switch self {
+        case .learn:    "books.vertical.fill"
+        case .archive:  "archivebox.fill"
+        case .add:      "plus"
+        case .trash:    "trash.fill"
+        case .settings: "gearshape.fill"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .learn:    "学習"
+        case .archive:  "アーカイブ"
+        case .add:      "追加"
+        case .trash:    "ゴミ箱"
+        case .settings: "設定"
+        }
+    }
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/TabBar.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/TabBar.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct TabBar: View {
+    @Binding var selected: Tab
+    @Binding var presentingAdd: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Tab.allCases) { tab in
+                if tab == .add {
+                    addButton
+                } else {
+                    tabButton(tab)
+                }
+            }
+        }
+        .frame(height: 56)
+        .background(.ultraThinMaterial)
+        .overlay(
+            Rectangle()
+                .frame(height: 0.5)
+                .foregroundStyle(Color(uiColor: .separator)),
+            alignment: .top
+        )
+    }
+
+    private func tabButton(_ tab: Tab) -> some View {
+        Button {
+            withAnimation(.easeOut(duration: 0.15)) { selected = tab }
+        } label: {
+            VStack(spacing: 2) {
+                ZStack {
+                    if selected == tab {
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.accentColor.opacity(0.18))
+                            .frame(width: 44, height: 28)
+                    }
+                    Image(systemName: tab.icon)
+                        .font(.system(size: 22))
+                }
+                Text(tab.label)
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .foregroundStyle(selected == tab ? Color.accentColor : Color.secondary)
+            .frame(maxWidth: .infinity)
+        }
+        .accessibilityLabel(tab.label)
+        .accessibilityAddTraits(selected == tab ? .isSelected : [])
+    }
+
+    private var addButton: some View {
+        Button {
+            presentingAdd = true
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color.accentColor)
+                    .frame(width: 44, height: 28)
+                Image(systemName: Tab.add.icon)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(.white)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .accessibilityLabel(Tab.add.label)
+    }
+}
+
+#Preview {
+    @Previewable @State var selected: Tab = .learn
+    @Previewable @State var presentingAdd = false
+    VStack {
+        Spacer()
+        TabBar(selected: $selected, presentingAdd: $presentingAdd)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `Tab` enum (`Views/Helpers/Tab.swift`) defining the 5 tabs with icons and Japanese labels
- Add `TabBar` view (`Views/Helpers/TabBar.swift`) — custom 56pt bar with `.ultraThinMaterial` background, 0.5pt separator overlay at top
- Active non-add tab shows a `44×28` filled rounded-rect pill at `0.18` accent opacity behind the icon
- Center Add tab renders as a `44×28` accent-filled pill; tapping it presents `AddWordView` as a sheet
- Tab switches animate with `withAnimation(.easeOut(duration: 0.15))`
- Navigation stacks are preserved across tab switches via `opacity` + `allowsHitTesting` in a `ZStack`
- VoiceOver: each tab announces its label and selected state via `accessibilityLabel` + `.isSelected` trait
- Bar respects safe area via `safeAreaInset(edge: .bottom)`

## Test plan

- [ ] Build and run on a device/simulator (iOS 17+)
- [ ] Tap each of the 4 non-add tabs — confirm active pill appears, inactive tabs show gray
- [ ] Tap the center Add button — confirm `AddWordView` sheet opens
- [ ] Navigate into a word in 学習 tab, switch to アーカイブ, switch back — confirm navigation stack is preserved
- [ ] Test on a home-indicator device — confirm bar clears the home indicator
- [ ] Enable VoiceOver — confirm each tab announces label and selected state
- [ ] Test dark mode — confirm `.ultraThinMaterial` and `.accentColor` render correctly

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Completely redesigned tab navigation with a custom-built tab bar providing enhanced visual feedback and smooth animations when switching sections.
  * Streamlined bottom layout that seamlessly integrates the music player queue display with navigation controls for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->