### PR TITLE
feat: sticky search + A-Z filter header for WordListView

### DIFF
--- a/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
+++ b/EnglishLearnApp/EnglishLearnApp.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		E1000004238D1234567890AB /* TabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000003238D1234567890AB /* TabBar.swift */; };
 		E1000006238D1234567890AB /* CoverArtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000005238D1234567890AB /* CoverArtView.swift */; };
 		F1000002238D1234567890AB /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1000001238D1234567890AB /* DesignTokens.swift */; };
+		G1000002238D1234567890AB /* WordListHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = G1000001238D1234567890AB /* WordListHeader.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +106,7 @@
 		E1000001238D1234567890AB /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		E1000003238D1234567890AB /* TabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBar.swift; sourceTree = "<group>"; };
 		E1000005238D1234567890AB /* CoverArtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoverArtView.swift; sourceTree = "<group>"; };
+		G1000001238D1234567890AB /* WordListHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordListHeader.swift; sourceTree = "<group>"; };
 		C1A00011238D1234567890AB /* QueueItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueItem.swift; sourceTree = "<group>"; };
 		C1A00012238D1234567890AB /* GlobalPlaybackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalPlaybackManager.swift; sourceTree = "<group>"; };
 		C1A00013238D1234567890AB /* MiniPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerView.swift; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 				E1000001238D1234567890AB /* Tab.swift */,
 				E1000003238D1234567890AB /* TabBar.swift */,
 				E1000005238D1234567890AB /* CoverArtView.swift */,
+				G1000001238D1234567890AB /* WordListHeader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				E1000004238D1234567890AB /* TabBar.swift in Sources */,
 				E1000006238D1234567890AB /* CoverArtView.swift in Sources */,
 				F1000002238D1234567890AB /* DesignTokens.swift in Sources */,
