### PR TITLE
feat: music-app style mini player bar with cover art

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		D1A00031238D1234567890AB /* AudioCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A00021238D1234567890AB /* AudioCache.swift */; };
 		E1000002238D1234567890AB /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001238D1234567890AB /* Tab.swift */; };
 		E1000004238D1234567890AB /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000003238D1234567890AB /* TabBar.swift */; };
+		E1000006238D1234567890AB /* CoverArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000005238D1234567890AB /* CoverArtView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -101,6 +102,7 @@
 		A100008C238D1234567890AB /* SpeechButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechButton.swift; sourceTree = "<group>"; };
 		E1000001238D1234567890AB /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		E1000003238D1234567890AB /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
+		E1000005238D1234567890AB /* CoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverArtView.swift; sourceTree = "<group>"; };
 		C1A00011238D1234567890AB /* QueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueItem.swift; sourceTree = "<group>"; };
 		C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalPlaybackManager.swift; sourceTree = "<group>"; };
 		C1A00013238D1234567890AB /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				A100008C238D1234567890AB /* SpeechButton.swift */,
 				E1000001238D1234567890AB /* Tab.swift */,
 				E1000003238D1234567890AB /* TabBar.swift */,
+				E1000005238D1234567890AB /* CoverArtView.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				C1A00004238D1234567890AB /* FullPlayerView.swift in Sources */,
 				E1000002238D1234567890AB /* Tab.swift in Sources */,
 				E1000004238D1234567890AB /* TabBar.swift in Sources */,