+				G1000002238D1234567890AB /* WordListHeader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/WordListHeader.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/WordListHeader.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct WordListHeader: View {
+    @Binding var query: String
+    @Binding var letter: String  // "ALL" | "A"…"Z"
+
+    private static let chips = ["ALL"] + (65...90).map { String(UnicodeScalar($0)!) }
+
+    var body: some View {
+        VStack(spacing: Tokens.Spacing.sm) {
+            searchField
+            letterStrip
+        }
+        .padding(.top, Tokens.Spacing.md)
+        .padding(.bottom, Tokens.Spacing.sm)
+        .padding(.horizontal, Tokens.Spacing.lg)
+        .background(Color.token(\.bg))
+    }
+
+    private var searchField: some View {
+        HStack(spacing: Tokens.Spacing.sm) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Color.token(\.subtext))
+            TextField("単語・意味・発音記号で検索", text: $query)
+                .font(.system(size: 14))
+                .foregroundStyle(Color.token(\.text))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+            if !query.isEmpty {
+                Button { query = "" } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Color.token(\.subtext))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, Tokens.Spacing.md)
+        .padding(.vertical, 10)
+        .background(Color.token(\.card))
+        .clipShape(RoundedRectangle(cornerRadius: Tokens.Radius.md))
+    }
+
+    private var letterStrip: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(Self.chips, id: \.self) { chip in
+                        Button { letter = chip } label: {
+                            Text(chip)
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: chip == "ALL" ? 44 : 36, height: 28)
+                                .background(letter == chip ? Color.token(\.accent) : Color.token(\.card))
+                                .foregroundStyle(letter == chip ? Color.white : Color.token(\.text))
+                                .clipShape(RoundedRectangle(cornerRadius: Tokens.Radius.sm))
+                        }
+                        .id(chip)
+                    }
+                }
+                .padding(.horizontal, Tokens.Spacing.lg)
+            }
+            .onChange(of: letter) { _, newLetter in
+                withAnimation { proxy.scrollTo(newLetter, anchor: .center) }
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var query = ""
+    @Previewable @State var letter = "ALL"
+
+    WordListHeader(query: $query, letter: $letter)
+        .background(Color.token(\.bg))
+}

--- a/EnglishLearnApp/EnglishLearnApp/Views/Helpers/WordListHeader.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/Helpers/WordListHeader.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WordListHeader: View {
     @Binding var query: String
     @Binding var letter: String  // "ALL" | "A"…"Z"
+    @EnvironmentObject private var settings: SettingsManager
 
     private static let chips = ["ALL"] + (65...90).map { String(UnicodeScalar($0)!) }
 
@@ -71,4 +72,5 @@ struct WordListHeader: View {
 
     WordListHeader(query: $query, letter: $letter)
         .background(Color.token(\.bg))
+        .environmentObject(SettingsManager.shared)
 }

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -125,44 +125,44 @@ struct WordListView: View {
                     message: "検索条件を変えてお試しください"
                 )
             } else {
-            List(filteredWords) { word in
-                if selection.isSelecting {
-                    SelectableListRow(id: word.id, selection: selection) {
-                        WordRowView(word: word, speechService: speechService)
-                    }
-                } else {
-                    NavigationLink(destination: destinationView(for: word)) {
-                        WordRowView(word: word, speechService: speechService)
-                    }
-                    .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) {
-                            WordDataManager.shared.moveToTrash(wordId: word.id)
-                        } label: {
-                            Label("ゴミ箱へ", systemImage: "trash")
+                List(filteredWords) { word in
+                    if selection.isSelecting {
+                        SelectableListRow(id: word.id, selection: selection) {
+                            WordRowView(word: word, speechService: speechService)
                         }
-                        Button {
-                            WordDataManager.shared.archive(wordId: word.id)
-                        } label: {
-                            Label("アーカイブ", systemImage: "archivebox")
+                    } else {
+                        NavigationLink(destination: destinationView(for: word)) {
+                            WordRowView(word: word, speechService: speechService)
                         }
-                        .tint(.teal)
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                WordDataManager.shared.moveToTrash(wordId: word.id)
+                            } label: {
+                                Label("ゴミ箱へ", systemImage: "trash")
+                            }
+                            Button {
+                                WordDataManager.shared.archive(wordId: word.id)
+                            } label: {
+                                Label("アーカイブ", systemImage: "archivebox")
+                            }
+                            .tint(.teal)
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                wordToEdit = word
+                            } label: {
+                                Label("編集", systemImage: "pencil")
+                            }
+                            .tint(.orange)
+                        }
                     }
-                    .swipeActions(edge: .leading) {
-                        Button {
-                            wordToEdit = word
-                        } label: {
-                            Label("編集", systemImage: "pencil")
-                        }
-                        .tint(.orange)
+                }
+                .safeAreaInset(edge: .bottom) {
+                    if selection.isSelecting {
+                        wordListActionBar
                     }
                 }
             }
-            .safeAreaInset(edge: .bottom) {
-                if selection.isSelecting {
-                    wordListActionBar
-                }
-            }
-            } // end else
         }
         .navigationTitle("英単語リスト")
         .navigationBarTitleDisplayMode(.inline)

--- a/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
+++ b/EnglishLearnApp/EnglishLearnApp/Views/WordListView.swift
@@ -28,7 +28,7 @@ struct WordListView: View {
     @ObservedObject private var dataManager = WordDataManager.shared
     @State private var searchText: String = ""
     @State private var wordToEdit: Word? = nil
-    @State private var selectedLetter: Character? = nil
+    @State private var selectedLetter: String = "ALL"
     @State private var selectedCategory: String? = nil
 
     @AppStorage("wordSortOption") private var sortOptionRaw: String = WordSortOption.alphabeticalAZ.rawValue
@@ -43,11 +43,6 @@ struct WordListView: View {
         WordSortOption(rawValue: sortOptionRaw) ?? .alphabeticalAZ
     }
 
-    private var availableLetters: [Character] {
-        let letters = dataManager.words.compactMap { $0.word.uppercased().first }
-        return Array(Set(letters)).sorted()
-    }
-
     /// Unique categories from all active words' sentences, sorted.
     private var availableCategories: [String] {
         let cats = dataManager.words.flatMap { $0.sentences.map { $0.category } }
@@ -58,8 +53,10 @@ struct WordListView: View {
         var result = dataManager.words
 
         // Letter filter
-        if let letter = selectedLetter {
-            result = result.filter { $0.word.uppercased().first == letter }
+        if selectedLetter != "ALL" {
+            result = result.filter {
+                $0.word.first.map { String($0).uppercased() } == selectedLetter
+            }
         }
 
         // Category filter: keep words that have at least one sentence in the selected category
@@ -117,10 +114,17 @@ struct WordListView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            letterFilterBar
+            WordListHeader(query: $searchText, letter: $selectedLetter)
             if !availableCategories.isEmpty {
                 categoryFilterBar
             }
+            if filteredWords.isEmpty {
+                EmptyListView(
+                    systemImage: "magnifyingglass",
+                    title: "該当する単語がありません",
+                    message: "検索条件を変えてお試しください"
+                )
+            } else {
             List(filteredWords) { word in
                 if selection.isSelecting {
                     SelectableListRow(id: word.id, selection: selection) {
@@ -153,12 +157,12 @@ struct WordListView: View {
                     }
                 }
             }
-            .searchable(text: $searchText, prompt: "単語・意味・発音記号で検索")
             .safeAreaInset(edge: .bottom) {
                 if selection.isSelecting {
                     wordListActionBar
                 }
             }
+            } // end else
         }
         .navigationTitle("英単語リスト")
         .navigationBarTitleDisplayMode(.inline)
@@ -272,20 +276,6 @@ struct WordListView: View {
 
     // MARK: - Subviews
 
-    private var letterFilterBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                letterChip(nil, label: "All")
-                ForEach(availableLetters, id: \.self) { letter in
-                    letterChip(letter, label: String(letter))
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-        }
-        .background(Color(.systemGroupedBackground))
-    }
-
     private var categoryFilterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
@@ -299,20 +289,6 @@ struct WordListView: View {
         }
         .background(Color(.systemGroupedBackground))
         .overlay(alignment: .top) { Divider() }
-    }
-
-    private func letterChip(_ letter: Character?, label: String) -> some View {
-        Button {
-            selectedLetter = letter
-        } label: {
-            Text(label)
-                .font(.subheadline.bold())
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(selectedLetter == letter ? Color.accentColor : Color(.secondarySystemGroupedBackground))
-                .foregroundColor(selectedLetter == letter ? .white : .primary)
-                .cornerRadius(8)
-        }
     }
 
     private func categoryChip(_ category: String?, label: String) -> some View {


### PR DESCRIPTION
## Summary

- Added `WordListHeader` component with an inline search field and a full A–Z chip strip
- Replaced the system `.searchable()` modifier and the old letter filter bar with the new header
- The header pins to the top while the word list scrolls beneath it
- The full alphabet (ALL + A–Z) is always shown — selected chip auto-centers via `ScrollViewReader`
- Both search and letter filters compose (`search ∧ letter`)
- Shows `EmptyListView` with a "該当する単語がありません" message when no words match
- Uses the `Tokens` design system throughout (`Color.token`, `Tokens.Spacing`, `Tokens.Radius`)

## Test plan

- [ ] Search filters words by `word`, `meaning`, and `phonetic` (case-insensitive)
- [ ] Tapping a letter chip filters to words starting with that letter; tapping ALL clears it
- [ ] Both filters compose correctly (narrowing from letter + search simultaneously)
- [ ] Selecting a letter chip auto-scrolls the strip so the chip is visible and centered
- [ ] Empty state view appears when no words match the current filter
- [ ] Header stays fixed at the top while the word list scrolls
- [ ] Clear button (×) appears in the search field only when input is non-empty
- [ ] Category filter bar still appears when categories are present

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized search and letter filtering interface into a dedicated header component for improved UI organization.
  * Enhanced empty state display when no matching words are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->