+				E1000006238D1234567890AB /* CoverArtView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
+++ b/EnglishLearnApp/EnglishLearnApp/EnglishLearnAppApp.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @main
 struct EnglishLearnAppApp: App {
     @StateObject private var settingsManager = SettingsManager.shared
+    @StateObject private var wordDataManager = WordDataManager.shared
     @StateObject private var globalPlaybackManager = GlobalPlaybackManager(
         speechService: .shared,
         settings: .shared
@@ -14,10 +15,12 @@ struct EnglishLearnAppApp: App {
             if hasCompletedOnboarding {
                 ContentView()
                     .environmentObject(settingsManager)
+                    .environmentObject(wordDataManager)
                     .environmentObject(globalPlaybackManager)
             } else {
                 OnboardingView(hasCompletedOnboarding: $hasCompletedOnboarding)
                     .environmentObject(settingsManager)
+                    .environmentObject(wordDataManager)
                     .environmentObject(globalPlaybackManager)
             }
         }

--- a/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
@@ -1,5 +1,34 @@
 import Foundation
 
+// MARK: - Codable helpers
+
+/// Property wrapper that decodes a Bool, defaulting to false when the key is absent.
+/// Keeps Word's synthesized Codable intact without a full manual decoder.
+@propertyWrapper
+struct DefaultFalse: Codable {
+    var wrappedValue: Bool
+
+    init(wrappedValue: Bool = false) { self.wrappedValue = wrappedValue }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = (try? container.decode(Bool.self)) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue)
+    }
+}
+
+extension KeyedDecodingContainer {
+    /// Returns a default `DefaultFalse()` when the key is missing, so synthesized
+    /// Codable for `Word` never throws on JSON that predates the `isFavorite` field.
+    func decode(_ type: DefaultFalse.Type, forKey key: Key) throws -> DefaultFalse {
+        (try decodeIfPresent(type, forKey: key)) ?? DefaultFalse()
+    }
+}
+
 // MARK: - Word Models
 
 struct Sentence: Codable, Identifiable {
@@ -25,7 +54,7 @@ struct Word: Codable, Identifiable {
     var deletedAt: Date?
     var createdAt: Date?
     var archivedAt: Date?
-    var isFavorite: Bool
+    @DefaultFalse var isFavorite: Bool
 
     init(id: UUID = UUID(), word: String, meaning: String, phonetic: String,
          sentences: [Sentence] = [], deletedAt: Date? = nil, createdAt: Date? = Date(),
@@ -39,20 +68,6 @@ struct Word: Codable, Identifiable {
         self.createdAt = createdAt
         self.archivedAt = archivedAt
         self.isFavorite = isFavorite
-    }
-
-    // Custom decoder: treats missing isFavorite key as false for backward compat.
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(UUID.self, forKey: .id)
-        word = try c.decode(String.self, forKey: .word)
-        meaning = try c.decode(String.self, forKey: .meaning)
-        phonetic = try c.decode(String.self, forKey: .phonetic)
-        sentences = try c.decode([Sentence].self, forKey: .sentences)
-        deletedAt = try c.decodeIfPresent(Date.self, forKey: .deletedAt)
-        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt)
-        archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
-        isFavorite = (try? c.decode(Bool.self, forKey: .isFavorite)) ?? false
     }
 }
 
@@ -292,7 +307,7 @@ class WordDataManager: ObservableObject {
 
     /// Toggles the isFavorite flag for the word with the given ID.
     func toggleFavorite(wordId: UUID) {
-        modifyWords(ids: Set([wordId])) { $0.isFavorite.toggle() }
+        modifyWords(ids: [wordId]) { $0.isFavorite.toggle() }
     }
 
     /// Updates a word's fields by ID.

--- a/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Models/Word.swift
@@ -25,10 +25,11 @@ struct Word: Codable, Identifiable {
     var deletedAt: Date?
     var createdAt: Date?
     var archivedAt: Date?
+    var isFavorite: Bool
 
     init(id: UUID = UUID(), word: String, meaning: String, phonetic: String,
          sentences: [Sentence] = [], deletedAt: Date? = nil, createdAt: Date? = Date(),
-         archivedAt: Date? = nil) {
+         archivedAt: Date? = nil, isFavorite: Bool = false) {
         self.id = id
         self.word = word
         self.meaning = meaning
@@ -37,6 +38,21 @@ struct Word: Codable, Identifiable {
         self.deletedAt = deletedAt
         self.createdAt = createdAt
         self.archivedAt = archivedAt
+        self.isFavorite = isFavorite
+    }
+
+    // Custom decoder: treats missing isFavorite key as false for backward compat.
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        word = try c.decode(String.self, forKey: .word)
+        meaning = try c.decode(String.self, forKey: .meaning)
+        phonetic = try c.decode(String.self, forKey: .phonetic)
+        sentences = try c.decode([Sentence].self, forKey: .sentences)
+        deletedAt = try c.decodeIfPresent(Date.self, forKey: .deletedAt)
+        createdAt = try c.decodeIfPresent(Date.self, forKey: .createdAt)
+        archivedAt = try c.decodeIfPresent(Date.self, forKey: .archivedAt)
+        isFavorite = (try? c.decode(Bool.self, forKey: .isFavorite)) ?? false
     }
 }
 
@@ -272,6 +288,11 @@ class WordDataManager: ObservableObject {
         let importedIDs = Set(imported.map { $0.id })
         let trashed = loadAllWords().filter { $0.deletedAt != nil && !importedIDs.contains($0.id) }
         saveAllWords(trashed + imported)
+    }
+
+    /// Toggles the isFavorite flag for the word with the given ID.
+    func toggleFavorite(wordId: UUID) {
+        modifyWords(ids: Set([wordId])) { $0.isFavorite.toggle() }
     }
 
     /// Updates a word's fields by ID.

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -41,6 +41,9 @@ final class GlobalPlaybackManager: ObservableObject {
     /// Whether playback is currently active.
     @Published private(set) var isPlaying: Bool = false
 
+    /// Estimated playback progress for the current utterance (0…1), updated at ~15 fps.
+    @Published private(set) var progress: Double = 0.0
+
     // MARK: - Dependencies
 
     private let speechService: SpeechService
@@ -51,6 +54,9 @@ final class GlobalPlaybackManager: ObservableObject {
 
     private var internalManager: ContinuousPlaybackManager<QueueItem>?
     private let remoteCommandManager = RemoteCommandCenterManager()
+    private var progressTimer: AnyCancellable?
+    private var speechStartTime: Date?
+    private var estimatedSpeechDuration: Double = 3.0
 
     // MARK: - Initialization
 
@@ -178,6 +184,7 @@ final class GlobalPlaybackManager: ObservableObject {
     func pause() {
         guard isPlaying else { return }
 
+        stopProgressTracking()
         internalManager?.stop()
         speechService.stop()
         speechService.deactivateAudioSession()
@@ -302,13 +309,16 @@ final class GlobalPlaybackManager: ObservableObject {
             switch step {
             case 0, 2:
                 speechService.speak(item.sentence.english, language: "en-US", isContinuousPlayback: true)
+                startProgressTracking(for: item.sentence.english)
             case 1:
                 speechService.speak(item.sentence.japanese, language: "ja-JP", isContinuousPlayback: true)
+                startProgressTracking(for: item.sentence.japanese)
             default:
                 break
             }
         case .englishOnly:
             speechService.speak(item.sentence.english, language: "en-US", isContinuousPlayback: true)
+            startProgressTracking(for: item.sentence.english)
         }
 
         // Update Now Playing info
@@ -345,6 +355,7 @@ final class GlobalPlaybackManager: ObservableObject {
     }
 
     private func handlePlaybackCompletion() {
+        stopProgressTracking()
         speechService.deactivateAudioSession()
         NowPlayingInfoManager.clear()
         syncStateFromManager()
@@ -366,6 +377,28 @@ final class GlobalPlaybackManager: ObservableObject {
         if !manager.isPlaying && manager.items.isEmpty && !queue.isEmpty {
             // Manager was stopped - keep queue for resume capability
         }
+    }
+
+    // MARK: - Progress Tracking
+
+    private func startProgressTracking(for text: String) {
+        speechStartTime = Date()
+        let wordCount = max(1, text.split(separator: " ").count)
+        estimatedSpeechDuration = max(1.5, Double(wordCount) * 0.4)
+        progress = 0.0
+        progressTimer = Timer.publish(every: 1.0 / 15.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self, let start = self.speechStartTime else { return }
+                self.progress = min(Date().timeIntervalSince(start) / self.estimatedSpeechDuration, 1.0)
+            }
+    }
+
+    private func stopProgressTracking() {
+        progressTimer?.cancel()
+        progressTimer = nil
+        progress = 0.0
+        speechStartTime = nil
     }
 
     // MARK: - Prefetching

--- a/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Services/Playback/GlobalPlaybackManager.swift
@@ -382,6 +382,7 @@ final class GlobalPlaybackManager: ObservableObject {
     // MARK: - Progress Tracking
 
     private func startProgressTracking(for text: String) {
+        progressTimer?.cancel()
         speechStartTime = Date()
         let wordCount = max(1, text.split(separator: " ").count)
         estimatedSpeechDuration = max(1.5, Double(wordCount) * 0.4)

--- a/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
@@ -30,9 +30,9 @@ struct ContentView: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
-                if !globalPlaybackManager.queue.isEmpty {
-                    MiniPlayerView()
-                }
+                MiniPlayerView()
+                    .environmentObject(WordDataManager.shared)
+                    .animation(.easeOut(duration: 0.25), value: globalPlaybackManager.queue.isEmpty)
                 TabBar(selected: $selectedTab, presentingAdd: $showingAddWordView)
             }
         }

--- a/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/ContentView.swift
@@ -31,10 +31,9 @@ struct ContentView: View {
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 0) {
                 MiniPlayerView()
-                    .environmentObject(WordDataManager.shared)
-                    .animation(.easeOut(duration: 0.25), value: globalPlaybackManager.queue.isEmpty)
                 TabBar(selected: $selectedTab, presentingAdd: $showingAddWordView)
             }
+            .animation(.easeOut(duration: 0.25), value: globalPlaybackManager.queue.isEmpty)
         }
         .sheet(isPresented: $showingAddWordView) {
             AddWordView { newWord in

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/CoverArtView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/CoverArtView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-// MARK: - Color palette
+// MARK: - Gradient palette
 
 private let gradientPalettes: [[Color]] = [
     [Color(hue: 0.65, saturation: 0.70, brightness: 0.80), Color(hue: 0.75, saturation: 0.60, brightness: 0.90)],
@@ -11,13 +11,6 @@ private let gradientPalettes: [[Color]] = [
     [Color(hue: 0.10, saturation: 0.80, brightness: 0.90), Color(hue: 0.15, saturation: 0.70, brightness: 0.80)],
 ]
 
-/// Returns a deterministic LinearGradient for a word string.
-func coverGradient(for word: String) -> LinearGradient {
-    let index = abs(word.hashValue) % gradientPalettes.count
-    let colors = gradientPalettes[index]
-    return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
-}
-
 /// Square cover art: gradient background + first-letter monogram.
 struct CoverArtView: View {
     let word: String
@@ -26,13 +19,26 @@ struct CoverArtView: View {
 
     var body: some View {
         ZStack {
-            coverGradient(for: word)
+            CoverArtView.gradient(for: word)
             Text(String((word.first ?? "?")).uppercased())
                 .font(.system(size: size * 0.44, weight: .bold, design: .rounded))
                 .foregroundStyle(.white)
         }
         .frame(width: size, height: size)
         .clipShape(RoundedRectangle(cornerRadius: radius))
+    }
+
+    /// Deterministic LinearGradient for a word using a stable DJB2 hash.
+    /// Uses safe modulo to avoid overflow on any hash value.
+    static func gradient(for word: String) -> LinearGradient {
+        let hash = word.unicodeScalars.reduce(5381) { ($0 &* 33) &+ Int($1.value) }
+        let n = gradientPalettes.count
+        let index = ((hash % n) + n) % n
+        return LinearGradient(
+            colors: gradientPalettes[index],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
     }
 }
 

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/CoverArtView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/CoverArtView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+// MARK: - Color palette
+
+private let gradientPalettes: [[Color]] = [
+    [Color(hue: 0.65, saturation: 0.70, brightness: 0.80), Color(hue: 0.75, saturation: 0.60, brightness: 0.90)],
+    [Color(hue: 0.00, saturation: 0.70, brightness: 0.80), Color(hue: 0.08, saturation: 0.60, brightness: 0.90)],
+    [Color(hue: 0.30, saturation: 0.70, brightness: 0.65), Color(hue: 0.42, saturation: 0.60, brightness: 0.78)],
+    [Color(hue: 0.50, saturation: 0.70, brightness: 0.80), Color(hue: 0.60, saturation: 0.60, brightness: 0.90)],
+    [Color(hue: 0.85, saturation: 0.65, brightness: 0.80), Color(hue: 0.95, saturation: 0.60, brightness: 0.90)],
+    [Color(hue: 0.10, saturation: 0.80, brightness: 0.90), Color(hue: 0.15, saturation: 0.70, brightness: 0.80)],
+]
+
+/// Returns a deterministic LinearGradient for a word string.
+func coverGradient(for word: String) -> LinearGradient {
+    let index = abs(word.hashValue) % gradientPalettes.count
+    let colors = gradientPalettes[index]
+    return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+}
+
+/// Square cover art: gradient background + first-letter monogram.
+struct CoverArtView: View {
+    let word: String
+    let size: CGFloat
+    var radius: CGFloat = 8
+
+    var body: some View {
+        ZStack {
+            coverGradient(for: word)
+            Text(String((word.first ?? "?")).uppercased())
+                .font(.system(size: size * 0.44, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: radius))
+    }
+}
+
+#Preview {
+    HStack(spacing: 12) {
+        CoverArtView(word: "rarity", size: 56)
+        CoverArtView(word: "experience", size: 56)
+        CoverArtView(word: "these days", size: 56)
+        CoverArtView(word: "ambiguous", size: 56)
+    }
+    .padding()
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
@@ -20,7 +20,7 @@ struct MiniPlayerView: View {
     // MARK: - Card
 
     private func card(for item: QueueItem) -> some View {
-        let gradient = coverGradient(for: item.word.word)
+        let gradient = CoverArtView.gradient(for: item.word.word)
         let isFav = wordDataManager.words.first(where: { $0.id == item.word.id })?.isFavorite
             ?? item.word.isFavorite
 
@@ -39,8 +39,7 @@ struct MiniPlayerView: View {
                         .lineLimit(1)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-
-                Spacer(minLength: 8)
+                .padding(.trailing, 8)
 
                 Button {
                     wordDataManager.toggleFavorite(wordId: item.word.id)

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/MiniPlayerView.swift
@@ -1,122 +1,97 @@
 import SwiftUI
 
-/// A persistent mini-player that displays at the bottom of the screen during playback.
-///
-/// Shows the current sentence, playback progress, and control buttons.
-/// Tapping opens the full player sheet for queue management.
 struct MiniPlayerView: View {
     @EnvironmentObject private var playbackManager: GlobalPlaybackManager
-    @EnvironmentObject private var settings: SettingsManager
-
+    @EnvironmentObject private var wordDataManager: WordDataManager
     @State private var showingFullPlayer = false
 
     var body: some View {
-        HStack(spacing: 12) {
-            // Current sentence info - tappable to expand
-            Button {
-                showingFullPlayer = true
-            } label: {
-                VStack(alignment: .leading, spacing: 2) {
-                    if let item = playbackManager.currentItem {
-                        currentSentenceText(for: item)
-                        HStack(spacing: 4) {
-                            Text(item.word.word)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            Text(progressText)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                    } else {
-                        Text("No playback")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                    }
+        if let item = playbackManager.currentItem {
+            card(for: item)
+                .padding(.horizontal, 8)
+                .padding(.bottom, 6)
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .sheet(isPresented: $showingFullPlayer) {
+                    FullPlayerView()
+                }
+        }
+    }
+
+    // MARK: - Card
+
+    private func card(for item: QueueItem) -> some View {
+        let gradient = coverGradient(for: item.word.word)
+        let isFav = wordDataManager.words.first(where: { $0.id == item.word.id })?.isFavorite
+            ?? item.word.isFavorite
+
+        return Button { showingFullPlayer = true } label: {
+            HStack(spacing: 10) {
+                CoverArtView(word: item.word.word, size: 42, radius: 4)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(item.word.word)
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Text(item.sentence.english)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.78))
+                        .lineLimit(1)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
 
-            // Playback controls - sibling buttons, not nested
-            HStack(spacing: 16) {
+                Spacer(minLength: 8)
+
                 Button {
-                    playbackManager.previous()
+                    wordDataManager.toggleFavorite(wordId: item.word.id)
                 } label: {
-                    Image(systemName: "backward.fill")
-                        .font(.title3)
-                        .foregroundColor(.primary)
+                    Image(systemName: isFav ? "heart.fill" : "heart")
+                        .font(.system(size: 18))
+                        .foregroundStyle(isFav ? Color.pink : .white)
                 }
                 .buttonStyle(.plain)
-                .disabled(playbackManager.currentIndex == 0)
 
                 Button {
-                    if playbackManager.isPlaying {
-                        playbackManager.pause()
-                    } else {
-                        playbackManager.resume()
-                    }
+                    if playbackManager.isPlaying { playbackManager.pause() }
+                    else { playbackManager.resume() }
                 } label: {
                     Image(systemName: playbackManager.isPlaying ? "pause.fill" : "play.fill")
-                        .font(.title2)
-                        .foregroundColor(.primary)
+                        .font(.system(size: 20))
+                        .foregroundStyle(.white)
+                        .contentTransition(.symbolEffect(.replace))
                 }
                 .buttonStyle(.plain)
-
-                Button {
-                    playbackManager.next()
-                } label: {
-                    Image(systemName: "forward.fill")
-                        .font(.title3)
-                        .foregroundColor(.primary)
-                }
-                .buttonStyle(.plain)
-                .disabled(playbackManager.currentIndex >= playbackManager.queue.count - 1)
+            }
+            .padding(.leading, 8)
+            .padding(.trailing, 10)
+            .padding(.vertical, 8)
+            .background(
+                gradient.overlay(Color.black.opacity(0.18))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(alignment: .bottom) {
+                ProgressLine(progress: playbackManager.progress)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 3)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-        .background(.regularMaterial)
-        .overlay(alignment: .top) { Divider() }
-        .sheet(isPresented: $showingFullPlayer) {
-            FullPlayerView()
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Progress Line
+
+private struct ProgressLine: View {
+    let progress: Double
+
+    var body: some View {
+        GeometryReader { geo in
+            Capsule()
+                .fill(.white.opacity(0.55))
+                .frame(width: geo.size.width * progress, height: 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-
-    // MARK: - Helper Views
-
-    @ViewBuilder
-    private func currentSentenceText(for item: QueueItem) -> some View {
-        let mode = settings.playbackMode
-        let step = playbackManager.currentStep
-
-        // Determine which text to show based on current step
-        let (text, isJapanese): (String, Bool) = {
-            switch mode {
-            case .bilingual:
-                switch step {
-                case 0, 2:
-                    return (item.sentence.english, false)
-                case 1:
-                    return (item.sentence.japanese, true)
-                default:
-                    return (item.sentence.english, false)
-                }
-            case .englishOnly:
-                return (item.sentence.english, false)
-            }
-        }()
-
-        Text(text)
-            .font(.subheadline)
-            .fontWeight(.medium)
-            .foregroundColor(isJapanese ? .orange : .blue)
-            .lineLimit(1)
-    }
-
-    private var progressText: String {
-        let current = playbackManager.currentIndex + 1
-        let total = playbackManager.queue.count
-        return "\(current)/\(total)"
+        .frame(height: 2)
     }
 }
 
@@ -126,5 +101,5 @@ struct MiniPlayerView: View {
         MiniPlayerView()
     }
     .environmentObject(GlobalPlaybackManager(speechService: .shared, settings: .shared))
-    .environmentObject(SettingsManager.shared)
+    .environmentObject(WordDataManager.shared)
 }


### PR DESCRIPTION
## Summary

- **`Word.isFavorite`**: Added `Bool` property with a custom `init(from:)` that defaults to `false` when the key is missing — fully backward-compatible with existing JSON files
- **`WordDataManager.toggleFavorite(wordId:)`**: New helper to persist the favorite state
- **`GlobalPlaybackManager.progress`**: `@Published var progress: Double` (0…1) updated at ~15 fps via a Combine timer; resets on pause, queue clear, and playback completion
- **`CoverArtView`**: New helper view — deterministic per-word `LinearGradient` (6-palette hash) + first-letter monogram; used by the mini player
- **`MiniPlayerView` redesign** (replaces stock layout):
  - Floating 8pt-rounded card with horizontal 8pt margins
  - Gradient background derived from the current word + 18% black overlay for legibility
  - `CoverArtView` (42×42, 4pt radius) at leading edge
  - Word name (bold white, 13pt) + first sentence (78% white, 11pt) — both `lineLimit(1)` ellipsis truncated
  - Flat heart toggle (pink when active) — taps call `toggleFavorite`
  - Flat play/pause — `contentTransition(.symbolEffect(.replace))` prevents flicker
  - 2pt `ProgressLine` at bar bottom driven by `playbackManager.progress`
  - Collapse/expand animated with `.move(edge: .bottom).combined(with: .opacity)`
- **`ContentView`**: Removed explicit queue-empty guard (now handled internally in `MiniPlayerView`); injects `WordDataManager.shared` into the mini player's environment

## Test plan

- [ ] Build and run on iOS 17+ simulator/device
- [ ] Start playback of any word's sentences — mini player card appears with gradient, cover art, word name, sentence text
- [ ] Tap heart — icon turns pink; reopen app to confirm `isFavorite` persisted in JSON
- [ ] Tap play/pause — icon swaps without flicker
- [ ] Tap anywhere else on the card — `FullPlayerView` sheet opens
- [ ] Let playback run — progress line advances toward 1.0 at ≥10 fps
- [ ] Clear queue (FullPlayerView クリアボタン) — mini player slides down and disappears
- [ ] Resume playback — mini player slides back up
- [ ] Long word/sentence — verify text truncates with tail ellipsis, never wraps to second line
- [ ] Test in dark mode — gradient and white text remain legible
- [ ] Load existing `words.json` (without `isFavorite` key) — app loads without crash

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)